### PR TITLE
Fix JSON Marshal for StreamingMessageEvent

### DIFF
--- a/protocol/types.go
+++ b/protocol/types.go
@@ -661,11 +661,12 @@ func NewTaskStatusUpdateEvent(taskID, contextID string, status TaskStatus, final
 		ContextID: contextID,
 		Kind:      KindTaskStatusUpdate,
 		Status:    status,
+		Final:     &final,
 	}
 }
 
 // NewTaskArtifactUpdateEvent creates a new TaskArtifactUpdateEvent.
-func NewTaskArtifactUpdateEvent(taskID, contextID string, artifact Artifact, final bool) TaskArtifactUpdateEvent {
+func NewTaskArtifactUpdateEvent(taskID, contextID string, artifact Artifact) TaskArtifactUpdateEvent {
 	return TaskArtifactUpdateEvent{
 		TaskID:    taskID,
 		ContextID: contextID,

--- a/protocol/types.go
+++ b/protocol/types.go
@@ -807,7 +807,7 @@ type StreamingMessageEvent struct {
 }
 
 // UnmarshalJSON implements custom unmarshalling logic for StreamingMessageEvent
-func (r StreamingMessageEvent) UnmarshalJSON(data []byte) error {
+func (r *StreamingMessageEvent) UnmarshalJSON(data []byte) error {
 	// First, try to detect if this is wrapped in a Result field
 	type StreamingMessageEventRaw struct {
 		Result json.RawMessage `json:"Result"`
@@ -865,7 +865,7 @@ func (r StreamingMessageEvent) UnmarshalJSON(data []byte) error {
 }
 
 // MarshalJSON implements custom marshalling logic for StreamingMessageResult
-func (r StreamingMessageEvent) MarshalJSON() ([]byte, error) {
+func (r *StreamingMessageEvent) MarshalJSON() ([]byte, error) {
 	switch r.Result.GetKind() {
 	case KindMessage:
 		return json.Marshal(r.Result)

--- a/protocol/types.go
+++ b/protocol/types.go
@@ -118,9 +118,9 @@ const (
 	// KindTask is the kind of the task.
 	KindTask = "task"
 	// KindTaskStatusUpdate is the kind of the task status update event.
-	KindTaskStatusUpdate = "status_update"
+	KindTaskStatusUpdate = "status-update"
 	// KindTaskArtifactUpdate is the kind of the task artifact update event.
-	KindTaskArtifactUpdate = "artifact_update"
+	KindTaskArtifactUpdate = "artifact-update"
 	// KindData is the kind of the data.
 	KindData = "data"
 	// KindFile is the kind of the file.

--- a/protocol/types.go
+++ b/protocol/types.go
@@ -875,12 +875,6 @@ func (r StreamingMessageEvent) MarshalJSON() ([]byte, error) {
 		return json.Marshal(r.Result)
 	case KindTaskArtifactUpdate:
 		return json.Marshal(r.Result)
-	case KindData:
-		return json.Marshal(r.Result)
-	case KindFile:
-		return json.Marshal(r.Result)
-	case KindText:
-		return json.Marshal(r.Result)
 	default:
 		return nil, fmt.Errorf("unsupported result kind: %s", r.Result.GetKind())
 	}

--- a/protocol/types.go
+++ b/protocol/types.go
@@ -806,7 +806,7 @@ type StreamingMessageEvent struct {
 }
 
 // UnmarshalJSON implements custom unmarshalling logic for StreamingMessageEvent
-func (r *StreamingMessageEvent) UnmarshalJSON(data []byte) error {
+func (r StreamingMessageEvent) UnmarshalJSON(data []byte) error {
 	// First, try to detect if this is wrapped in a Result field
 	type StreamingMessageEventRaw struct {
 		Result json.RawMessage `json:"Result"`
@@ -864,11 +864,21 @@ func (r *StreamingMessageEvent) UnmarshalJSON(data []byte) error {
 }
 
 // MarshalJSON implements custom marshalling logic for StreamingMessageResult
-func (r *StreamingMessageEvent) MarshalJSON() ([]byte, error) {
+func (r StreamingMessageEvent) MarshalJSON() ([]byte, error) {
 	switch r.Result.GetKind() {
 	case KindMessage:
 		return json.Marshal(r.Result)
 	case KindTask:
+		return json.Marshal(r.Result)
+	case KindTaskStatusUpdate:
+		return json.Marshal(r.Result)
+	case KindTaskArtifactUpdate:
+		return json.Marshal(r.Result)
+	case KindData:
+		return json.Marshal(r.Result)
+	case KindFile:
+		return json.Marshal(r.Result)
+	case KindText:
 		return json.Marshal(r.Result)
 	default:
 		return nil, fmt.Errorf("unsupported result kind: %s", r.Result.GetKind())

--- a/server/server.go
+++ b/server/server.go
@@ -739,7 +739,7 @@ func handleSSEStream[T interface{}](
 				}
 				return // End the handler.
 			}
-			if err := sendSSEEvent(w, rpcID, flusher, event); err != nil {
+			if err := sendSSEEvent(w, rpcID, flusher, &event); err != nil {
 				if err == errUnknownEvent {
 					log.Warnf("Unknown event type received for request ID: %s: %T. Skipping.", rpcID, event)
 					continue
@@ -763,7 +763,7 @@ func sendSSEEvent(w http.ResponseWriter, rpcID string, flusher http.Flusher, eve
 	var actualEvent protocol.Event
 
 	// Handle StreamingMessageEvent by extracting the inner Result
-	if streamEvent, ok := event.(protocol.StreamingMessageEvent); ok {
+	if streamEvent, ok := event.(*protocol.StreamingMessageEvent); ok {
 		actualEvent = streamEvent.Result
 	} else if directEvent, ok := event.(protocol.Event); ok {
 		actualEvent = directEvent

--- a/server/server.go
+++ b/server/server.go
@@ -732,7 +732,7 @@ func handleSSEStream[T interface{}](
 					Reason: "task ended",
 				}
 				// Use JSON-RPC format for the close event
-				if err := sse.FormatJSONRPCEvent(w, protocol.EventClose, rpcID, closeData); err != nil {
+				if err := sse.FormatJSONRPCEvent(w, protocol.EventClose, rpcID, &closeData); err != nil {
 					log.Errorf("Error writing SSE JSON-RPC close event for request ID: %s: %v", rpcID, err)
 				} else {
 					flusher.Flush()


### PR DESCRIPTION
1. The status enum for `status_update`should be `status-update`
2. The `final` args is missing in `NewTaskStatusUpdateEvent`
3. The `MarshalJSON` is using a pointer receiver, while will casue this function not be called. The SSE json data is wrong(the right screenshot):
![image](https://github.com/user-attachments/assets/d8127f2c-e9e4-4193-8141-6f30e7f0ab79)