### PR TITLE
Fix memory task subscriber cleanup

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -166,6 +166,14 @@ func (s *A2AServer) Stop(ctx context.Context) error {
 	if err := s.httpServer.Shutdown(ctx); err != nil {
 		shutdownErrs = append(shutdownErrs, fmt.Errorf("http server shutdown failed: %w", err))
 	}
+	// Release task manager resources (e.g. stop the in-memory cleanup goroutine or
+	// close the Redis client) once in-flight requests have drained. Done via the
+	// optional io.Closer to avoid widening the TaskManager interface.
+	if closer, ok := s.taskManager.(io.Closer); ok {
+		if err := closer.Close(); err != nil {
+			shutdownErrs = append(shutdownErrs, fmt.Errorf("task manager close failed: %w", err))
+		}
+	}
 	if err := s.shutdownTelemetry(ctx); err != nil {
 		shutdownErrs = append(shutdownErrs, fmt.Errorf("telemetry shutdown failed: %w", err))
 	}

--- a/taskmanager/memory.go
+++ b/taskmanager/memory.go
@@ -87,6 +87,7 @@ func WithSubscriberBlockingSend(blockingSend bool) MemoryTaskSubscriberOption {
 type MemoryTaskSubscriber struct {
 	taskID         string
 	eventQueue     chan protocol.StreamingMessageEvent
+	done           chan struct{}
 	lastAccessTime time.Time
 	closed         atomic.Bool
 	mu             sync.RWMutex
@@ -113,6 +114,7 @@ func NewMemoryTaskSubscriber(
 	return &MemoryTaskSubscriber{
 		taskID:         taskID,
 		eventQueue:     eventQueue,
+		done:           make(chan struct{}),
 		lastAccessTime: time.Now(),
 		closed:         atomic.Bool{},
 		opts:           subscriberOpts,
@@ -121,12 +123,14 @@ func NewMemoryTaskSubscriber(
 
 // Close closes the task subscriber
 func (s *MemoryTaskSubscriber) Close() {
+	if !s.closed.CompareAndSwap(false, true) {
+		return
+	}
+	close(s.done)
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if !s.closed.Load() {
-		s.closed.Store(true)
-		close(s.eventQueue)
-	}
+	close(s.eventQueue)
 }
 
 // Channel returns the channel of the task subscriber
@@ -160,13 +164,19 @@ func (s *MemoryTaskSubscriber) Send(event protocol.StreamingMessageEvent) error 
 	}
 
 	if s.opts.blockingSend {
-		s.eventQueue <- event
-		return nil
+		select {
+		case s.eventQueue <- event:
+			return nil
+		case <-s.done:
+			return fmt.Errorf("task subscriber is closed")
+		}
 	}
 
 	select {
 	case s.eventQueue <- event:
 		return nil
+	case <-s.done:
+		return fmt.Errorf("task subscriber is closed")
 	default:
 		return fmt.Errorf("event queue is full or closed")
 	}
@@ -219,7 +229,9 @@ type MemoryTaskManager struct {
 
 	// stopCleanup signals the cleanup goroutine to stop
 	stopCleanup chan struct{}
-	closeOnce   sync.Once
+	// cleanupWg tracks the cleanup goroutine so Close can wait for it to exit
+	cleanupWg sync.WaitGroup
+	closeOnce sync.Once
 }
 
 // NewMemoryTaskManager creates a new MemoryTaskManager instance
@@ -249,7 +261,9 @@ func NewMemoryTaskManager(processor MessageProcessor, opts ...MemoryTaskManagerO
 
 	// Start cleanup goroutine if enabled
 	if options.EnableCleanup {
+		manager.cleanupWg.Add(1)
 		go func() {
+			defer manager.cleanupWg.Done()
 			ticker := time.NewTicker(options.CleanupInterval)
 			defer ticker.Stop()
 
@@ -690,24 +704,23 @@ func (m *MemoryTaskManager) notifySubscribers(taskID string, event protocol.Stre
 // cleanupFailedSubscribers cleans up failed or closed subscribers
 func (m *MemoryTaskManager) cleanupFailedSubscribers(taskID string, failedSubscribers []*MemoryTaskSubscriber) {
 	m.taskMu.Lock()
-	defer m.taskMu.Unlock()
 
 	subs, exists := m.Subscribers[taskID]
 	if !exists {
+		m.taskMu.Unlock()
 		return
 	}
 
 	// Filter out failed subscribers
 	filteredSubs := make([]*MemoryTaskSubscriber, 0, len(subs))
-	removedCount := 0
+	removedSubs := make([]*MemoryTaskSubscriber, 0, len(failedSubscribers))
 
 	for _, sub := range subs {
 		shouldRemove := false
 		for _, failedSub := range failedSubscribers {
 			if sub == failedSub {
 				shouldRemove = true
-				removedCount++
-				sub.Close()
+				removedSubs = append(removedSubs, sub)
 				break
 			}
 		}
@@ -716,29 +729,38 @@ func (m *MemoryTaskManager) cleanupFailedSubscribers(taskID string, failedSubscr
 		}
 	}
 
-	if removedCount > 0 {
+	if len(removedSubs) > 0 {
 		m.Subscribers[taskID] = filteredSubs
-		log.Debugf("Removed %d failed subscribers for task %s", removedCount, taskID)
+		log.Debugf("Removed %d failed subscribers for task %s", len(removedSubs), taskID)
 
 		// If there are no subscribers left, delete the entire entry
 		if len(filteredSubs) == 0 {
 			delete(m.Subscribers, taskID)
 		}
 	}
+	m.taskMu.Unlock()
+
+	for _, sub := range removedSubs {
+		sub.Close()
+	}
 }
 
 // cleanSubscribers closes and removes all subscribers for a task.
 func (m *MemoryTaskManager) cleanSubscribers(taskID string) {
 	m.taskMu.Lock()
-	defer m.taskMu.Unlock()
 
-	if subs, exists := m.Subscribers[taskID]; exists {
-		for _, sub := range subs {
-			sub.Close()
-		}
-		delete(m.Subscribers, taskID)
-		log.Debugf("Cleaned subscribers for task %s", taskID)
+	subs, exists := m.Subscribers[taskID]
+	if !exists {
+		m.taskMu.Unlock()
+		return
 	}
+	delete(m.Subscribers, taskID)
+	m.taskMu.Unlock()
+
+	for _, sub := range subs {
+		sub.Close()
+	}
+	log.Debugf("Cleaned subscribers for task %s", taskID)
 }
 
 // addSubscriber adds a subscriber
@@ -799,6 +821,7 @@ func (m *MemoryTaskManager) cleanExpiredTasks(maxAge time.Duration) int {
 
 	now := time.Now()
 	expiredTaskIDs := make([]string, 0)
+	subsToClose := make([]*MemoryTaskSubscriber, 0)
 
 	for taskID, task := range m.Tasks {
 		if !isFinalState(task.Task().Status.State) {
@@ -806,6 +829,12 @@ func (m *MemoryTaskManager) cleanExpiredTasks(maxAge time.Duration) int {
 		}
 		ts, err := time.Parse(time.RFC3339, task.Task().Status.Timestamp)
 		if err != nil {
+			// A terminal task with an unparsable/empty timestamp would never be
+			// cleaned up. This is unreachable via the public API today (all writers
+			// use RFC3339), but log it so a future bad-timestamp path is observable
+			// instead of leaking silently.
+			log.Debugf("Skipping task %s in cleanup: unparsable timestamp %q: %v",
+				taskID, task.Task().Status.Timestamp, err)
 			continue
 		}
 		if now.Sub(ts) > maxAge {
@@ -819,14 +848,16 @@ func (m *MemoryTaskManager) cleanExpiredTasks(maxAge time.Duration) int {
 			delete(m.Tasks, taskID)
 		}
 		if subs, exists := m.Subscribers[taskID]; exists {
-			for _, sub := range subs {
-				sub.Close()
-			}
+			subsToClose = append(subsToClose, subs...)
 			delete(m.Subscribers, taskID)
 		}
 	}
 
 	m.taskMu.Unlock()
+
+	for _, sub := range subsToClose {
+		sub.Close()
+	}
 
 	if len(expiredTaskIDs) > 0 {
 		log.Debugf("Cleaned %d expired tasks", len(expiredTaskIDs))
@@ -842,16 +873,20 @@ func (m *MemoryTaskManager) cleanExpiredTasks(maxAge time.Duration) int {
 }
 
 // Close stops the cleanup goroutine and releases all resources.
-// It is safe to call Close multiple times.
-func (m *MemoryTaskManager) Close() {
+// It cancels any in-flight (non-terminal) tasks and closes their subscribers
+// without emitting a terminal event, so streaming clients observe the channel
+// close directly. It is safe to call Close multiple times; it always returns nil.
+func (m *MemoryTaskManager) Close() error {
 	m.closeOnce.Do(func() {
+		// Signal the cleanup goroutine to stop and wait for it to exit so that no
+		// tick runs concurrently with the teardown below.
 		close(m.stopCleanup)
+		m.cleanupWg.Wait()
 
 		m.taskMu.Lock()
+		subsToClose := make([]*MemoryTaskSubscriber, 0)
 		for _, subs := range m.Subscribers {
-			for _, sub := range subs {
-				sub.Close()
-			}
+			subsToClose = append(subsToClose, subs...)
 		}
 		m.Subscribers = make(map[string][]*MemoryTaskSubscriber)
 
@@ -860,7 +895,14 @@ func (m *MemoryTaskManager) Close() {
 		}
 		m.Tasks = make(map[string]*MemoryCancellableTask)
 		m.taskMu.Unlock()
+
+		// Close subscribers outside taskMu so a stuck blocking send can never
+		// wedge the manager-wide lock.
+		for _, sub := range subsToClose {
+			sub.Close()
+		}
 	})
+	return nil
 }
 
 // GetConversationStats gets conversation statistics

--- a/taskmanager/memory.go
+++ b/taskmanager/memory.go
@@ -22,6 +22,7 @@ import (
 const defaultMaxHistoryLength = 100
 const defaultCleanupInterval = 30 * time.Second
 const defaultConversationTTL = 1 * time.Hour
+const defaultTaskTTL = 0
 const defaultSubscriberBufferSize = 1024
 
 // ConversationHistory stores conversation history information
@@ -215,6 +216,10 @@ type MemoryTaskManager struct {
 
 	// options
 	options *MemoryTaskManagerOptions
+
+	// stopCleanup signals the cleanup goroutine to stop
+	stopCleanup chan struct{}
+	closeOnce   sync.Once
 }
 
 // NewMemoryTaskManager creates a new MemoryTaskManager instance
@@ -239,6 +244,7 @@ func NewMemoryTaskManager(processor MessageProcessor, opts ...MemoryTaskManagerO
 		Subscribers:       make(map[string][]*MemoryTaskSubscriber),
 		PushNotifications: make(map[string]protocol.TaskPushNotificationConfig),
 		options:           options,
+		stopCleanup:       make(chan struct{}),
 	}
 
 	// Start cleanup goroutine if enabled
@@ -247,8 +253,14 @@ func NewMemoryTaskManager(processor MessageProcessor, opts ...MemoryTaskManagerO
 			ticker := time.NewTicker(options.CleanupInterval)
 			defer ticker.Stop()
 
-			for range ticker.C {
-				manager.CleanExpiredConversations(options.ConversationTTL)
+			for {
+				select {
+				case <-ticker.C:
+					manager.CleanExpiredConversations(options.ConversationTTL)
+					manager.cleanExpiredTasks(options.TaskTTL)
+				case <-manager.stopCleanup:
+					return
+				}
 			}
 		}()
 	}
@@ -695,6 +707,7 @@ func (m *MemoryTaskManager) cleanupFailedSubscribers(taskID string, failedSubscr
 			if sub == failedSub {
 				shouldRemove = true
 				removedCount++
+				sub.Close()
 				break
 			}
 		}
@@ -711,6 +724,20 @@ func (m *MemoryTaskManager) cleanupFailedSubscribers(taskID string, failedSubscr
 		if len(filteredSubs) == 0 {
 			delete(m.Subscribers, taskID)
 		}
+	}
+}
+
+// cleanSubscribers closes and removes all subscribers for a task.
+func (m *MemoryTaskManager) cleanSubscribers(taskID string) {
+	m.taskMu.Lock()
+	defer m.taskMu.Unlock()
+
+	if subs, exists := m.Subscribers[taskID]; exists {
+		for _, sub := range subs {
+			sub.Close()
+		}
+		delete(m.Subscribers, taskID)
+		log.Debugf("Cleaned subscribers for task %s", taskID)
 	}
 }
 
@@ -759,6 +786,81 @@ func (m *MemoryTaskManager) CleanExpiredConversations(maxAge time.Duration) int 
 	}
 
 	return len(expiredContexts)
+}
+
+// cleanExpiredTasks cleans up tasks that have been in a terminal state longer than maxAge.
+// It removes the task, its subscribers, and associated push notification configs.
+// A maxAge of 0 disables cleanup and returns immediately.
+func (m *MemoryTaskManager) cleanExpiredTasks(maxAge time.Duration) int {
+	if maxAge <= 0 {
+		return 0
+	}
+	m.taskMu.Lock()
+
+	now := time.Now()
+	expiredTaskIDs := make([]string, 0)
+
+	for taskID, task := range m.Tasks {
+		if !isFinalState(task.Task().Status.State) {
+			continue
+		}
+		ts, err := time.Parse(time.RFC3339, task.Task().Status.Timestamp)
+		if err != nil {
+			continue
+		}
+		if now.Sub(ts) > maxAge {
+			expiredTaskIDs = append(expiredTaskIDs, taskID)
+		}
+	}
+
+	for _, taskID := range expiredTaskIDs {
+		if task, exists := m.Tasks[taskID]; exists {
+			task.Cancel()
+			delete(m.Tasks, taskID)
+		}
+		if subs, exists := m.Subscribers[taskID]; exists {
+			for _, sub := range subs {
+				sub.Close()
+			}
+			delete(m.Subscribers, taskID)
+		}
+	}
+
+	m.taskMu.Unlock()
+
+	if len(expiredTaskIDs) > 0 {
+		log.Debugf("Cleaned %d expired tasks", len(expiredTaskIDs))
+
+		m.mu.Lock()
+		for _, taskID := range expiredTaskIDs {
+			delete(m.PushNotifications, taskID)
+		}
+		m.mu.Unlock()
+	}
+
+	return len(expiredTaskIDs)
+}
+
+// Close stops the cleanup goroutine and releases all resources.
+// It is safe to call Close multiple times.
+func (m *MemoryTaskManager) Close() {
+	m.closeOnce.Do(func() {
+		close(m.stopCleanup)
+
+		m.taskMu.Lock()
+		for _, subs := range m.Subscribers {
+			for _, sub := range subs {
+				sub.Close()
+			}
+		}
+		m.Subscribers = make(map[string][]*MemoryTaskSubscriber)
+
+		for _, task := range m.Tasks {
+			task.Cancel()
+		}
+		m.Tasks = make(map[string]*MemoryCancellableTask)
+		m.taskMu.Unlock()
+	})
 }
 
 // GetConversationStats gets conversation statistics

--- a/taskmanager/memory_handler.go
+++ b/taskmanager/memory_handler.go
@@ -75,6 +75,10 @@ func (h *memoryTaskHandler) UpdateTaskState(
 
 	// notify subscribers will lock again
 	h.manager.notifySubscribers(*taskID, streamEvent)
+
+	if finalState {
+		h.manager.cleanSubscribers(*taskID)
+	}
 	return nil
 }
 

--- a/taskmanager/memory_options.go
+++ b/taskmanager/memory_options.go
@@ -19,10 +19,15 @@ type MemoryTaskManagerOptions struct {
 	// ConversationTTL is the maximum lifetime of conversations.
 	ConversationTTL time.Duration
 
+	// TaskTTL is the maximum lifetime of tasks in terminal states (completed/failed/canceled/rejected).
+	// Tasks that have been in a terminal state longer than this duration will be automatically cleaned up.
+	// Default is 0 (disabled). Use WithTaskTTL to enable automatic task cleanup.
+	TaskTTL time.Duration
+
 	// CleanupInterval is the interval for cleanup checks.
 	CleanupInterval time.Duration
 
-	// EnableCleanup enables automatic cleanup of expired conversations.
+	// EnableCleanup enables automatic cleanup of expired conversations and tasks.
 	EnableCleanup bool
 
 	// TaskSubscriberBufSize is the buffer size for task subscribers.
@@ -37,6 +42,7 @@ func DefaultMemoryTaskManagerOptions() *MemoryTaskManagerOptions {
 	return &MemoryTaskManagerOptions{
 		MaxHistoryLength:           defaultMaxHistoryLength,
 		ConversationTTL:            defaultConversationTTL,
+		TaskTTL:                    defaultTaskTTL,
 		CleanupInterval:            defaultCleanupInterval,
 		EnableCleanup:              true,
 		TaskSubscriberBufSize:      defaultSubscriberBufferSize,
@@ -66,6 +72,15 @@ func WithConversationTTL(ttl, cleanupInterval time.Duration) MemoryTaskManagerOp
 			opts.CleanupInterval = cleanupInterval
 			opts.EnableCleanup = true
 		}
+	}
+}
+
+// WithTaskTTL sets the task TTL for automatic cleanup of tasks in terminal states.
+// When enabled, tasks in terminal states (completed/failed/canceled/rejected) will be
+// automatically removed after the specified duration. A TTL of 0 disables task cleanup.
+func WithTaskTTL(ttl time.Duration) MemoryTaskManagerOption {
+	return func(opts *MemoryTaskManagerOptions) {
+		opts.TaskTTL = ttl
 	}
 }
 

--- a/taskmanager/memory_options.go
+++ b/taskmanager/memory_options.go
@@ -78,9 +78,13 @@ func WithConversationTTL(ttl, cleanupInterval time.Duration) MemoryTaskManagerOp
 // WithTaskTTL sets the task TTL for automatic cleanup of tasks in terminal states.
 // When enabled, tasks in terminal states (completed/failed/canceled/rejected) will be
 // automatically removed after the specified duration. A TTL of 0 disables task cleanup.
+// A positive ttl also enables the cleanup goroutine, mirroring WithConversationTTL.
 func WithTaskTTL(ttl time.Duration) MemoryTaskManagerOption {
 	return func(opts *MemoryTaskManagerOptions) {
 		opts.TaskTTL = ttl
+		if ttl > 0 {
+			opts.EnableCleanup = true
+		}
 	}
 }
 

--- a/taskmanager/memory_test.go
+++ b/taskmanager/memory_test.go
@@ -699,6 +699,211 @@ func TestCancellableTask(t *testing.T) {
 	}
 }
 
+func TestMemoryTaskManager_UpdateTaskState_CleansSubscribersOnFinalState(t *testing.T) {
+	handler, manager := setupTestHandler(t)
+
+	taskID, err := handler.BuildTask(nil, nil)
+	if err != nil {
+		t.Fatalf("Failed to create task: %v", err)
+	}
+
+	sub, err := handler.SubscribeTask(&taskID)
+	if err != nil {
+		t.Fatalf("Failed to subscribe: %v", err)
+	}
+
+	// Verify subscriber exists
+	manager.taskMu.RLock()
+	if len(manager.Subscribers[taskID]) != 1 {
+		t.Fatalf("Expected 1 subscriber, got %d", len(manager.Subscribers[taskID]))
+	}
+	manager.taskMu.RUnlock()
+
+	// Drain events before completing
+	go func() {
+		for range sub.Channel() {
+		}
+	}()
+
+	// Transition to final state
+	err = handler.UpdateTaskState(&taskID, protocol.TaskStateCompleted, nil)
+	if err != nil {
+		t.Fatalf("Failed to update state: %v", err)
+	}
+
+	// Subscribers should be cleaned up
+	manager.taskMu.RLock()
+	subs := manager.Subscribers[taskID]
+	manager.taskMu.RUnlock()
+
+	if len(subs) != 0 {
+		t.Errorf("Expected subscribers to be cleaned after final state, got %d", len(subs))
+	}
+}
+
+func TestMemoryTaskManager_cleanExpiredTasks(t *testing.T) {
+	processor := &MockMessageProcessor{}
+	manager, err := NewMemoryTaskManager(processor)
+	if err != nil {
+		t.Fatalf("Failed to create manager: %v", err)
+	}
+	defer manager.Close()
+
+	// Create a task and move it to a final state with an old timestamp
+	task := protocol.Task{
+		ID:   "expired-task",
+		Kind: protocol.KindTask,
+		Status: protocol.TaskStatus{
+			State:     protocol.TaskStateCompleted,
+			Timestamp: time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339),
+		},
+	}
+	cancellableTask := NewCancellableTask(task)
+
+	manager.taskMu.Lock()
+	manager.Tasks["expired-task"] = cancellableTask
+	manager.Subscribers["expired-task"] = []*MemoryTaskSubscriber{
+		NewMemoryTaskSubscriber("expired-task", 10),
+	}
+	manager.taskMu.Unlock()
+
+	// Create a non-expired task
+	activeTask := protocol.Task{
+		ID:   "active-task",
+		Kind: protocol.KindTask,
+		Status: protocol.TaskStatus{
+			State:     protocol.TaskStateWorking,
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+		},
+	}
+	activeCancellable := NewCancellableTask(activeTask)
+
+	manager.taskMu.Lock()
+	manager.Tasks["active-task"] = activeCancellable
+	manager.taskMu.Unlock()
+
+	// Create a recently completed task (should NOT be cleaned)
+	recentTask := protocol.Task{
+		ID:   "recent-task",
+		Kind: protocol.KindTask,
+		Status: protocol.TaskStatus{
+			State:     protocol.TaskStateCompleted,
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+		},
+	}
+	recentCancellable := NewCancellableTask(recentTask)
+
+	manager.taskMu.Lock()
+	manager.Tasks["recent-task"] = recentCancellable
+	manager.taskMu.Unlock()
+
+	// TTL=0 should skip cleanup entirely
+	skipped := manager.cleanExpiredTasks(0)
+	if skipped != 0 {
+		t.Errorf("Expected 0 cleaned tasks with TTL=0, got %d", skipped)
+	}
+	manager.taskMu.RLock()
+	if _, exists := manager.Tasks["expired-task"]; !exists {
+		t.Error("Expired task should still exist when TTL=0")
+	}
+	manager.taskMu.RUnlock()
+
+	// Clean with 1 hour TTL
+	cleaned := manager.cleanExpiredTasks(1 * time.Hour)
+
+	if cleaned != 1 {
+		t.Errorf("Expected 1 cleaned task, got %d", cleaned)
+	}
+
+	manager.taskMu.RLock()
+	defer manager.taskMu.RUnlock()
+
+	if _, exists := manager.Tasks["expired-task"]; exists {
+		t.Error("Expected expired task to be removed")
+	}
+	if _, exists := manager.Subscribers["expired-task"]; exists {
+		t.Error("Expected expired task subscribers to be removed")
+	}
+	if _, exists := manager.Tasks["active-task"]; !exists {
+		t.Error("Active task should not be removed")
+	}
+	if _, exists := manager.Tasks["recent-task"]; !exists {
+		t.Error("Recently completed task should not be removed")
+	}
+}
+
+func TestMemoryTaskManager_Close(t *testing.T) {
+	processor := &MockMessageProcessor{}
+	manager, err := NewMemoryTaskManager(processor)
+	if err != nil {
+		t.Fatalf("Failed to create manager: %v", err)
+	}
+
+	// Add some tasks and subscribers
+	task := protocol.Task{
+		ID:   "close-test-task",
+		Kind: protocol.KindTask,
+		Status: protocol.TaskStatus{
+			State:     protocol.TaskStateWorking,
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+		},
+	}
+	cancellableTask := NewCancellableTask(task)
+	sub := NewMemoryTaskSubscriber("close-test-task", 10)
+
+	manager.taskMu.Lock()
+	manager.Tasks["close-test-task"] = cancellableTask
+	manager.Subscribers["close-test-task"] = []*MemoryTaskSubscriber{sub}
+	manager.taskMu.Unlock()
+
+	manager.Close()
+
+	if !sub.Closed() {
+		t.Error("Expected subscriber to be closed after manager.Close()")
+	}
+
+	manager.taskMu.RLock()
+	defer manager.taskMu.RUnlock()
+
+	if len(manager.Tasks) != 0 {
+		t.Errorf("Expected all tasks to be cleaned, got %d", len(manager.Tasks))
+	}
+	if len(manager.Subscribers) != 0 {
+		t.Errorf("Expected all subscribers to be cleaned, got %d", len(manager.Subscribers))
+	}
+}
+
+func TestMemoryTaskManager_Close_Idempotent(t *testing.T) {
+	processor := &MockMessageProcessor{}
+	manager, err := NewMemoryTaskManager(processor)
+	if err != nil {
+		t.Fatalf("Failed to create manager: %v", err)
+	}
+
+	// Calling Close multiple times must not panic.
+	manager.Close()
+	manager.Close()
+}
+
+func TestWithTaskTTL(t *testing.T) {
+	opts := DefaultMemoryTaskManagerOptions()
+
+	if opts.TaskTTL != 0 {
+		t.Errorf("Expected default TaskTTL=0 (disabled), got %v", opts.TaskTTL)
+	}
+
+	WithTaskTTL(30 * time.Minute)(opts)
+	if opts.TaskTTL != 30*time.Minute {
+		t.Errorf("Expected TaskTTL=30m, got %v", opts.TaskTTL)
+	}
+
+	// Zero value explicitly disables task cleanup
+	WithTaskTTL(0)(opts)
+	if opts.TaskTTL != 0 {
+		t.Errorf("Expected TaskTTL=0 after explicit disable, got %v", opts.TaskTTL)
+	}
+}
+
 func stringPtr(s string) *string {
 	return &s
 }

--- a/taskmanager/memory_test.go
+++ b/taskmanager/memory_test.go
@@ -676,6 +676,38 @@ func TestTaskSubscriber(t *testing.T) {
 	}
 }
 
+func TestMemoryTaskSubscriber_CloseUnblocksBlockingSend(t *testing.T) {
+	subscriber := NewMemoryTaskSubscriber(
+		"blocking-send-task",
+		1,
+		WithSubscriberBlockingSend(true),
+	)
+
+	if err := subscriber.Send(protocol.StreamingMessageEvent{}); err != nil {
+		t.Fatalf("Failed to fill subscriber channel: %v", err)
+	}
+
+	sendErr := make(chan error, 1)
+	started := make(chan struct{})
+	go func() {
+		close(started)
+		sendErr <- subscriber.Send(protocol.StreamingMessageEvent{})
+	}()
+
+	<-started
+	time.Sleep(10 * time.Millisecond)
+	subscriber.Close()
+
+	select {
+	case err := <-sendErr:
+		if err == nil {
+			t.Error("Expected blocked send to return an error after Close")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Expected Close to unblock blocking send")
+	}
+}
+
 func TestCancellableTask(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -719,9 +751,13 @@ func TestMemoryTaskManager_UpdateTaskState_CleansSubscribersOnFinalState(t *test
 	}
 	manager.taskMu.RUnlock()
 
-	// Drain events before completing
+	// Collect events until the channel is closed by the final-state cleanup.
+	var events []protocol.StreamingMessageEvent
+	consumerDone := make(chan struct{})
 	go func() {
-		for range sub.Channel() {
+		defer close(consumerDone)
+		for ev := range sub.Channel() {
+			events = append(events, ev)
 		}
 	}()
 
@@ -731,6 +767,26 @@ func TestMemoryTaskManager_UpdateTaskState_CleansSubscribersOnFinalState(t *test
 		t.Fatalf("Failed to update state: %v", err)
 	}
 
+	// Reaching a final state must close the subscriber channel (range returns).
+	select {
+	case <-consumerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("subscriber channel was not closed after final state")
+	}
+
+	// deliver-then-close ordering must not drop the terminal event: the final
+	// TaskStatusUpdateEvent has to arrive before the channel close.
+	var gotFinal bool
+	for _, ev := range events {
+		if statusEvt, ok := ev.Result.(*protocol.TaskStatusUpdateEvent); ok &&
+			statusEvt.Final && statusEvt.Status.State == protocol.TaskStateCompleted {
+			gotFinal = true
+		}
+	}
+	if !gotFinal {
+		t.Errorf("Expected a final Completed TaskStatusUpdateEvent before close, got %d events", len(events))
+	}
+
 	// Subscribers should be cleaned up
 	manager.taskMu.RLock()
 	subs := manager.Subscribers[taskID]
@@ -738,6 +794,40 @@ func TestMemoryTaskManager_UpdateTaskState_CleansSubscribersOnFinalState(t *test
 
 	if len(subs) != 0 {
 		t.Errorf("Expected subscribers to be cleaned after final state, got %d", len(subs))
+	}
+}
+
+func TestMemoryTaskManager_cleanupFailedSubscribersClosesRemovedSubscribers(t *testing.T) {
+	processor := &MockMessageProcessor{}
+	manager, err := NewMemoryTaskManager(processor)
+	if err != nil {
+		t.Fatalf("Failed to create manager: %v", err)
+	}
+	defer manager.Close()
+
+	taskID := "failed-subscriber-task"
+	failedSub := NewMemoryTaskSubscriber(taskID, 10)
+	activeSub := NewMemoryTaskSubscriber(taskID, 10)
+
+	manager.taskMu.Lock()
+	manager.Subscribers[taskID] = []*MemoryTaskSubscriber{failedSub, activeSub}
+	manager.taskMu.Unlock()
+
+	manager.cleanupFailedSubscribers(taskID, []*MemoryTaskSubscriber{failedSub})
+
+	if !failedSub.Closed() {
+		t.Error("Expected failed subscriber to be closed")
+	}
+	if activeSub.Closed() {
+		t.Error("Expected active subscriber to remain open")
+	}
+
+	manager.taskMu.RLock()
+	subs := manager.Subscribers[taskID]
+	manager.taskMu.RUnlock()
+
+	if len(subs) != 1 || subs[0] != activeSub {
+		t.Fatalf("Expected only active subscriber to remain, got %d subscribers", len(subs))
 	}
 }
 
@@ -832,6 +922,70 @@ func TestMemoryTaskManager_cleanExpiredTasks(t *testing.T) {
 	}
 }
 
+func TestMemoryTaskManager_TaskTTLCleanupGoroutine(t *testing.T) {
+	processor := &MockMessageProcessor{}
+	manager, err := NewMemoryTaskManager(
+		processor,
+		WithConversationTTL(time.Hour, 5*time.Millisecond),
+		WithTaskTTL(time.Nanosecond),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create manager: %v", err)
+	}
+	defer manager.Close()
+
+	taskID := "auto-expired-task"
+	sub := NewMemoryTaskSubscriber(taskID, 10)
+	task := protocol.Task{
+		ID:   taskID,
+		Kind: protocol.KindTask,
+		Status: protocol.TaskStatus{
+			State:     protocol.TaskStateCompleted,
+			Timestamp: time.Now().Add(-time.Hour).UTC().Format(time.RFC3339),
+		},
+	}
+
+	manager.taskMu.Lock()
+	manager.Tasks[taskID] = NewCancellableTask(task)
+	manager.Subscribers[taskID] = []*MemoryTaskSubscriber{sub}
+	manager.taskMu.Unlock()
+
+	manager.mu.Lock()
+	manager.PushNotifications[taskID] = protocol.TaskPushNotificationConfig{TaskID: taskID}
+	manager.mu.Unlock()
+
+	deadline := time.After(500 * time.Millisecond)
+	ticker := time.NewTicker(5 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		manager.taskMu.RLock()
+		_, taskExists := manager.Tasks[taskID]
+		_, subsExists := manager.Subscribers[taskID]
+		manager.taskMu.RUnlock()
+
+		manager.mu.RLock()
+		_, pushExists := manager.PushNotifications[taskID]
+		manager.mu.RUnlock()
+
+		if !taskExists && !subsExists && !pushExists && sub.Closed() {
+			return
+		}
+
+		select {
+		case <-deadline:
+			t.Fatalf(
+				"Timed out waiting for task TTL cleanup: taskExists=%v subsExists=%v pushExists=%v subClosed=%v",
+				taskExists,
+				subsExists,
+				pushExists,
+				sub.Closed(),
+			)
+		case <-ticker.C:
+		}
+	}
+}
+
 func TestMemoryTaskManager_Close(t *testing.T) {
 	processor := &MockMessageProcessor{}
 	manager, err := NewMemoryTaskManager(processor)
@@ -892,15 +1046,24 @@ func TestWithTaskTTL(t *testing.T) {
 		t.Errorf("Expected default TaskTTL=0 (disabled), got %v", opts.TaskTTL)
 	}
 
-	WithTaskTTL(30 * time.Minute)(opts)
-	if opts.TaskTTL != 30*time.Minute {
-		t.Errorf("Expected TaskTTL=30m, got %v", opts.TaskTTL)
+	// A positive TTL also enables the cleanup goroutine, mirroring WithConversationTTL.
+	fresh := &MemoryTaskManagerOptions{}
+	WithTaskTTL(30 * time.Minute)(fresh)
+	if fresh.TaskTTL != 30*time.Minute {
+		t.Errorf("Expected TaskTTL=30m, got %v", fresh.TaskTTL)
+	}
+	if !fresh.EnableCleanup {
+		t.Error("Expected WithTaskTTL(>0) to enable cleanup")
 	}
 
-	// Zero value explicitly disables task cleanup
-	WithTaskTTL(0)(opts)
-	if opts.TaskTTL != 0 {
-		t.Errorf("Expected TaskTTL=0 after explicit disable, got %v", opts.TaskTTL)
+	// A zero TTL disables task cleanup and must not flip EnableCleanup on.
+	disabled := &MemoryTaskManagerOptions{}
+	WithTaskTTL(0)(disabled)
+	if disabled.TaskTTL != 0 {
+		t.Errorf("Expected TaskTTL=0 after explicit disable, got %v", disabled.TaskTTL)
+	}
+	if disabled.EnableCleanup {
+		t.Error("Expected WithTaskTTL(0) to leave EnableCleanup untouched")
 	}
 }
 

--- a/taskmanager/redis/redis_manager.go
+++ b/taskmanager/redis/redis_manager.go
@@ -29,7 +29,7 @@ const (
 	pushNotificationPrefix = "push:"
 	subscriberPrefix       = "sub:"
 
-	// Default expiration time for Redis keys (30 days).
+	// Default expiration time for Redis keys.
 	defaultExpiration = 1 * time.Hour
 
 	// Default configuration values.

--- a/taskmanager/redis/redis_manager.go
+++ b/taskmanager/redis/redis_manager.go
@@ -29,7 +29,7 @@ const (
 	pushNotificationPrefix = "push:"
 	subscriberPrefix       = "sub:"
 
-	// Default expiration time for Redis keys.
+	// Default expiration time for Redis keys (1 hour).
 	defaultExpiration = 1 * time.Hour
 
 	// Default configuration values.


### PR DESCRIPTION
## Summary

- close and remove MemoryTaskManager subscribers when a task reaches a terminal state
- close failed subscribers before removing them from the subscriber map
- add an opt-in TaskTTL cleanup path for terminal tasks, disabled by default
- add tests for final-state subscriber cleanup, task TTL cleanup, and manager Close
- align Redis TaskManager expiration comment with the actual one-hour default

## Root Cause

MemoryTaskSubscriber.Close only closed the channel owned by the subscriber. The MemoryTaskManager could still keep task and subscriber references in its internal maps unless user code explicitly cleaned the task, which could retain memory after streaming completed.

Fixes #104

## Validation

- go test ./taskmanager
- go test -race ./taskmanager
- go test ./...
- (cd taskmanager/redis && go test .)