### PR TITLE
feat(client.go): client rpc method for tasks/resubscribe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ test_output.txt
 *jwt-secret.key*
 
 !CODEOWNERS
+.idea/


### PR DESCRIPTION
#60

- client/client.go: Add ResubscribeTask method for "tasks/resubscribe" in client.go,  as it would be valuable.