### PR TITLE
Sync

### DIFF
--- a/examples/simple/client/main.go
+++ b/examples/simple/client/main.go
@@ -46,7 +46,8 @@ func main() {
 	params := protocol.SendMessageParams{
 		Message: userMessage,
 		Configuration: &protocol.SendMessageConfiguration{
-			Blocking: boolPtr(false), // Non-blocking for streaming, blocking for standard
+			Blocking:            boolPtr(false), // Non-blocking for streaming, blocking for standard
+			AcceptedOutputModes: []string{"text"},
 		},
 	}
 

--- a/examples/simple/python_client/official_a2a_client.py
+++ b/examples/simple/python_client/official_a2a_client.py
@@ -20,7 +20,7 @@ import uuid
 
 try:
     from a2a.client import A2AClient, create_text_message_object
-    from a2a.types import SendMessageRequest, SendStreamingMessageRequest, MessageSendParams, Role
+    from a2a.types import SendMessageRequest, SendStreamingMessageRequest, MessageSendParams, Role, MessageSendConfiguration
     import httpx
     print("✅ Successfully imported official A2A SDK")
 except ImportError as e:
@@ -93,7 +93,7 @@ class SimpleA2AClient:
         try:
             # Create A2A message for streaming
             message = create_text_message_object(role=Role.user, content=text)
-            params = MessageSendParams(message=message)
+            params = MessageSendParams(message=message, configuration=MessageSendConfiguration(acceptedOutputModes=["text"]))
             
             request = SendStreamingMessageRequest(
                 id=str(uuid.uuid4()),

--- a/examples/simple/python_client/requirements.txt
+++ b/examples/simple/python_client/requirements.txt
@@ -1,3 +1,3 @@
 # Official A2A SDK dependencies  
-a2a-sdk>=0.1.0
+a2a-sdk>=0.2.5
 httpx>=0.24.0 

--- a/protocol/types.go
+++ b/protocol/types.go
@@ -490,7 +490,7 @@ type TaskStatus struct {
 	// Message is the optional message associated with the status (e.g., final response).
 	Message *Message `json:"message,omitempty"`
 	// Timestamp is the ISO 8601 timestamp of the status change.
-	Timestamp string `json:"timestamp"`
+	Timestamp string `json:"timestamp,omitempty"`
 }
 
 // Task represents a unit of work being processed by the agent.
@@ -746,6 +746,8 @@ type SendMessageParams struct {
 
 // SendMessageConfiguration defines optional configuration for message sending.
 type SendMessageConfiguration struct {
+	// AcceptedOutputModes is the list of accepted output modes.
+	AcceptedOutputModes []string `json:"acceptedOutputModes"`
 	// PushNotificationConfig contains optional push notification settings.
 	PushNotificationConfig *PushNotificationConfig `json:"pushNotificationConfig,omitempty"`
 	// HistoryLength is the requested history length in response.

--- a/server/types.go
+++ b/server/types.go
@@ -7,6 +7,11 @@
 // Package server contains the A2A server implementation and related types.
 package server
 
+const (
+	// ProtocolVersion is the protocol version.
+	ProtocolVersion = "0.2.5"
+)
+
 // SecurityScheme represents an authentication scheme supported by the agent.
 // Based on A2A 0.2.2 specification.
 type SecurityScheme struct {
@@ -75,7 +80,7 @@ type OAuthFlow struct {
 	// RefreshURL is the refresh URL.
 	RefreshURL *string `json:"refreshUrl,omitempty"`
 	// Scopes are the available scopes.
-	Scopes map[string]string `json:"scopes,omitempty"`
+	Scopes map[string]string `json:"scopes"`
 }
 
 // AgentExtension represents an agent extension.
@@ -111,7 +116,7 @@ type AgentSkill struct {
 	// Description is an optional detailed description of the skill.
 	Description *string `json:"description,omitempty"`
 	// Tags are optional tags for categorization.
-	Tags []string `json:"tags,omitempty"`
+	Tags []string `json:"tags"`
 	// Examples are optional usage examples.
 	Examples []string `json:"examples,omitempty"`
 	// InputModes are the supported input data modes/types.
@@ -136,6 +141,15 @@ type AgentAuthentication struct {
 	Required bool `json:"required"`
 	// Config is an optional configuration details for the auth type.
 	Config interface{} `json:"config,omitempty"`
+}
+
+// AgentInterface provides a declaration of a combination of the
+// target url and the supported transport to interact with the agent.
+type AgentInterface struct {
+	// URL is the target URL of the agent.
+	URL string `json:"url"`
+	// Transport is the supported transport.
+	Transport string `json:"transport"`
 }
 
 // AgentCard is the metadata structure describing an A2A agent.
@@ -169,4 +183,10 @@ type AgentCard struct {
 	Skills []AgentSkill `json:"skills"`
 	// SupportsAuthenticatedExtendedCard indicates if the agent supports authenticated extended card.
 	SupportsAuthenticatedExtendedCard *bool `json:"supportsAuthenticatedExtendedCard,omitempty"`
+	// PreferredTransport is the preferred transport.
+	PreferredTransport *string `json:"preferredTransport,omitempty"`
+	// ProtocolVersion is the protocol version.
+	ProtocolVersion *string `json:"protocolVersion,omitempty"`
+	// Interfaces are the list of interfaces supported by the agent.
+	AdditionalInterfaces []AgentInterface `json:"additionalInterfaces,omitempty"`
 }

--- a/taskmanager/interface.go
+++ b/taskmanager/interface.go
@@ -26,6 +26,9 @@ type ProcessOptions struct {
 	// PushNotificationConfig contains push notification configuration
 	PushNotificationConfig *protocol.PushNotificationConfig
 
+	// AcceptedOutputModes is the list of accepted output modes.
+	AcceptedOutputModes []string
+
 	// Streaming indicates whether this is a streaming request
 	// If true, the user should return event streams through the StreamingEvents channel
 	// If false, the user should return a single result through Result

--- a/taskmanager/memory.go
+++ b/taskmanager/memory.go
@@ -599,6 +599,11 @@ func (m *MemoryTaskManager) processConfiguration(config *protocol.SendMessageCon
 		result.PushNotificationConfig = config.PushNotificationConfig
 	}
 
+	// Process AcceptedOutputModes configuration
+	if config.AcceptedOutputModes != nil {
+		result.AcceptedOutputModes = config.AcceptedOutputModes
+	}
+
 	return result
 }
 

--- a/taskmanager/redis/redis_manager.go
+++ b/taskmanager/redis/redis_manager.go
@@ -400,6 +400,11 @@ func (m *TaskManager) processConfiguration(
 		result.PushNotificationConfig = config.PushNotificationConfig
 	}
 
+	// Process AcceptedOutputModes configuration.
+	if config.AcceptedOutputModes != nil {
+		result.AcceptedOutputModes = config.AcceptedOutputModes
+	}
+
 	return result
 }
 


### PR DESCRIPTION
**Key changes include:**
- server/types.go: Updated the AgentCard and its related structs to match the spec, adding new fields like protocolVersion and additionalInterfaces, and correcting required fields like tags and scopes.
- protocol/types.go: Made critical fields optional (e.g., TaskStatus.Timestamp) and added acceptedOutputModes to the message configuration to align with the latest spec.
- Client Examples: Both the Go and Python client examples were updated to include the new acceptedOutputModes parameter in their requests, ensuring they work correctly with the updated types. The Python client's dependencies were also bumped to a2a-sdk>=0.2.5.