### PR TITLE
Utilise UniversalRedisClient for Redis task manager

### DIFF
--- a/taskmanager/redis/redis_manager.go
+++ b/taskmanager/redis/redis_manager.go
@@ -45,7 +45,7 @@ type TaskManager struct {
 	// processor is the user-provided message processor.
 	processor taskmanager.MessageProcessor
 	// client is the Redis client.
-	client *redis.Client
+	client redis.UniversalClient
 	// expiration is the time after which Redis keys expire.
 	expiration time.Duration
 
@@ -65,7 +65,7 @@ type TaskManager struct {
 
 // NewTaskManager creates a new Redis-based TaskManager with the provided options.
 func NewTaskManager(
-	client *redis.Client,
+	client redis.UniversalClient,
 	processor taskmanager.MessageProcessor,
 	opts ...TaskManagerOption,
 ) (*TaskManager, error) {


### PR DESCRIPTION
Since the 0.2.0 upgrade, the Redis task manager was changed to utilize a `*redis.Client` rather than the `redis.UniversalClient` [interface](https://redis.uptrace.dev/guide/universal.html). 

If possible, I'd prefer to use the interface, as it allows us to easily use a cluster client - we use clusters in our remote environments.