### PR TITLE
add GetSessionId to TaskHandle

### DIFF
--- a/taskmanager/interface.go
+++ b/taskmanager/interface.go
@@ -28,6 +28,10 @@ type TaskHandle interface {
 	// (OnSendTaskSubscribe) rather than a synchronous request (OnSendTask).
 	// This allows the TaskProcessor to adapt its behavior based on the request type.
 	IsStreamingRequest() bool
+
+	// GetSessionID returns the session ID for the task.
+	// If the task is not associated with a session, it returns nil.
+	GetSessionID() *string
 }
 
 // TaskProcessor defines the interface for the core agent logic that processes a task.

--- a/taskmanager/task.go
+++ b/taskmanager/task.go
@@ -44,6 +44,19 @@ func (h *memoryTaskHandle) IsStreamingRequest() bool {
 	return exists && len(subscribers) > 0
 }
 
+// GetSessionID implements TaskHandle.
+func (h *memoryTaskHandle) GetSessionID() *string {
+	h.manager.SubMutex.RLock()
+	defer h.manager.SubMutex.RUnlock()
+
+	task, exists := h.manager.Tasks[h.taskID]
+	if !exists {
+		return nil
+	}
+
+	return task.SessionID
+}
+
 // isFinalState checks if a TaskState represents a terminal state.
 // Not exported as it's an internal helper.
 func isFinalState(state protocol.TaskState) bool {

--- a/tests/e2e_auth_test.go
+++ b/tests/e2e_auth_test.go
@@ -724,6 +724,15 @@ func (h *mockTaskHandle) IsStreamingRequest() bool {
 	return false
 }
 
+// GetSessionID implements the TaskHandle interface.
+func (h *mockTaskHandle) GetSessionID() *string {
+	task, err := h.manager.Task(h.taskID)
+	if err != nil {
+		return nil
+	}
+	return task.SessionID
+}
+
 // AddResponse adds a response to a task.
 func (h *mockTaskHandle) AddResponse(response protocol.Message) error {
 	task, err := h.manager.Task(h.taskID)


### PR DESCRIPTION
Currently when using ` TaskProcessor` there's no official way to access the `session_id` for a given task. This PR adds a fn to the `TaskHandle` called `GetSessionId` which allows the processor to access the `session_id` if it exists.

I also thought about adding `session_id *string` as an arg to the `Processor` but that would have been much larger break so I went with this approach. 

It seemed that the intended way to manage this would be a full `TaskManager` with session management, but in my case session management is happening on a separate backend, so the `MemoryTaskManager` along with access to the `session_id` gives me all of the information I need and allows re-use of the existing code.