### PR TITLE
server: tenant-native multi-agent and optional agent card; split taskmanager/memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ if err != nil {
 }
 
 // Create the server
-srv, err := server.NewA2AServer(agentCard, taskManager)
+srv, err := server.NewA2AServer(taskManager, server.WithAgentCard(agentCard))
 if err != nil {
     log.Fatalf("Failed to create server: %v", err)
 }
@@ -353,8 +353,8 @@ chainProvider := auth.NewChainAuthProvider(
 
 // Create the server with authentication
 srv, err := server.NewA2AServer(
-    agentCard,
     taskManager,
+    server.WithAgentCard(agentCard),
     server.WithAuthProvider(chainProvider),
 )
 ```
@@ -425,8 +425,8 @@ http.HandleFunc("/.well-known/jwks.json", notifAuth.HandleJWKS)
 
 // Enable JWKS endpoint when creating the server
 srv, err := server.NewA2AServer(
-    agentCard,
     taskManager,
+    server.WithAgentCard(agentCard),
     server.WithJWKSEndpoint(true, "/.well-known/jwks.json"),
 )
 ```
@@ -483,8 +483,8 @@ import (
 )
 
 srv, err := server.NewA2AServer(
-    agentCard,
     taskManager,
+    server.WithAgentCard(agentCard),
     server.WithTelemetryMeterProviderOptions(
         metrics.WithProtocol("grpc"),            // "grpc" (default) or "http"
         metrics.WithEndpoint("localhost:4317"), // OTLP collector endpoint
@@ -518,8 +518,8 @@ import (
 provider := noop.NewMeterProvider()
 
 srv, err := server.NewA2AServer(
-    agentCard,
     taskManager,
+    server.WithAgentCard(agentCard),
     server.WithTelemetryMeterProvider(provider),
 )
 if err != nil {
@@ -555,8 +555,8 @@ func (customFirstTokenPolicy) IsNonStreamingFirstToken(_ *protocol.MessageResult
 }
 
 srv, err := server.NewA2AServer(
-    agentCard,
     taskManager,
+    server.WithAgentCard(agentCard),
     server.WithFirstTokenPolicy(customFirstTokenPolicy{}),
 )
 if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -231,6 +231,7 @@ func (c *A2AClient) sendA2AStreamRequest(ctx context.Context, id, method string,
 	// Set headers, including Accept for event stream.
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	req.Header.Set("Accept", "text/event-stream") // Crucial for SSE.
+	req.Header.Set("A2A-Version", protocol.ProtocolVersionV1)
 	if c.userAgent != "" {
 		req.Header.Set("User-Agent", c.userAgent)
 	}
@@ -456,6 +457,7 @@ func (c *A2AClient) doRequest(ctx context.Context, request *jsonrpc.Request, opt
 	// Set required headers.
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	req.Header.Set("Accept", "application/json")
+	req.Header.Set("A2A-Version", protocol.ProtocolVersionV1)
 	if c.userAgent != "" {
 		req.Header.Set("User-Agent", c.userAgent)
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -43,20 +43,20 @@ func TestA2AClient_ResubscribeTask(t *testing.T) {
 	t.Run("ResubscribeTask Success", func(t *testing.T) {
 		// Prepare mock SSE stream data.
 		sseEvent1Data, _ := json.Marshal(protocol.StreamResponse{
-			StatusUpdate: &protocol.TaskStatusUpdateEvent{
+			Result: &protocol.TaskStatusUpdateEvent{
 				TaskID: taskID,
 				Status: protocol.TaskStatus{State: protocol.TaskStateWorking},
 				Final:  false,
 			},
 		})
 		sseEvent2Data, _ := json.Marshal(protocol.StreamResponse{
-			ArtifactUpdate: &protocol.TaskArtifactUpdateEvent{
+			Result: &protocol.TaskArtifactUpdateEvent{
 				TaskID:   taskID,
 				Artifact: protocol.Artifact{ArtifactID: "0", Parts: []*protocol.Part{protocol.NewTextPart("SSE data")}},
 			},
 		})
 		sseEvent3Data, _ := json.Marshal(protocol.StreamResponse{
-			StatusUpdate: &protocol.TaskStatusUpdateEvent{
+			Result: &protocol.TaskStatusUpdateEvent{
 				TaskID: taskID,
 				Status: protocol.TaskStatus{State: protocol.TaskStateCompleted},
 				Final:  true,
@@ -116,16 +116,16 @@ func TestA2AClient_ResubscribeTask(t *testing.T) {
 
 		// Assert the content and order of received events.
 		require.Len(t, receivedEvents, 3, "Should receive exactly 3 events")
-		assert.NotNil(t, receivedEvents[0].StatusUpdate, "First event should be StatusUpdate")
-		assert.NotNil(t, receivedEvents[1].ArtifactUpdate, "Second event should be ArtifactUpdate")
-		assert.NotNil(t, receivedEvents[2].StatusUpdate, "Third event should be StatusUpdate")
+		assert.NotNil(t, receivedEvents[0].GetStatusUpdate(), "First event should be StatusUpdate")
+		assert.NotNil(t, receivedEvents[1].GetArtifactUpdate(), "Second event should be ArtifactUpdate")
+		assert.NotNil(t, receivedEvents[2].GetStatusUpdate(), "Third event should be StatusUpdate")
 		assert.Equal(t, protocol.TaskStateWorking,
-			receivedEvents[0].StatusUpdate.Status.State, "First event state mismatch")
-		assert.False(t, receivedEvents[0].StatusUpdate.IsFinal(), "First event should not be final")
-		assert.False(t, receivedEvents[1].ArtifactUpdate.IsFinal(), "Second event should not be final")
+			receivedEvents[0].GetStatusUpdate().Status.State, "First event state mismatch")
+		assert.False(t, receivedEvents[0].GetStatusUpdate().IsFinal(), "First event should not be final")
+		assert.False(t, receivedEvents[1].GetArtifactUpdate().IsFinal(), "Second event should not be final")
 		assert.Equal(t, protocol.TaskStateCompleted,
-			receivedEvents[2].StatusUpdate.Status.State, "Third event state mismatch")
-		assert.True(t, receivedEvents[2].StatusUpdate.IsFinal(), "Last event should be final")
+			receivedEvents[2].GetStatusUpdate().Status.State, "Third event state mismatch")
+		assert.True(t, receivedEvents[2].GetStatusUpdate().IsFinal(), "Last event should be final")
 	})
 
 	t.Run("ResubscribeTask HTTP Error", func(t *testing.T) {

--- a/client/options_test.go
+++ b/client/options_test.go
@@ -205,7 +205,7 @@ func TestRequestOptions_CustomHeaders(t *testing.T) {
 		var resultBytes []byte
 		switch req.Method {
 		case protocol.MethodMessageSend:
-			resultBytes, _ = json.Marshal(protocol.SendMessageResponse{Task: &task})
+			resultBytes, _ = json.Marshal(protocol.SendMessageResponse{Result: &task})
 		default:
 			resultBytes, _ = json.Marshal(task)
 		}

--- a/compat/v0/conversions.go
+++ b/compat/v0/conversions.go
@@ -403,13 +403,13 @@ func FromV1ArtifactUpdate(e *protocol.TaskArtifactUpdateEvent) *TaskArtifactUpda
 func ToV1StreamResponse(ev StreamingMessageEvent) (protocol.StreamResponse, error) {
 	switch v := ev.Result.(type) {
 	case *Message:
-		return protocol.StreamResponse{Message: ToV1Message(v)}, nil
+		return protocol.StreamResponse{Result: ToV1Message(v)}, nil
 	case *Task:
-		return protocol.StreamResponse{Task: ToV1Task(v)}, nil
+		return protocol.StreamResponse{Result: ToV1Task(v)}, nil
 	case *TaskStatusUpdateEvent:
-		return protocol.StreamResponse{StatusUpdate: ToV1StatusUpdate(v)}, nil
+		return protocol.StreamResponse{Result: ToV1StatusUpdate(v)}, nil
 	case *TaskArtifactUpdateEvent:
-		return protocol.StreamResponse{ArtifactUpdate: ToV1ArtifactUpdate(v)}, nil
+		return protocol.StreamResponse{Result: ToV1ArtifactUpdate(v)}, nil
 	default:
 		return protocol.StreamResponse{}, fmt.Errorf("compat/v0: unknown streaming result type %T", ev.Result)
 	}
@@ -418,14 +418,14 @@ func ToV1StreamResponse(ev StreamingMessageEvent) (protocol.StreamResponse, erro
 // FromV1StreamResponse converts a v1 stream response to a legacy streaming event.
 func FromV1StreamResponse(r protocol.StreamResponse) (StreamingMessageEvent, error) {
 	switch {
-	case r.Message != nil:
-		return StreamingMessageEvent{Result: FromV1Message(r.Message)}, nil
-	case r.Task != nil:
-		return StreamingMessageEvent{Result: FromV1Task(r.Task)}, nil
-	case r.StatusUpdate != nil:
-		return StreamingMessageEvent{Result: FromV1StatusUpdate(r.StatusUpdate)}, nil
-	case r.ArtifactUpdate != nil:
-		return StreamingMessageEvent{Result: FromV1ArtifactUpdate(r.ArtifactUpdate)}, nil
+	case r.GetMessage() != nil:
+		return StreamingMessageEvent{Result: FromV1Message(r.GetMessage())}, nil
+	case r.GetTask() != nil:
+		return StreamingMessageEvent{Result: FromV1Task(r.GetTask())}, nil
+	case r.GetStatusUpdate() != nil:
+		return StreamingMessageEvent{Result: FromV1StatusUpdate(r.GetStatusUpdate())}, nil
+	case r.GetArtifactUpdate() != nil:
+		return StreamingMessageEvent{Result: FromV1ArtifactUpdate(r.GetArtifactUpdate())}, nil
 	default:
 		return StreamingMessageEvent{}, fmt.Errorf("compat/v0: empty v1 stream response")
 	}
@@ -438,9 +438,9 @@ func ToV1SendMessageResponse(r *MessageResult) (*protocol.SendMessageResponse, e
 	}
 	switch v := r.Result.(type) {
 	case *Message:
-		return &protocol.SendMessageResponse{Message: ToV1Message(v)}, nil
+		return &protocol.SendMessageResponse{Result: ToV1Message(v)}, nil
 	case *Task:
-		return &protocol.SendMessageResponse{Task: ToV1Task(v)}, nil
+		return &protocol.SendMessageResponse{Result: ToV1Task(v)}, nil
 	default:
 		return nil, fmt.Errorf("compat/v0: unknown unary result type %T", r.Result)
 	}
@@ -452,10 +452,10 @@ func FromV1SendMessageResponse(r *protocol.SendMessageResponse) (*MessageResult,
 		return nil, nil
 	}
 	switch {
-	case r.Message != nil:
-		return &MessageResult{Result: FromV1Message(r.Message)}, nil
-	case r.Task != nil:
-		return &MessageResult{Result: FromV1Task(r.Task)}, nil
+	case r.GetMessage() != nil:
+		return &MessageResult{Result: FromV1Message(r.GetMessage())}, nil
+	case r.GetTask() != nil:
+		return &MessageResult{Result: FromV1Task(r.GetTask())}, nil
 	default:
 		return nil, fmt.Errorf("compat/v0: empty v1 send message response")
 	}

--- a/compat/v0/conversions_stream_test.go
+++ b/compat/v0/conversions_stream_test.go
@@ -55,16 +55,16 @@ func TestToV1StreamResponse_AllBranches(t *testing.T) {
 	statusEvt := NewTaskStatusUpdateEvent("t", "c", TaskStatus{State: TaskStateWorking}, false)
 	artEvt := &TaskArtifactUpdateEvent{TaskID: "t", Artifact: csArtifact()}
 
-	if r, err := ToV1StreamResponse(StreamingMessageEvent{Result: &msg}); err != nil || r.Message == nil {
+	if r, err := ToV1StreamResponse(StreamingMessageEvent{Result: &msg}); err != nil || r.GetMessage() == nil {
 		t.Errorf("message branch: r=%+v err=%v", r, err)
 	}
-	if r, err := ToV1StreamResponse(StreamingMessageEvent{Result: task}); err != nil || r.Task == nil {
+	if r, err := ToV1StreamResponse(StreamingMessageEvent{Result: task}); err != nil || r.GetTask() == nil {
 		t.Errorf("task branch: r=%+v err=%v", r, err)
 	}
-	if r, err := ToV1StreamResponse(StreamingMessageEvent{Result: &statusEvt}); err != nil || r.StatusUpdate == nil {
+	if r, err := ToV1StreamResponse(StreamingMessageEvent{Result: &statusEvt}); err != nil || r.GetStatusUpdate() == nil {
 		t.Errorf("status-update branch: r=%+v err=%v", r, err)
 	}
-	if r, err := ToV1StreamResponse(StreamingMessageEvent{Result: artEvt}); err != nil || r.ArtifactUpdate == nil {
+	if r, err := ToV1StreamResponse(StreamingMessageEvent{Result: artEvt}); err != nil || r.GetArtifactUpdate() == nil {
 		t.Errorf("artifact-update branch: r=%+v err=%v", r, err)
 	}
 	// nil/unknown Result -> error.
@@ -84,10 +84,10 @@ func TestFromV1StreamResponse_AllBranches(t *testing.T) {
 		in   protocol.StreamResponse
 		want interface{} // expected concrete legacy type
 	}{
-		{"message", protocol.StreamResponse{Message: ToV1Message(&msg)}, &Message{}},
-		{"task", protocol.StreamResponse{Task: ToV1Task(task)}, &Task{}},
-		{"status", protocol.StreamResponse{StatusUpdate: ToV1StatusUpdate(&statusEvt)}, &TaskStatusUpdateEvent{}},
-		{"artifact", protocol.StreamResponse{ArtifactUpdate: ToV1ArtifactUpdate(artEvt)}, &TaskArtifactUpdateEvent{}},
+		{"message", protocol.StreamResponse{Result: ToV1Message(&msg)}, &Message{}},
+		{"task", protocol.StreamResponse{Result: ToV1Task(task)}, &Task{}},
+		{"status", protocol.StreamResponse{Result: ToV1StatusUpdate(&statusEvt)}, &TaskStatusUpdateEvent{}},
+		{"artifact", protocol.StreamResponse{Result: ToV1ArtifactUpdate(artEvt)}, &TaskArtifactUpdateEvent{}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -116,7 +116,7 @@ func TestFromV1StreamResponse_AllBranches(t *testing.T) {
 		})
 	}
 	if _, err := FromV1StreamResponse(protocol.StreamResponse{}); err == nil {
-		t.Error("empty v1 StreamResponse should error")
+		t.Error("empty v1 StreamingMessageEvent should error")
 	}
 }
 
@@ -127,10 +127,10 @@ func TestSendMessageResponseConversion(t *testing.T) {
 	if r, err := ToV1SendMessageResponse(nil); err != nil || r != nil {
 		t.Errorf("ToV1SendMessageResponse(nil) = (%v,%v)", r, err)
 	}
-	if r, err := ToV1SendMessageResponse(&MessageResult{Result: &msg}); err != nil || r.Message == nil {
+	if r, err := ToV1SendMessageResponse(&MessageResult{Result: &msg}); err != nil || r.GetMessage() == nil {
 		t.Errorf("message branch: r=%+v err=%v", r, err)
 	}
-	if r, err := ToV1SendMessageResponse(&MessageResult{Result: task}); err != nil || r.Task == nil {
+	if r, err := ToV1SendMessageResponse(&MessageResult{Result: task}); err != nil || r.GetTask() == nil {
 		t.Errorf("task branch: r=%+v err=%v", r, err)
 	}
 	if _, err := ToV1SendMessageResponse(&MessageResult{}); err == nil {
@@ -140,17 +140,17 @@ func TestSendMessageResponseConversion(t *testing.T) {
 	if r, err := FromV1SendMessageResponse(nil); err != nil || r != nil {
 		t.Errorf("FromV1SendMessageResponse(nil) = (%v,%v)", r, err)
 	}
-	if r, err := FromV1SendMessageResponse(&protocol.SendMessageResponse{Message: ToV1Message(&msg)}); err != nil {
+	if r, err := FromV1SendMessageResponse(&protocol.SendMessageResponse{Result: ToV1Message(&msg)}); err != nil {
 		t.Errorf("message branch err: %v", err)
 	} else if _, ok := r.Result.(*Message); !ok {
 		t.Errorf("got %T, want *Message", r.Result)
 	}
-	if r, err := FromV1SendMessageResponse(&protocol.SendMessageResponse{Task: ToV1Task(task)}); err != nil {
+	if r, err := FromV1SendMessageResponse(&protocol.SendMessageResponse{Result: ToV1Task(task)}); err != nil {
 		t.Errorf("task branch err: %v", err)
 	} else if _, ok := r.Result.(*Task); !ok {
 		t.Errorf("got %T, want *Task", r.Result)
 	}
 	if _, err := FromV1SendMessageResponse(&protocol.SendMessageResponse{}); err == nil {
-		t.Error("empty v1 SendMessageResponse should error")
+		t.Error("empty v1 MessageResult should error")
 	}
 }

--- a/compat/v0/jsonrpc_client_test.go
+++ b/compat/v0/jsonrpc_client_test.go
@@ -52,9 +52,9 @@ func TestClientServerLoopback(t *testing.T) {
 		assert.Equal(t, "ping", fake.gotSendParams.Message.Parts[0].TextContent())
 
 		// And the caller gets v1 types back.
-		require.NotNil(t, resp.Message)
-		assert.Equal(t, protocol.MessageRoleAgent, resp.Message.Role)
-		assert.Equal(t, "pong", resp.Message.Parts[0].TextContent())
+		require.NotNil(t, resp.GetMessage())
+		assert.Equal(t, protocol.MessageRoleAgent, resp.GetMessage().Role)
+		assert.Equal(t, "pong", resp.GetMessage().Parts[0].TextContent())
 	})
 
 	t.Run("GetTasks", func(t *testing.T) {
@@ -82,11 +82,11 @@ func TestClientServerLoopback(t *testing.T) {
 
 	t.Run("StreamMessage", func(t *testing.T) {
 		fake.streamEvents = []protocol.StreamResponse{
-			{StatusUpdate: &protocol.TaskStatusUpdateEvent{
+			{Result: &protocol.TaskStatusUpdateEvent{
 				TaskID: "task-1", ContextID: "ctx-1",
 				Status: protocol.TaskStatus{State: protocol.TaskStateWorking},
 			}},
-			{StatusUpdate: &protocol.TaskStatusUpdateEvent{
+			{Result: &protocol.TaskStatusUpdateEvent{
 				TaskID: "task-1", ContextID: "ctx-1",
 				Status: protocol.TaskStatus{State: protocol.TaskStateCompleted},
 			}},
@@ -104,8 +104,8 @@ func TestClientServerLoopback(t *testing.T) {
 			received = append(received, ev)
 		}
 		require.Len(t, received, 2)
-		assert.Equal(t, protocol.TaskStateWorking, received[0].StatusUpdate.Status.State)
-		assert.Equal(t, protocol.TaskStateCompleted, received[1].StatusUpdate.Status.State)
+		assert.Equal(t, protocol.TaskStateWorking, received[0].GetStatusUpdate().Status.State)
+		assert.Equal(t, protocol.TaskStateCompleted, received[1].GetStatusUpdate().Status.State)
 		assert.True(t, received[1].IsFinal())
 	})
 }
@@ -122,7 +122,7 @@ func TestClientServerLoopback_MoreMethods(t *testing.T) {
 			TaskID: "task-1", URL: "https://example.com/hook",
 		},
 		streamEvents: []protocol.StreamResponse{
-			{StatusUpdate: &protocol.TaskStatusUpdateEvent{
+			{Result: &protocol.TaskStatusUpdateEvent{
 				TaskID: "task-1", Status: protocol.TaskStatus{State: protocol.TaskStateCompleted}}},
 		},
 	}

--- a/compat/v0/jsonrpc_server_test.go
+++ b/compat/v0/jsonrpc_server_test.go
@@ -182,11 +182,11 @@ func TestHandler_TasksGet_LegacyWire(t *testing.T) {
 func TestHandler_Streaming_LegacyWire(t *testing.T) {
 	fake := &fakeTaskManager{
 		streamEvents: []protocol.StreamResponse{
-			{StatusUpdate: &protocol.TaskStatusUpdateEvent{
+			{Result: &protocol.TaskStatusUpdateEvent{
 				TaskID: "task-1", ContextID: "ctx-1",
 				Status: protocol.TaskStatus{State: protocol.TaskStateWorking},
 			}},
-			{StatusUpdate: &protocol.TaskStatusUpdateEvent{
+			{Result: &protocol.TaskStatusUpdateEvent{
 				TaskID: "task-1", ContextID: "ctx-1",
 				Status: protocol.TaskStatus{State: protocol.TaskStateCompleted},
 			}},

--- a/examples/auth/client/main.go
+++ b/examples/auth/client/main.go
@@ -150,7 +150,7 @@ func main() {
 	}
 
 	// Handle the response based on its type
-	if msg := result.Message; msg != nil {
+	if msg := result.GetMessage(); msg != nil {
 		fmt.Printf("Message Response: %s\n", msg.MessageID)
 		if msg.ContextID != nil {
 			fmt.Printf("Context ID: %s\n", *msg.ContextID)
@@ -160,7 +160,7 @@ func main() {
 				fmt.Printf("Response: %s\n", text)
 			}
 		}
-	} else if task := result.Task; task != nil {
+	} else if task := result.GetTask(); task != nil {
 		fmt.Printf("Task ID: %s, Status: %s\n", task.ID, task.Status.State)
 		if task.ContextID != "" {
 			fmt.Printf("Context ID: %s\n", task.ContextID)

--- a/examples/auth/server/main.go
+++ b/examples/auth/server/main.go
@@ -26,6 +26,7 @@ import (
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/server"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager/memory"
 )
 
 // config holds server configuration
@@ -87,7 +88,7 @@ func main() {
 	processor := &echoMessageProcessor{}
 
 	// Create a real task manager with our processor
-	taskManager, err := taskmanager.NewMemoryTaskManager(processor)
+	taskManager, err := memory.NewTaskManager(processor)
 	if err != nil {
 		log.Fatalf("Failed to create task manager: %v", err)
 	}
@@ -183,8 +184,8 @@ func main() {
 
 	// Create the server with authentication
 	a2aServer, err := server.NewA2AServer(
-		agentCard,
 		taskManager,
+		server.WithAgentCard(agentCard),
 		server.WithAuthProvider(chainProvider),
 		server.WithAuthenticatedExtendedCardHandler(
 			func(ctx context.Context, baseCard server.AgentCard) (server.AgentCard, error) {

--- a/examples/auth/server/main.go
+++ b/examples/auth/server/main.go
@@ -354,7 +354,7 @@ func (p *echoMessageProcessor) ProcessMessage(
 	)
 
 	return &taskmanager.MessageProcessingResult{
-		Result: &protocol.SendMessageResponse{Message: &responseMsg},
+		Result: &protocol.SendMessageResponse{Result: &responseMsg},
 	}, nil
 }
 

--- a/examples/basic/client/main.go
+++ b/examples/basic/client/main.go
@@ -628,10 +628,10 @@ func handleStandardInteraction(
 	fmt.Println(strings.Repeat("-", 10))
 
 	var taskID string
-	if response := result.Message; response != nil {
+	if response := result.GetMessage(); response != nil {
 		fmt.Println("  Message Response:")
 		printMessage(*response)
-	} else if response := result.Task; response != nil {
+	} else if response := result.GetTask(); response != nil {
 		taskID = response.ID
 		fmt.Printf("  Task %s State: %s (%s)\n", response.ID, response.Status.State, formatTimestamp(response.Status.Timestamp))
 
@@ -699,16 +699,16 @@ func processStreamResponse(
 				return taskID
 			}
 
-			if e := event.Message; e != nil {
+			if e := event.GetMessage(); e != nil {
 				fmt.Println("  [Message Response:]")
 				printMessage(*e)
-			} else if e := event.Task; e != nil {
+			} else if e := event.GetTask(); e != nil {
 				taskID = e.ID
 				fmt.Printf("  [Task %s State: %s (%s)]\n", e.ID, e.Status.State, formatTimestamp(e.Status.Timestamp))
 				if e.Status.Message != nil {
 					printMessage(*e.Status.Message)
 				}
-			} else if e := event.StatusUpdate; e != nil {
+			} else if e := event.GetStatusUpdate(); e != nil {
 				taskID = e.TaskID
 				fmt.Printf("  [Status Update: %s (%s)]\n", e.Status.State, formatTimestamp(e.Status.Timestamp))
 				if e.Status.Message != nil {
@@ -730,7 +730,7 @@ func processStreamResponse(
 					}
 					return taskID
 				}
-			} else if e := event.ArtifactUpdate; e != nil {
+			} else if e := event.GetArtifactUpdate(); e != nil {
 				taskID = e.TaskID
 				name := getArtifactName(e.Artifact)
 

--- a/examples/basic/server/main.go
+++ b/examples/basic/server/main.go
@@ -25,6 +25,7 @@ import (
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/server"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager/memory"
 )
 
 // Command modes for the text processor
@@ -353,7 +354,7 @@ func main() {
 	}
 
 	// Create the base TaskManager with built-in push notification storage support
-	baseTaskManager, err := taskmanager.NewMemoryTaskManager(processor)
+	baseTaskManager, err := memory.NewTaskManager(processor)
 	if err != nil {
 		log.Fatalf("Failed to create task manager: %v", err)
 	}
@@ -362,7 +363,7 @@ func main() {
 	taskManager := newPushNotificationSender(baseTaskManager)
 
 	// Create the A2A server instance using the factory from server package
-	srv, err := server.NewA2AServer(agentCard, taskManager, server.WithCORSEnabled(!noCORS))
+	srv, err := server.NewA2AServer(taskManager, server.WithAgentCard(agentCard), server.WithCORSEnabled(!noCORS))
 	if err != nil {
 		log.Fatalf("Failed to create A2A server: %v", err)
 	}

--- a/examples/basic/server/main.go
+++ b/examples/basic/server/main.go
@@ -82,7 +82,7 @@ func (p *basicMessageProcessor) ProcessMessage(
 			[]*protocol.Part{protocol.NewTextPart(errMsg)},
 		)
 		return &taskmanager.MessageProcessingResult{
-			Result: &protocol.SendMessageResponse{Message: &errorMessage},
+			Result: &protocol.SendMessageResponse{Result: &errorMessage},
 		}, nil
 	}
 
@@ -142,7 +142,7 @@ func (p *basicMessageProcessor) ProcessMessage(
 			[]*protocol.Part{protocol.NewTextPart("Multi-turn interaction started. Please continue the conversation.")},
 		)
 		return &taskmanager.MessageProcessingResult{
-			Result: &protocol.SendMessageResponse{Message: &responseMessage},
+			Result: &protocol.SendMessageResponse{Result: &responseMessage},
 		}, nil
 	}
 
@@ -168,7 +168,7 @@ func (p *basicMessageProcessor) processSimpleCommand(text string) (*taskmanager.
 	)
 
 	return &taskmanager.MessageProcessingResult{
-		Result: &protocol.SendMessageResponse{Message: &responseMessage},
+		Result: &protocol.SendMessageResponse{Result: &responseMessage},
 	}, nil
 }
 
@@ -195,7 +195,7 @@ func (p *basicMessageProcessor) processMultiTurnSession(
 		[]*protocol.Part{protocol.NewTextPart("Processing your multi-turn request...")},
 	)
 	return &taskmanager.MessageProcessingResult{
-		Result: &protocol.SendMessageResponse{Message: &responseMessage},
+		Result: &protocol.SendMessageResponse{Result: &responseMessage},
 	}, nil
 }
 
@@ -431,7 +431,7 @@ func (p *pushNotificationSender) OnSendMessage(
 ) (*protocol.SendMessageResponse, error) {
 	result, err := p.TaskManager.OnSendMessage(ctx, params)
 	if err == nil && result != nil {
-		if task := result.Task; task != nil {
+		if task := result.GetTask(); task != nil {
 			go p.maybeSendStatusPushNotification(ctx, task.ID, task.Status.State)
 		}
 	}
@@ -455,7 +455,7 @@ func (p *pushNotificationSender) OnSendMessageStream(
 		for event := range eventChan {
 			wrappedChan <- event
 
-			if statusEvent := event.StatusUpdate; statusEvent != nil {
+			if statusEvent := event.GetStatusUpdate(); statusEvent != nil {
 				go p.maybeSendStatusPushNotification(ctx, statusEvent.TaskID, statusEvent.Status.State)
 			}
 		}

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -7,7 +7,6 @@ replace trpc.group/trpc-go/trpc-a2a-go/v2 => ../
 replace trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager/redis => ../taskmanager/redis
 
 require (
-	github.com/go-chi/chi/v5 v5.2.2
 	github.com/google/uuid v1.6.0
 	github.com/lestrrat-go/jwx/v2 v2.1.4
 	github.com/redis/go-redis/v9 v9.10.0

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -10,8 +10,6 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 h1:NMZiJj8QnKe1LgsbDayM4UoHwbvw
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
-github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
-github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/examples/jwks/client/main.go
+++ b/examples/jwks/client/main.go
@@ -605,15 +605,15 @@ func sendMessage(ctx context.Context, a2aClient *client.A2AClient, content strin
 		return "", fmt.Errorf("failed to send message: %w", err)
 	}
 
-	// Check the result type (v1.0: SendMessageResponse is a Message/Task union)
+	// Check the result type (v1.0: MessageResult is a Message/Task union)
 	switch {
-	case result.Message != nil:
+	case result.GetMessage() != nil:
 		log.Infof("Received direct message response")
 		return "", nil // No task ID for direct message responses
 
-	case result.Task != nil:
-		log.Infof("Task created: %s (State: %s)", result.Task.ID, result.Task.Status.State)
-		return result.Task.ID, nil
+	case result.GetTask() != nil:
+		log.Infof("Task created: %s (State: %s)", result.GetTask().ID, result.GetTask().Status.State)
+		return result.GetTask().ID, nil
 
 	default:
 		return "", fmt.Errorf("unexpected empty SendMessage response")

--- a/examples/jwks/server/main.go
+++ b/examples/jwks/server/main.go
@@ -27,6 +27,7 @@ import (
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/server"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager/memory"
 )
 
 const (
@@ -194,7 +195,7 @@ type pushNotificationTaskManager struct {
 func (m *pushNotificationTaskManager) sendPushNotification(ctx context.Context, taskID, status string) {
 	log.Infof("Sending push notification for task: %s with status: %s", taskID, status)
 	// Get push config from task manager
-	ptm, ok := m.TaskManager.(*taskmanager.MemoryTaskManager)
+	ptm, ok := m.TaskManager.(*memory.TaskManager)
 	if !ok {
 		log.Errorf("failed to cast task manager to memory task manager")
 		return
@@ -261,7 +262,7 @@ func main() {
 		notifyHost: *notifyHost,
 	}
 	// Create task manager
-	tm, err := taskmanager.NewMemoryTaskManager(processor)
+	tm, err := memory.NewTaskManager(processor)
 	if err != nil {
 		log.Fatalf("failed to create task manager: %v", err)
 	}
@@ -280,9 +281,8 @@ func main() {
 
 	// Create server with the authenticator
 	a2aServer, err := server.NewA2AServer(
-		agentCard,
 		customTM,
-		options...,
+		append([]server.Option{server.WithAgentCard(agentCard)}, options...)...,
 	)
 	if err != nil {
 		log.Fatalf("failed to create A2A server: %v", err)

--- a/examples/multi/cli/main.go
+++ b/examples/multi/cli/main.go
@@ -89,10 +89,10 @@ func sendMessage(client *client.A2AClient, text string) (string, error) {
 		return "", fmt.Errorf("failed to send message: %w", err)
 	}
 
-	if msg := result.Message; msg != nil {
+	if msg := result.GetMessage(); msg != nil {
 		return extractText(*msg), nil
 	}
-	if task := result.Task; task != nil {
+	if task := result.GetTask(); task != nil {
 		if task.Status.Message != nil {
 			return extractText(*task.Status.Message), nil
 		}

--- a/examples/multi/creative/main.go
+++ b/examples/multi/creative/main.go
@@ -22,6 +22,7 @@ import (
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/server"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager/memory"
 )
 
 // conversationCache to store conversation histories
@@ -233,14 +234,14 @@ func main() {
 	}
 
 	// Create task manager and inject processor
-	taskManager, err := taskmanager.NewMemoryTaskManager(processor)
+	taskManager, err := memory.NewTaskManager(processor)
 	if err != nil {
 		log.Fatal("Failed to create task manager: %v", err)
 	}
 
 	// Create the A2A server
 	agentCard := getAgentCard()
-	a2aServer, err := server.NewA2AServer(agentCard, taskManager)
+	a2aServer, err := server.NewA2AServer(taskManager, server.WithAgentCard(agentCard))
 	if err != nil {
 		log.Fatal("Failed to create A2A server: %v", err)
 	}

--- a/examples/multi/exchange/main.go
+++ b/examples/multi/exchange/main.go
@@ -24,6 +24,7 @@ import (
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/server"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager/memory"
 )
 
 // exchangeProcessor implements the taskmanager.MessageProcessor interface
@@ -336,14 +337,14 @@ func main() {
 	}
 
 	// Create task manager and inject processor
-	taskManager, err := taskmanager.NewMemoryTaskManager(processor)
+	taskManager, err := memory.NewTaskManager(processor)
 	if err != nil {
 		log.Fatal("Failed to create task manager: %v", err)
 	}
 
 	// Create the A2A server
 	agentCard := getAgentCard()
-	a2aServer, err := server.NewA2AServer(agentCard, taskManager)
+	a2aServer, err := server.NewA2AServer(taskManager, server.WithAgentCard(agentCard))
 	if err != nil {
 		log.Fatal("Failed to create A2A server: %v", err)
 	}

--- a/examples/multi/reimbursement/main.go
+++ b/examples/multi/reimbursement/main.go
@@ -21,6 +21,7 @@ import (
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/server"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager/memory"
 )
 
 // Store request IDs for demonstration purposes
@@ -333,14 +334,14 @@ func main() {
 	}
 
 	// Create task manager and inject processor
-	taskManager, err := taskmanager.NewMemoryTaskManager(processor)
+	taskManager, err := memory.NewTaskManager(processor)
 	if err != nil {
 		log.Fatal("Failed to create task manager: %v", err)
 	}
 
 	// Create the A2A server
 	agentCard := getAgentCard()
-	a2aServer, err := server.NewA2AServer(agentCard, taskManager)
+	a2aServer, err := server.NewA2AServer(taskManager, server.WithAgentCard(agentCard))
 	if err != nil {
 		log.Fatal("Failed to create A2A server: %v", err)
 	}

--- a/examples/multi/root/main.go
+++ b/examples/multi/root/main.go
@@ -227,10 +227,10 @@ func (p *rootAgentProcessor) callReimbursementAgent(ctx context.Context, text st
 }
 
 func extractResponseText(result *protocol.SendMessageResponse, agentName string) (string, error) {
-	if msg := result.Message; msg != nil {
+	if msg := result.GetMessage(); msg != nil {
 		return extractText(*msg), nil
 	}
-	if task := result.Task; task != nil {
+	if task := result.GetTask(); task != nil {
 		if task.Status.Message != nil {
 			return extractText(*task.Status.Message), nil
 		}

--- a/examples/multi/root/main.go
+++ b/examples/multi/root/main.go
@@ -20,6 +20,7 @@ import (
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/server"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager/memory"
 )
 
 // rootAgentProcessor implements the taskmanager.MessageProcessor interface.
@@ -337,14 +338,14 @@ func main() {
 	}
 
 	// Create task manager with our processor
-	taskManager, err := taskmanager.NewMemoryTaskManager(processor)
+	taskManager, err := memory.NewTaskManager(processor)
 	if err != nil {
 		log.Fatal("Failed to create task manager: %v", err)
 	}
 
 	// Create the A2A server
 	agentCard := getAgentCard()
-	a2aServer, err := server.NewA2AServer(agentCard, taskManager)
+	a2aServer, err := server.NewA2AServer(taskManager, server.WithAgentCard(agentCard))
 	if err != nil {
 		log.Fatal("Failed to create A2A server: %v", err)
 	}

--- a/examples/multi_endpoint/README.md
+++ b/examples/multi_endpoint/README.md
@@ -1,218 +1,147 @@
-# Multi-Agent Server Example
+# Multi-Agent Server Example (tenant-native)
 
-This example demonstrates how to run **multiple agents in a single process** using different URL paths to define separate endpoints for each agent.
+This example runs **multiple agents in a single process** using the A2A **v1.0
+tenant** model: all agents share **one** endpoint, and each request names the
+agent it wants via the `tenant` field in the request body. The agent-card
+endpoint serves the right card for `?tenant=<tenant>`.
+
+This replaces the older v0.x approach that distinguished agents by **URL path**
+(`/api/v1/agent/{agentName}/`), which required a placeholder card, a custom
+`AgentCardHandler`, a `{agentName}` path template, request middleware and a chi
+router. None of that is needed anymore.
 
 ## Architecture Overview
 
-**Single Process, Multiple Agents**: This implementation runs all agents within one server process, using URL path routing to distinguish between different agents. Each agent gets its own endpoint path but shares the same server resources.
-
 ```
 Single Server Process (localhost:8080)
-├── /api/v1/agent/chatAgent/     → Chat Agent
-└── /api/v1/agent/workerAgent/   → Worker Agent  
+└── /                          → JSON-RPC for every agent
+    └── request.tenant selects the agent ("chatAgent" | "workerAgent")
+    /.well-known/agent-card.json?tenant=chatAgent   → Chat Agent card
+    /.well-known/agent-card.json?tenant=workerAgent → Worker Agent card
+    /.well-known/agent-card.json                    → 404 (no default card here;
+                                                       add one with WithAgentCard)
 ```
 
-## Key Features
+## Key Points
 
-- **Single Process Architecture**: All agents run in one server process
-- **Path-Based Routing**: Each agent has a unique URL path endpoint
-- **Dynamic Agent Discovery**: URL path parameter `{agentName}` determines which agent handles the request
-- **Shared Resources**: All agents share the same server process, memory, and resources
-- **Unified Protocol**: All agents follow the same A2A protocol interface
+- **One endpoint, many agents**: routing is by the `tenant` field, not the URL.
+- **Static or dynamic registry**: register known agents with
+  `server.WithTenantCard(tenant, card)`; for tenants not known at startup use
+  `server.WithTenantCardProvider(func(ctx, tenant) (AgentCard, error))`.
+- **Processor dispatch**: the processor switches on `options.Tenant`.
+- **No router/middleware/placeholder card** needed.
 
 ## Available Agents
 
-### Chat Agent (`chatAgent`)
-- **Function**: Provides chat conversation capabilities
-- **Description**: "I am a chatbot"
-- **Endpoints**: 
-  - Agent Card: `GET /api/v1/agent/chatAgent/.well-known/agent-card.json`
-  - JSON-RPC: `POST /api/v1/agent/chatAgent/`
-
-### Worker Agent (`workerAgent`)
-- **Function**: Provides worker task processing
-- **Description**: "I am a worker"
-- **Endpoints**:
-  - Agent Card: `GET /api/v1/agent/workerAgent/.well-known/agent-card.json`
-  - JSON-RPC: `POST /api/v1/agent/workerAgent/`
+| Tenant        | Card name   | Reply                      |
+|---------------|-------------|----------------------------|
+| `chatAgent`   | ChatAgent   | `Hello from chat agent!`   |
+| `workerAgent` | WorkerAgent | `Hello from worker agent!` |
 
 ## Running the Example
 
 ### 1. Start the Server
 ```bash
-cd examples/multiagent/server
+cd examples/multi_endpoint/server
 go run main.go
 ```
 
-The server will start on `localhost:8080` and display available endpoints:
+The server starts on `localhost:8080`:
 ```
-Starting A2A server listening on localhost:8080
-Chat agent card url : http://localhost:8080/api/v1/agent/chatAgent/.well-known/agent-card.json:
-Chat agent interfaces: http://localhost:8080/api/v1/agent/chatAgent/
-Worker agent card url: http://localhost:8080/api/v1/agent/workerAgent/.well-known/agent-card.json
-Worker agent interfaces: http://localhost:8080/api/v1/agent/workerAgent/
+Starting A2A server on localhost:8080
+  Per-tenant card: http://localhost:8080/.well-known/agent-card.json?tenant=chatAgent|workerAgent
+  JSON-RPC: http://localhost:8080/  (set the "tenant" field in the request to pick an agent)
 ```
 
 ### 2. Run the Test Client
-In another terminal:
 ```bash
-cd examples/multiagent/client
-go run main.go
-```
-
-Or with custom message:
-```bash
-go run main.go -message="How are you today?"
+cd examples/multi_endpoint/client
+go run main.go            # or: go run main.go -message="How are you today?"
 ```
 
 ### 3. Manual Testing
 
-#### Get Agent Cards
 ```bash
-# Chat Agent
-curl http://localhost:8080/api/v1/agent/chatAgent/.well-known/agent-card.json
+# Per-tenant agent card
+curl "http://localhost:8080/.well-known/agent-card.json?tenant=chatAgent"
+curl "http://localhost:8080/.well-known/agent-card.json?tenant=workerAgent"
 
-# Worker Agent
-curl http://localhost:8080/api/v1/agent/workerAgent/.well-known/agent-card.json
-```
-
-#### Send Messages to Agents
-```bash
-# Send message to Chat Agent
-curl -X POST http://localhost:8080/api/v1/agent/chatAgent/ \
+# Send a message — "tenant" in params selects the agent
+curl -X POST http://localhost:8080/ \
   -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","method":"message/send","params":{"message":{"role":"user","kind":"message","messageId":"test-123","parts":[{"kind":"text","text":"Hello!"}]}},"id":1}'
-
-# Send message to Worker Agent
-curl -X POST http://localhost:8080/api/v1/agent/workerAgent/ \
-  -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","method":"message/send","params":{"message":{"role":"user","kind":"message","messageId":"test-456","parts":[{"kind":"text","text":"What can you do?"}]}},"id":1}'
+  -d '{"jsonrpc":"2.0","method":"SendMessage","id":1,"params":{
+        "tenant":"chatAgent",
+        "message":{"role":"ROLE_USER","messageId":"test-123",
+                   "content":[{"text":"Hello!"}]}}}'
 ```
 
 ## Core Implementation
 
-### 1. HTTPRouter Interface
+### 1. Register a card per tenant
 ```go
-type HTTPRouter interface {
-    Handle(pattern string, handler http.Handler)
-    ServeHTTP(w http.ResponseWriter, r *http.Request)
-}
+a2aServer, _ := server.NewA2AServer(taskManager,
+    server.WithTenantCard("chatAgent", chatCard),
+    server.WithTenantCard("workerAgent", workerCard),
+)
 ```
+The agent card is no longer a required positional argument: a multi-tenant server
+needs no default card. Add an optional default ("directory") card served when no
+`?tenant=` is given with `server.WithAgentCard(card)`.
 
-### 2. Using Chi Router with Path Parameters
+For a dynamic set of agents instead of (or alongside) the static registry:
 ```go
-// Create Chi router
-router := chi.NewMux()
-
-// Register routes with path parameters using Chi's Route method
-router.Route("/api/v1/agent/{agentName}", func(r chi.Router) {
-    // Create A2A server for this route group
-    a2aServer, err := server.NewA2AServer(
-        agentCard,
-        taskManager,
-        server.WithMiddleWare(&middleWare{}),
-        server.WithHTTPRouter(r),
-        server.WithAgentCardHandler(&multiAgentCardHandler{}),
-    )
-    if err != nil {
-        log.Fatalf("Failed to create A2A server: %v", err)
-    }
-    
-    // Mount the A2A server handler to the subrouter
-    r.Mount("/", a2aServer.Handler())
+server.WithTenantCardProvider(func(ctx context.Context, tenant string) (server.AgentCard, error) {
+    return loadCardFromDB(ctx, tenant) // return an error for an unknown tenant
 })
 ```
 
-### 3. Middleware for Agent Name Extraction
+### 2. Dispatch on the tenant in the processor
 ```go
-type middleWare struct{}
-
-func (m *middleWare) Wrap(next http.Handler) http.Handler {
-    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-        ctx := r.Context()
-        ctx = context.WithValue(ctx, ctxAgentNameKey, chi.URLParam(r, "agentName"))
-        next.ServeHTTP(w, r.WithContext(ctx))
-    })
-}
-```
-
-### 4. Dynamic Agent Card Handler
-```go
-type multiAgentCardHandler struct{}
-
-func (h *multiAgentCardHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-    agentName := chi.URLParam(r, "agentName")
-    var agentCard server.AgentCard
-    
-    switch agentName {
+func (p *multiAgentProcessor) ProcessMessage(
+    _ context.Context, _ protocol.Message,
+    options taskmanager.ProcessOptions, _ taskmanager.TaskHandler,
+) (*taskmanager.MessageProcessingResult, error) {
+    switch options.Tenant {
     case "chatAgent":
-        agentCard = server.AgentCard{
-            Name:        "ChatAgent",
-            Description: "I am a chatbot",
-            // ... other fields
-        }
+        return reply("Hello from chat agent!"), nil
     case "workerAgent":
-        agentCard = server.AgentCard{
-            Name:        "WorkerAgent",
-            Description: "I am a worker",
-            // ... other fields
-        }
+        return reply("Hello from worker agent!"), nil
     default:
-        w.WriteHeader(http.StatusNotFound)
-        return
+        return nil, fmt.Errorf("no such tenant %q", options.Tenant)
     }
-    
-    w.Header().Set("Content-Type", "application/json; charset=utf-8")
-    json.NewEncoder(w).Encode(agentCard)
 }
 ```
 
-## Extension Example
-
-You can easily add more agents by extending the switch cases in the handlers:
-
+### 3. Client sends the tenant
 ```go
-// Add a new agent in multiAgentCardHandler
-case "calculatorAgent":
-    agentCard = server.AgentCard{
-        Name:        "CalculatorAgent",
-        Description: "I can perform mathematical calculations",
-        URL:         fmt.Sprintf("http://%s/api/v1/agent/calculatorAgent/", *host),
-        Skills: []server.AgentSkill{
-            {
-                Name:        "calculate",
-                Description: stringPtr("Perform mathematical operations"),
-                InputModes:  []string{"text"},
-                OutputModes: []string{"text"},
-                Tags:        []string{"math", "calculator"},
-                Examples:    []string{"2 + 2", "10 * 5"},
-            },
-        },
-        // ... other fields
-    }
-
-// Add corresponding case in multiAgentProcessor
-case "calculatorAgent":
-    return u.calculatorAgentProcessMessage(ctx, message, options, taskHandler)
+params := protocol.SendMessageParams{
+    Tenant:  "chatAgent", // route to the agent registered under this tenant
+    Message: userMessage,
+}
+resp, _ := a2aClient.SendMessage(ctx, params)
 ```
 
-## Client Usage
+## Adding an Agent
 
-The client automatically tests both agents and displays their responses:
+1. `server.WithTenantCard("calculatorAgent", calcCard)` (or return it from the provider).
+2. Add a `case "calculatorAgent":` to the processor.
 
-```bash
+That's it — no new route, middleware, or card handler.
+
+## Expected Client Output
+
+```
 === Multi-Agent tRPC Client Demo ===
-Server: http://localhost:8080
-Testing both agents...
+Server: http://localhost:8080/ (agents addressed by tenant)
 
 --- Conversation with chatAgent ---
 Agent: ChatAgent - I am a chatbot
-User: Hello, how are you?
+User: Hello!
 Response: Hello from chat agent!
 
 --- Conversation with workerAgent ---
 Agent: WorkerAgent - I am a worker
-User: Hello, how are you?
+User: Hello!
 Response: Hello from worker agent!
 
 === Demo completed ===

--- a/examples/multi_endpoint/client/main.go
+++ b/examples/multi_endpoint/client/main.go
@@ -1,4 +1,7 @@
-// Package main implements a simple A2A client example.
+// Package main implements a multi-agent A2A client using the v1.0 tenant model.
+//
+// All agents share one endpoint; the client picks an agent by setting the
+// "tenant" field on each request (and on the agent-card lookup via "?tenant=").
 package main
 
 import (
@@ -8,6 +11,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"time"
 
 	"trpc.group/trpc-go/trpc-a2a-go/v2/client"
@@ -23,37 +27,29 @@ var (
 func main() {
 	flag.Parse()
 
+	baseURL := fmt.Sprintf("http://%s/", *host)
 	fmt.Printf("=== Multi-Agent tRPC Client Demo ===\n")
-	fmt.Printf("Server: http://%s\n", *host)
-	fmt.Printf("Testing both agents...\n\n")
+	fmt.Printf("Server: %s (agents addressed by tenant)\n\n", baseURL)
 
-	// Test both agents
-	agents := []string{"chatAgent", "workerAgent"}
-	for _, agentName := range agents {
-		fmt.Printf("--- Conversation with %s ---\n", agentName)
+	// One client for the shared endpoint; the tenant on each request selects the agent.
+	a2aClient, err := client.NewA2AClient(baseURL, client.WithTimeout(30*time.Second))
+	if err != nil {
+		log.Fatalf("Failed to create A2A client: %v", err)
+	}
 
-		// Create agent URL
-		agentURL := fmt.Sprintf("http://%s/api/v1/agent/%s/", *host, agentName)
+	for _, tenant := range []string{"chatAgent", "workerAgent"} {
+		fmt.Printf("--- Conversation with %s ---\n", tenant)
 
-		// Get agent card first
-		agentCard, err := getAgentCard(agentURL)
+		agentCard, err := getAgentCard(baseURL, tenant)
 		if err != nil {
-			log.Printf("Failed to get agent card for %s: %v", agentName, err)
+			log.Printf("Failed to get agent card for %s: %v", tenant, err)
 			continue
 		}
 		fmt.Printf("Agent: %s - %s\n", agentCard.Name, agentCard.Description)
 
-		// Create A2A client for this agent
-		a2aClient, err := client.NewA2AClient(agentURL, client.WithTimeout(30*time.Second))
+		response, err := sendMessageToTenant(context.Background(), a2aClient, tenant, *message)
 		if err != nil {
-			log.Printf("Failed to create A2A client for %s: %v", agentName, err)
-			continue
-		}
-
-		// Send message using A2A client
-		response, err := sendMessageToAgent(context.Background(), a2aClient, *message)
-		if err != nil {
-			log.Printf("Failed to send message to %s: %v", agentName, err)
+			log.Printf("Failed to send message to %s: %v", tenant, err)
 			continue
 		}
 		fmt.Printf("Response: %s\n\n", response)
@@ -62,12 +58,12 @@ func main() {
 	fmt.Println("=== Demo completed ===")
 }
 
-// getAgentCard retrieves the agent card for the specified agent
-func getAgentCard(agentURL string) (*server.AgentCard, error) {
-	cardURL := fmt.Sprintf("%s.well-known/agent-card.json", agentURL)
+// getAgentCard retrieves a tenant's agent card from the shared endpoint via "?tenant=".
+func getAgentCard(baseURL, tenant string) (*server.AgentCard, error) {
+	cardURL := fmt.Sprintf("%s.well-known/agent-card.json?tenant=%s", baseURL, url.QueryEscape(tenant))
 
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Get(cardURL)
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+	resp, err := httpClient.Get(cardURL)
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
@@ -85,18 +81,17 @@ func getAgentCard(agentURL string) (*server.AgentCard, error) {
 	return &agentCard, nil
 }
 
-// sendMessageToAgent sends a message to the specified agent using A2A client
-func sendMessageToAgent(ctx context.Context, a2aClient *client.A2AClient, messageText string) (string, error) {
-
+// sendMessageToTenant sends a message addressed to a specific tenant (agent).
+func sendMessageToTenant(ctx context.Context, a2aClient *client.A2AClient, tenant, messageText string) (string, error) {
 	fmt.Printf("User: %s\n", messageText)
-	// Create the message to send
+
 	userMessage := protocol.NewMessage(
 		protocol.MessageRoleUser,
 		[]*protocol.Part{protocol.NewTextPart(messageText)},
 	)
 
-	// Create message parameters
 	params := protocol.SendMessageParams{
+		Tenant:  tenant, // v1.0: route to the agent registered under this tenant.
 		Message: userMessage,
 		Configuration: &protocol.SendMessageConfiguration{
 			ReturnImmediately:   boolPtr(false), // v1.0: false = wait for completion (was Blocking: true)
@@ -104,13 +99,12 @@ func sendMessageToAgent(ctx context.Context, a2aClient *client.A2AClient, messag
 		},
 	}
 
-	// Send message using A2A client
 	messageResult, err := a2aClient.SendMessage(ctx, params)
 	if err != nil {
 		return "", fmt.Errorf("failed to send message: %w", err)
 	}
 
-	// Extract text from the response (v1.0: SendMessageResponse is a Message/Task union)
+	// v1.0: SendMessageResponse is a Message/Task union.
 	switch {
 	case messageResult.Message != nil:
 		return extractTextFromMessage(messageResult.Message), nil
@@ -125,22 +119,20 @@ func sendMessageToAgent(ctx context.Context, a2aClient *client.A2AClient, messag
 	}
 }
 
-// extractTextFromMessage extracts text content from a message
+// extractTextFromMessage extracts text content from a message.
 func extractTextFromMessage(msg *protocol.Message) string {
 	if msg == nil {
 		return ""
 	}
-
 	for _, part := range msg.Parts {
 		if t := part.TextContent(); t != "" {
 			return t
 		}
 	}
-
 	return "(no text content)"
 }
 
-// boolPtr returns a pointer to a boolean value
+// boolPtr returns a pointer to a boolean value.
 func boolPtr(b bool) *bool {
 	return &b
 }

--- a/examples/multi_endpoint/client/main.go
+++ b/examples/multi_endpoint/client/main.go
@@ -104,12 +104,12 @@ func sendMessageToTenant(ctx context.Context, a2aClient *client.A2AClient, tenan
 		return "", fmt.Errorf("failed to send message: %w", err)
 	}
 
-	// v1.0: SendMessageResponse is a Message/Task union.
+	// v1.0: MessageResult is a Message/Task union.
 	switch {
-	case messageResult.Message != nil:
-		return extractTextFromMessage(messageResult.Message), nil
-	case messageResult.Task != nil:
-		task := messageResult.Task
+	case messageResult.GetMessage() != nil:
+		return extractTextFromMessage(messageResult.GetMessage()), nil
+	case messageResult.GetTask() != nil:
+		task := messageResult.GetTask()
 		if task.Status.Message != nil {
 			return extractTextFromMessage(task.Status.Message), nil
 		}

--- a/examples/multi_endpoint/server/main.go
+++ b/examples/multi_endpoint/server/main.go
@@ -1,202 +1,107 @@
-// Package main is the entry point for the A2A server.
+// Package main is the entry point for a multi-agent A2A server.
+//
+// It hosts several agents in ONE process using the A2A v1.0 tenant model: all
+// agents share a single endpoint, and the request's "tenant" field (carried in
+// the JSON body) selects which agent handles it. The agent-card endpoint serves
+// the right card for "?tenant=<tenant>". This replaces the older approach of
+// distinguishing agents by URL path (which needed a placeholder card, a custom
+// AgentCardHandler, a {agentName} path template and a chi router).
 package main
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"flag"
 	"fmt"
 	"log"
-	"net/http"
 
-	"github.com/go-chi/chi/v5"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/server"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager/memory"
 )
-
-const ctxAgentNameKey = "agentName"
 
 var host = flag.String("host", "localhost:8080", "host")
 
 func main() {
 	flag.Parse()
-	// Create chi router
-	router := chi.NewMux()
 
-	processor := &multiAgentProecssor{}
-
-	taskManager, err := taskmanager.NewMemoryTaskManager(processor)
+	taskManager, err := memory.NewTaskManager(&multiAgentProcessor{})
 	if err != nil {
 		log.Fatalf("Failed to create task manager: %v", err)
 	}
 
-	agentCard := server.AgentCard{
-		Name:        "MultiAgent",
-		Description: "This agent card will not be used while AgentCardHandler is provided",
-	}
+	baseURL := fmt.Sprintf("http://%s/", *host)
 
-	a2aServer, err := server.NewA2AServer(
-		agentCard,
-		taskManager,
-		server.WithMiddleWare(&middleWare{}),
-		server.WithHTTPRouter(router),
-		server.WithAgentCardHandler(&multiAgentCardHandler{}),
-		server.WithBasePath("/api/v1/agent/{agentName}/"),
+	// No default ("directory") card is needed: each agent's real card is
+	// registered per tenant with WithTenantCard, and the server is addressed by
+	// the v1.0 tenant field. For a set of agents not known at startup, use
+	// server.WithTenantCardProvider instead. (WithAgentCard would add an optional
+	// default card served when no "?tenant=" is given.)
+	a2aServer, err := server.NewA2AServer(taskManager,
+		server.WithTenantCard("chatAgent", agentCardFor("ChatAgent", "I am a chatbot", "chat", baseURL)),
+		server.WithTenantCard("workerAgent", agentCardFor("WorkerAgent", "I am a worker", "worker", baseURL)),
 	)
 	if err != nil {
 		log.Fatalf("Failed to create A2A server: %v", err)
 	}
 
-	fmt.Println("Starting A2A server listening on", *host)
-	fmt.Println("Chat agent card url :", fmt.Sprintf("http://%s/api/v1/agent/chatAgent/.well-known/agent-card.json:", *host))
-	fmt.Println("Chat agent interfaces:", fmt.Sprintf("http://%s/api/v1/agent/chatAgent/", *host))
-	fmt.Println("Worker agent card url:", fmt.Sprintf("http://%s/api/v1/agent/workerAgent/.well-known/agent-card.json", *host))
-	fmt.Println("Worker agent interfaces:", fmt.Sprintf("http://%s/api/v1/agent/workerAgent/", *host))
+	fmt.Println("Starting A2A server on", *host)
+	fmt.Printf("  Per-tenant card: http://%s/.well-known/agent-card.json?tenant=chatAgent|workerAgent\n", *host)
+	fmt.Printf("  JSON-RPC: http://%s/  (set the \"tenant\" field in the request to pick an agent)\n", *host)
 
 	if err := a2aServer.Start(*host); err != nil {
 		log.Fatalf("Failed to start server: %v", err)
 	}
-
 }
 
-type middleWare struct{}
-
-func (m *middleWare) Wrap(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
-		ctx = context.WithValue(ctx, ctxAgentNameKey, chi.URLParam(r, "agentName"))
-		next.ServeHTTP(w, r.WithContext(ctx))
-	})
-}
-
-type multiAgentCardHandler struct{}
-
-func (h *multiAgentCardHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// Get agent name from url param, because middleware not task effect on agent card handler
-	agentName := chi.URLParam(r, "agentName")
-	var agentCard server.AgentCard
-	switch agentName {
-	case "chatAgent":
-		agentCard = server.AgentCard{
-			Name:        "ChatAgent",
-			Description: "I am a chatbot",
-			URL:         fmt.Sprintf("http://%s/api/v1/agent/chatAgent/", *host),
-			Skills: []server.AgentSkill{
-				{
-					Name:        "chat",
-					Description: stringPtr("I am a chatbot"),
-					InputModes:  []string{"text"},
-					OutputModes: []string{"text"},
-					Tags:        []string{"chat"},
-					Examples:    []string{"Hello"},
-				},
-			},
-			Capabilities: server.AgentCapabilities{
-				Streaming: boolPtr(false),
-			},
-			DefaultInputModes:  []string{"text"},
-			DefaultOutputModes: []string{"text"},
-		}
-	case "workerAgent":
-		agentCard = server.AgentCard{
-			Name:        "WorkerAgent",
-			Description: "I am a worker",
-			URL:         fmt.Sprintf("http://%s/api/v1/agent/workerAgent/", *host),
-			Skills: []server.AgentSkill{
-				{
-					Name:        "worker",
-					Description: stringPtr("I am a worker"),
-					InputModes:  []string{"text"},
-					OutputModes: []string{"text"},
-					Tags:        []string{"worker"},
-					Examples:    []string{"Hello"},
-				},
-			},
-			Capabilities: server.AgentCapabilities{
-				Streaming: boolPtr(false),
-			},
-			DefaultInputModes:  []string{"text"},
-			DefaultOutputModes: []string{"text"},
-		}
-	default:
-		w.WriteHeader(http.StatusNotFound)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	if err := json.NewEncoder(w).Encode(agentCard); err != nil {
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+// agentCardFor builds a simple single-skill card sharing the common endpoint.
+func agentCardFor(name, desc, skill, url string) server.AgentCard {
+	return server.AgentCard{
+		Name:        name,
+		Description: desc,
+		URL:         url,
+		Skills: []server.AgentSkill{{
+			Name:        skill,
+			Description: stringPtr(desc),
+			InputModes:  []string{"text"},
+			OutputModes: []string{"text"},
+			Tags:        []string{skill},
+			Examples:    []string{"Hello"},
+		}},
+		Capabilities:       server.AgentCapabilities{Streaming: boolPtr(false)},
+		DefaultInputModes:  []string{"text"},
+		DefaultOutputModes: []string{"text"},
 	}
 }
 
-type multiAgentProecssor struct {
-}
+// multiAgentProcessor dispatches on the v1.0 tenant carried in the request body
+// (taskmanager.ProcessOptions.Tenant) — no ctx-key, no URL parsing.
+type multiAgentProcessor struct{}
 
-func (u *multiAgentProecssor) ProcessMessage(
-	ctx context.Context,
-	message protocol.Message,
+func (p *multiAgentProcessor) ProcessMessage(
+	_ context.Context,
+	_ protocol.Message,
 	options taskmanager.ProcessOptions,
-	taskHandler taskmanager.TaskHandler,
+	_ taskmanager.TaskHandler,
 ) (*taskmanager.MessageProcessingResult, error) {
-	agentName := ctx.Value(ctxAgentNameKey)
-	if agentName == nil {
-		return nil, errors.New("agent name not found")
-	}
-
-	switch agentName.(string) {
+	switch options.Tenant {
 	case "chatAgent":
-		return u.chatAgentProcessMessage(ctx, message, options, taskHandler)
+		return reply("Hello from chat agent!"), nil
 	case "workerAgent":
-		return u.workerAgentProcessMessage(ctx, message, options, taskHandler)
+		return reply("Hello from worker agent!"), nil
 	default:
-		return nil, errors.New("unknown agent name")
+		return nil, fmt.Errorf("no such tenant %q (use chatAgent or workerAgent)", options.Tenant)
 	}
 }
 
-func (u *multiAgentProecssor) chatAgentProcessMessage(
-	ctx context.Context,
-	message protocol.Message,
-	options taskmanager.ProcessOptions,
-	taskHandler taskmanager.TaskHandler,
-) (*taskmanager.MessageProcessingResult, error) {
+func reply(text string) *taskmanager.MessageProcessingResult {
 	msg := &protocol.Message{
 		Role:      protocol.MessageRoleAgent,
 		MessageID: protocol.GenerateMessageID(),
-		Parts: []*protocol.Part{
-			protocol.NewTextPart("Hello from chat agent!"),
-		},
+		Parts:     []*protocol.Part{protocol.NewTextPart(text)},
 	}
-
-	return &taskmanager.MessageProcessingResult{
-		Result: protocol.NewSendMessageResponseMessage(msg),
-	}, nil
+	return &taskmanager.MessageProcessingResult{Result: protocol.NewSendMessageResponseMessage(msg)}
 }
 
-func (u *multiAgentProecssor) workerAgentProcessMessage(
-	ctx context.Context,
-	message protocol.Message,
-	options taskmanager.ProcessOptions,
-	taskHandler taskmanager.TaskHandler,
-) (*taskmanager.MessageProcessingResult, error) {
-	msg := &protocol.Message{
-		Role:      protocol.MessageRoleAgent,
-		MessageID: protocol.GenerateMessageID(),
-		Parts: []*protocol.Part{
-			protocol.NewTextPart("Hello from worker agent!"),
-		},
-	}
-
-	return &taskmanager.MessageProcessingResult{
-		Result: protocol.NewSendMessageResponseMessage(msg),
-	}, nil
-}
-
-func stringPtr(s string) *string {
-	return &s
-}
-
-func boolPtr(b bool) *bool {
-	return &b
-}
+func stringPtr(s string) *string { return &s }
+func boolPtr(b bool) *bool       { return &b }

--- a/examples/redis/client/main.go
+++ b/examples/redis/client/main.go
@@ -163,7 +163,7 @@ func runNonStreamingDemo(ctx context.Context, client *client.A2AClient, inputTex
 
 	fmt.Printf("%s Processing time: %v\n", prefixSuccess, duration)
 
-	if response := result.Message; response != nil {
+	if response := result.GetMessage(); response != nil {
 		for i, part := range response.Parts {
 			if t := part.TextContent(); t != "" {
 				fmt.Printf("%s %d: '%s'\n", prefixResult, i+1, t)
@@ -271,10 +271,10 @@ func (p *streamEventProcessor) handleStreamEvent(event protocol.StreamResponse) 
 		fmt.Printf("\r")
 	}
 
-	if event.StatusUpdate != nil {
-		p.handleTaskStatusEvent(event.StatusUpdate)
-	} else if event.ArtifactUpdate != nil {
-		p.handleTaskArtifactEvent(event.ArtifactUpdate)
+	if event.GetStatusUpdate() != nil {
+		p.handleTaskStatusEvent(event.GetStatusUpdate())
+	} else if event.GetArtifactUpdate() != nil {
+		p.handleTaskArtifactEvent(event.GetArtifactUpdate())
 	} else {
 		fmt.Printf("%s Unknown event\n", prefixUnknown)
 	}

--- a/examples/redis/server/main.go
+++ b/examples/redis/server/main.go
@@ -353,7 +353,7 @@ func main() {
 	}
 
 	// Create HTTP server
-	agentServer, err := server.NewA2AServer(agentCard, taskManager)
+	agentServer, err := server.NewA2AServer(taskManager, server.WithAgentCard(agentCard))
 	if err != nil {
 		log.Fatalf("Failed to create A2A server: %v", err)
 	}

--- a/examples/simple/client/main.go
+++ b/examples/simple/client/main.go
@@ -119,10 +119,10 @@ func handleStandardMode(ctx context.Context, a2aClient *client.A2AClient, params
 	// Display the result.
 	log.Infof("Message sent successfully")
 
-	if msg := messageResult.Message; msg != nil {
+	if msg := messageResult.GetMessage(); msg != nil {
 		log.Infof("Received message response:")
 		printMessage(*msg)
-	} else if task := messageResult.Task; task != nil {
+	} else if task := messageResult.GetTask(); task != nil {
 		log.Infof("Received task response - ID: %s, State: %s", task.ID, task.Status.State)
 
 		if task.Status.State != protocol.TaskStateCompleted &&
@@ -154,20 +154,20 @@ func handleStandardMode(ctx context.Context, a2aClient *client.A2AClient, params
 
 // getEventDescription returns a human-readable description of the streaming event
 func getEventDescription(event protocol.StreamResponse) string {
-	if msg := event.Message; msg != nil {
+	if msg := event.GetMessage(); msg != nil {
 		ctxID := "unknown"
 		if msg.ContextID != nil {
 			ctxID = *msg.ContextID
 		}
 		return fmt.Sprintf("Message from %s, ContextID: %v", msg.Role, ctxID)
 	}
-	if task := event.Task; task != nil {
+	if task := event.GetTask(); task != nil {
 		return fmt.Sprintf("Task %s - State: %s, ContextID: %v", task.ID, task.Status.State, task.ContextID)
 	}
-	if su := event.StatusUpdate; su != nil {
+	if su := event.GetStatusUpdate(); su != nil {
 		return fmt.Sprintf("Status Update - Task: %s, State: %s, ContextID: %v", su.TaskID, su.Status.State, su.ContextID)
 	}
-	if au := event.ArtifactUpdate; au != nil {
+	if au := event.GetArtifactUpdate(); au != nil {
 		artifactName := "Unnamed"
 		if au.Artifact.Name != nil {
 			artifactName = *au.Artifact.Name
@@ -179,14 +179,14 @@ func getEventDescription(event protocol.StreamResponse) string {
 
 // extractFinalResult extracts the final text result from streaming events
 func extractFinalResult(event protocol.StreamResponse) string {
-	if msg := event.Message; msg != nil {
+	if msg := event.GetMessage(); msg != nil {
 		for _, part := range msg.Parts {
 			if t := part.TextContent(); t != "" {
 				return t
 			}
 		}
 	}
-	if task := event.Task; task != nil {
+	if task := event.GetTask(); task != nil {
 		if task.Status.Message != nil {
 			for _, part := range task.Status.Message.Parts {
 				if t := part.TextContent(); t != "" {
@@ -195,7 +195,7 @@ func extractFinalResult(event protocol.StreamResponse) string {
 			}
 		}
 	}
-	if au := event.ArtifactUpdate; au != nil {
+	if au := event.GetArtifactUpdate(); au != nil {
 		for _, part := range au.Artifact.Parts {
 			if t := part.TextContent(); t != "" {
 				return t

--- a/examples/simple/server/main.go
+++ b/examples/simple/server/main.go
@@ -22,6 +22,7 @@ import (
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/server"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager/memory"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager/redis"
 )
 
@@ -216,7 +217,7 @@ func main() {
 	switch *manager {
 	case "memory":
 		log.Infof("Using memory task manager")
-		taskManager, err = taskmanager.NewMemoryTaskManager(processor)
+		taskManager, err = memory.NewTaskManager(processor)
 	case "redis":
 		log.Infof("Using redis task manager")
 		cli := goredis.NewClient(&goredis.Options{
@@ -232,7 +233,7 @@ func main() {
 	}
 
 	// Create the server.
-	srv, err := server.NewA2AServer(agentCard, taskManager)
+	srv, err := server.NewA2AServer(taskManager, server.WithAgentCard(agentCard))
 	if err != nil {
 		log.Fatalf("Failed to create server: %v", err)
 	}

--- a/examples/streaming/client/main.go
+++ b/examples/streaming/client/main.go
@@ -75,10 +75,10 @@ func main() {
 			log.Fatalf("Error sending task: %v.", err)
 		}
 
-		if msg := result.Message; msg != nil {
+		if msg := result.GetMessage(); msg != nil {
 			text := extractTextFromMessage(msg)
 			log.Infof("Final message: Role=%s, Text=%s", msg.Role, text)
-		} else if task := result.Task; task != nil {
+		} else if task := result.GetTask(); task != nil {
 			log.Infof("Final task: ID=%s, State=%s", task.ID, task.Status.State)
 		} else {
 			log.Infof("Unexpected empty result")
@@ -153,11 +153,11 @@ func processStreamEvents(ctx context.Context, streamChan <-chan protocol.StreamR
 				return
 			}
 
-			if msg := event.Message; msg != nil {
+			if msg := event.GetMessage(); msg != nil {
 				text := extractTextFromMessage(msg)
 				log.Infof("Received Message - MessageID: %s", msg.MessageID)
 				log.Infof("  Message Text: %s", text)
-			} else if au := event.ArtifactUpdate; au != nil {
+			} else if au := event.GetArtifactUpdate(); au != nil {
 				log.Infof("Received Artifact Update - TaskID: %s, ArtifactID: %s", au.TaskID, au.Artifact.ArtifactID)
 				for _, part := range au.Artifact.Parts {
 					if t := part.TextContent(); t != "" {
@@ -167,9 +167,9 @@ func processStreamEvents(ctx context.Context, streamChan <-chan protocol.StreamR
 				if au.LastChunk != nil && *au.LastChunk {
 					log.Info("Received final artifact update, waiting for final status.")
 				}
-			} else if task := event.Task; task != nil {
+			} else if task := event.GetTask(); task != nil {
 				log.Infof("Received Task - TaskID: %s, State: %s", task.ID, task.Status.State)
-			} else if su := event.StatusUpdate; su != nil {
+			} else if su := event.GetStatusUpdate(); su != nil {
 				log.Infof("Received Task Status Update - TaskID: %s, State: %s", su.TaskID, su.Status.State)
 			} else {
 				log.Infof("Received unknown event: %+v", event)

--- a/examples/streaming/server/main.go
+++ b/examples/streaming/server/main.go
@@ -26,6 +26,7 @@ import (
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/server"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager/memory"
 )
 
 // streamingMessageProcessor implements the MessageProcessor interface for streaming responses.
@@ -369,13 +370,13 @@ func main() {
 	processor := &streamingMessageProcessor{}
 
 	// Create the TaskManager, injecting the processor
-	taskManager, err := taskmanager.NewMemoryTaskManager(processor)
+	taskManager, err := memory.NewTaskManager(processor)
 	if err != nil {
 		log.Fatalf("Failed to create task manager: %v", err)
 	}
 
 	// Create the A2A server instance
-	srv, err := server.NewA2AServer(agentCard, taskManager)
+	srv, err := server.NewA2AServer(taskManager, server.WithAgentCard(agentCard))
 	if err != nil {
 		log.Fatalf("Failed to create A2A server: %v", err)
 	}

--- a/examples/subpath/README.md
+++ b/examples/subpath/README.md
@@ -56,7 +56,7 @@ func main() {
     taskManager, _ := taskmanager.NewMemoryTaskManager(&simpleProcessor{})
 
     // 3. Create server (path automatically configured)
-    a2aServer, _ := server.NewA2AServer(agentCard, taskManager)
+    a2aServer, _ := server.NewA2AServer(taskManager, server.WithAgentCard(agentCard))
 
     // 4. Start server
     a2aServer.Start(":8080")
@@ -80,8 +80,8 @@ agentCard := server.AgentCard{
 }
 
 a2aServer, _ := server.NewA2AServer(
-    agentCard, 
     taskManager,
+    server.WithAgentCard(agentCard),
     server.WithBasePath("/internal/api"), // ← Internal routing path
 )
 ```

--- a/examples/subpath/main.go
+++ b/examples/subpath/main.go
@@ -18,6 +18,7 @@ import (
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/server"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager/memory"
 )
 
 // simpleProcessor implements the MessageProcessor interface.
@@ -53,12 +54,12 @@ func main() {
 	}
 
 	// Create task manager with simple processor
-	taskManager, err := taskmanager.NewMemoryTaskManager(&simpleProcessor{})
+	taskManager, err := memory.NewTaskManager(&simpleProcessor{})
 	if err != nil {
 		log.Fatalf("Failed to create task manager: %v", err)
 	}
 
-	a2aServer, err := server.NewA2AServer(agentCard, taskManager)
+	a2aServer, err := server.NewA2AServer(taskManager, server.WithAgentCard(agentCard))
 	if err != nil {
 		log.Fatalf("Failed to create server: %v", err)
 	}

--- a/protocol/security.go
+++ b/protocol/security.go
@@ -28,6 +28,9 @@ type SecurityScheme struct {
 	BearerFormat     *string            `json:"bearerFormat,omitempty"`
 	Flows            *OAuthFlows        `json:"flows,omitempty"`
 	OpenIDConnectURL *string            `json:"openIdConnectUrl,omitempty"`
+	// OAuth2MetadataURL is the v1.0 OAuth2 authorization-server metadata URL
+	// (RFC 8414). It applies to the OAuth2 scheme.
+	OAuth2MetadataURL *string `json:"oauth2MetadataUrl,omitempty"`
 }
 
 // SecuritySchemeType represents the type of security scheme.
@@ -94,8 +97,9 @@ type httpAuthWire struct {
 }
 
 type oauth2Wire struct {
-	Description *string     `json:"description,omitempty"`
-	Flows       *OAuthFlows `json:"flows,omitempty"`
+	Description       *string     `json:"description,omitempty"`
+	Flows             *OAuthFlows `json:"flows,omitempty"`
+	OAuth2MetadataURL *string     `json:"oauth2MetadataUrl,omitempty"`
 }
 
 type openIDConnectWire struct {
@@ -150,7 +154,7 @@ func (s SecurityScheme) MarshalJSON() ([]byte, error) {
 	case SecuritySchemeTypeHTTP:
 		w.HTTPAuth = &httpAuthWire{Description: s.Description, Scheme: s.Scheme, BearerFormat: s.BearerFormat}
 	case SecuritySchemeTypeOAuth2:
-		w.OAuth2 = &oauth2Wire{Description: s.Description, Flows: s.Flows}
+		w.OAuth2 = &oauth2Wire{Description: s.Description, Flows: s.Flows, OAuth2MetadataURL: s.OAuth2MetadataURL}
 	case SecuritySchemeTypeOpenIDConnect:
 		w.OpenIDConnect = &openIDConnectWire{Description: s.Description, OpenIDConnectURL: s.OpenIDConnectURL}
 	case SecuritySchemeTypeMutualTLS:
@@ -183,6 +187,7 @@ func (s *SecurityScheme) UnmarshalJSON(data []byte) error {
 		s.Type = SecuritySchemeTypeOAuth2
 		s.Description = w.OAuth2.Description
 		s.Flows = w.OAuth2.Flows
+		s.OAuth2MetadataURL = w.OAuth2.OAuth2MetadataURL
 	case w.OpenIDConnect != nil:
 		s.Type = SecuritySchemeTypeOpenIDConnect
 		s.Description = w.OpenIDConnect.Description

--- a/protocol/types.go
+++ b/protocol/types.go
@@ -120,6 +120,8 @@ type Task struct {
 	Artifacts []Artifact     `json:"artifacts,omitempty"`
 	History   []Message      `json:"history,omitempty"`
 	Metadata  map[string]any `json:"metadata,omitempty"`
+	// Extensions are the URIs of A2A extensions activated for this task.
+	Extensions []string `json:"extensions,omitempty"`
 }
 
 // TaskStatusUpdateEvent indicates a change in the task's lifecycle state.

--- a/protocol/types.go
+++ b/protocol/types.go
@@ -325,11 +325,32 @@ type GetTaskPushNotificationConfigParams struct {
 // SendMessageResponse — the result of message/send (discriminated union)
 // ---------------------------------------------------------------------------
 
-// SendMessageResponse wraps the result of message/send.
-// Exactly one of Message or Task must be non-nil.
+// SendMessageResult is the sealed Message-or-Task union returned by message/send.
+// Exactly one concrete type (*Message or *Task) inhabits it, enforced by the type
+// system — unlike a struct with two optional pointers where both/neither is
+// representable. Mirrors the v0 SendMessageResult and the official SDK's
+// SendMessageResult.
+type SendMessageResult interface{ isSendMessageResult() }
+
+func (*Message) isSendMessageResult() {}
+func (*Task) isSendMessageResult()    {}
+
+// SendMessageResponse wraps a SendMessageResult. The wrapper hosts the
+// discriminating JSON (Go cannot unmarshal directly into an interface field).
 type SendMessageResponse struct {
-	Message *Message
-	Task    *Task
+	Result SendMessageResult
+}
+
+// GetMessage returns the *Message when the result is a message, else nil.
+func (r *SendMessageResponse) GetMessage() *Message {
+	m, _ := r.Result.(*Message)
+	return m
+}
+
+// GetTask returns the *Task when the result is a task, else nil.
+func (r *SendMessageResponse) GetTask() *Task {
+	t, _ := r.Result.(*Task)
+	return t
 }
 
 type sendMessageResponseWire struct {
@@ -339,10 +360,14 @@ type sendMessageResponseWire struct {
 
 // MarshalJSON implements json.Marshaler.
 func (r SendMessageResponse) MarshalJSON() ([]byte, error) {
-	return json.Marshal(sendMessageResponseWire{
-		Message: r.Message,
-		Task:    r.Task,
-	})
+	var w sendMessageResponseWire
+	switch v := r.Result.(type) {
+	case *Message:
+		w.Message = v
+	case *Task:
+		w.Task = v
+	}
+	return json.Marshal(w)
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -351,18 +376,14 @@ func (r *SendMessageResponse) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &w); err != nil {
 		return err
 	}
-	count := 0
-	if w.Message != nil {
-		count++
+	switch {
+	case w.Message != nil && w.Task == nil:
+		r.Result = w.Message
+	case w.Task != nil && w.Message == nil:
+		r.Result = w.Task
+	default:
+		return fmt.Errorf("send message response must have exactly one of message/task")
 	}
-	if w.Task != nil {
-		count++
-	}
-	if count != 1 {
-		return fmt.Errorf("send message response must have exactly one of message/task, got %d", count)
-	}
-	r.Message = w.Message
-	r.Task = w.Task
 	return nil
 }
 
@@ -370,13 +391,44 @@ func (r *SendMessageResponse) UnmarshalJSON(data []byte) error {
 // StreamResponse — a single event in message/stream SSE (discriminated union)
 // ---------------------------------------------------------------------------
 
-// StreamResponse wraps a single streaming event.
-// Exactly one field must be non-nil.
+// StreamEvent is the sealed union of events delivered in a message/stream SSE:
+// a status update, an artifact update, a full Task, or a Message. Exactly one
+// concrete type inhabits it. Mirrors the v0 StreamEvent.
+type StreamEvent interface{ isStreamEvent() }
+
+func (*TaskStatusUpdateEvent) isStreamEvent()   {}
+func (*TaskArtifactUpdateEvent) isStreamEvent() {}
+func (*Task) isStreamEvent()                    {}
+func (*Message) isStreamEvent()                 {}
+
+// StreamResponse wraps a single StreamEvent. The wrapper hosts the discriminating
+// JSON (Go cannot unmarshal directly into an interface field).
 type StreamResponse struct {
-	StatusUpdate   *TaskStatusUpdateEvent
-	ArtifactUpdate *TaskArtifactUpdateEvent
-	Task           *Task
-	Message        *Message
+	Result StreamEvent
+}
+
+// GetStatusUpdate returns the *TaskStatusUpdateEvent, or nil if not that type.
+func (r *StreamResponse) GetStatusUpdate() *TaskStatusUpdateEvent {
+	e, _ := r.Result.(*TaskStatusUpdateEvent)
+	return e
+}
+
+// GetArtifactUpdate returns the *TaskArtifactUpdateEvent, or nil if not that type.
+func (r *StreamResponse) GetArtifactUpdate() *TaskArtifactUpdateEvent {
+	e, _ := r.Result.(*TaskArtifactUpdateEvent)
+	return e
+}
+
+// GetTask returns the *Task, or nil if not that type.
+func (r *StreamResponse) GetTask() *Task {
+	t, _ := r.Result.(*Task)
+	return t
+}
+
+// GetMessage returns the *Message, or nil if not that type.
+func (r *StreamResponse) GetMessage() *Message {
+	m, _ := r.Result.(*Message)
+	return m
 }
 
 type streamResponseWire struct {
@@ -388,12 +440,18 @@ type streamResponseWire struct {
 
 // MarshalJSON implements json.Marshaler.
 func (r StreamResponse) MarshalJSON() ([]byte, error) {
-	return json.Marshal(streamResponseWire{
-		StatusUpdate:   r.StatusUpdate,
-		ArtifactUpdate: r.ArtifactUpdate,
-		Task:           r.Task,
-		Message:        r.Message,
-	})
+	var w streamResponseWire
+	switch v := r.Result.(type) {
+	case *TaskStatusUpdateEvent:
+		w.StatusUpdate = v
+	case *TaskArtifactUpdateEvent:
+		w.ArtifactUpdate = v
+	case *Task:
+		w.Task = v
+	case *Message:
+		w.Message = v
+	}
+	return json.Marshal(w)
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -405,36 +463,36 @@ func (r *StreamResponse) UnmarshalJSON(data []byte) error {
 	count := 0
 	if w.StatusUpdate != nil {
 		count++
+		r.Result = w.StatusUpdate
 	}
 	if w.ArtifactUpdate != nil {
 		count++
+		r.Result = w.ArtifactUpdate
 	}
 	if w.Task != nil {
 		count++
+		r.Result = w.Task
 	}
 	if w.Message != nil {
 		count++
+		r.Result = w.Message
 	}
 	if count != 1 {
 		return fmt.Errorf("stream response must have exactly one of statusUpdate/artifactUpdate/task/message, got %d", count)
 	}
-	r.StatusUpdate = w.StatusUpdate
-	r.ArtifactUpdate = w.ArtifactUpdate
-	r.Task = w.Task
-	r.Message = w.Message
 	return nil
 }
 
 // EventType returns the SSE event type string for this response.
 func (r *StreamResponse) EventType() string {
-	switch {
-	case r.StatusUpdate != nil:
+	switch r.Result.(type) {
+	case *TaskStatusUpdateEvent:
 		return EventStatusUpdate
-	case r.ArtifactUpdate != nil:
+	case *TaskArtifactUpdateEvent:
 		return EventArtifactUpdate
-	case r.Task != nil:
+	case *Task:
 		return EventTask
-	case r.Message != nil:
+	case *Message:
 		return EventMessage
 	default:
 		return ""
@@ -443,11 +501,11 @@ func (r *StreamResponse) EventType() string {
 
 // IsFinal returns true if this is a terminal event in the stream.
 func (r *StreamResponse) IsFinal() bool {
-	switch {
-	case r.StatusUpdate != nil:
-		return r.StatusUpdate.IsFinal()
-	case r.ArtifactUpdate != nil:
-		return r.ArtifactUpdate.IsFinal()
+	switch e := r.Result.(type) {
+	case *TaskStatusUpdateEvent:
+		return e.IsFinal()
+	case *TaskArtifactUpdateEvent:
+		return e.IsFinal()
 	default:
 		return false
 	}
@@ -527,12 +585,12 @@ func NewTaskArtifactUpdateEvent(taskID, contextID string, artifact Artifact, las
 
 // NewSendMessageResponseMessage wraps a Message as a SendMessageResponse.
 func NewSendMessageResponseMessage(m *Message) *SendMessageResponse {
-	return &SendMessageResponse{Message: m}
+	return &SendMessageResponse{Result: m}
 }
 
 // NewSendMessageResponseTask wraps a Task as a SendMessageResponse.
 func NewSendMessageResponseTask(t *Task) *SendMessageResponse {
-	return &SendMessageResponse{Task: t}
+	return &SendMessageResponse{Result: t}
 }
 
 // ---------------------------------------------------------------------------
@@ -541,20 +599,20 @@ func NewSendMessageResponseTask(t *Task) *SendMessageResponse {
 
 // NewStreamResponseStatusUpdate wraps a TaskStatusUpdateEvent.
 func NewStreamResponseStatusUpdate(e *TaskStatusUpdateEvent) StreamResponse {
-	return StreamResponse{StatusUpdate: e}
+	return StreamResponse{Result: e}
 }
 
 // NewStreamResponseArtifactUpdate wraps a TaskArtifactUpdateEvent.
 func NewStreamResponseArtifactUpdate(e *TaskArtifactUpdateEvent) StreamResponse {
-	return StreamResponse{ArtifactUpdate: e}
+	return StreamResponse{Result: e}
 }
 
 // NewStreamResponseTask wraps a Task.
 func NewStreamResponseTask(t *Task) StreamResponse {
-	return StreamResponse{Task: t}
+	return StreamResponse{Result: t}
 }
 
 // NewStreamResponseMessage wraps a Message.
 func NewStreamResponseMessage(m *Message) StreamResponse {
-	return StreamResponse{Message: m}
+	return StreamResponse{Result: m}
 }

--- a/protocol/types_test.go
+++ b/protocol/types_test.go
@@ -159,9 +159,9 @@ func TestSendMessageResponseJSON(t *testing.T) {
 		var decoded SendMessageResponse
 		err = json.Unmarshal(data, &decoded)
 		require.NoError(t, err)
-		require.NotNil(t, decoded.Message)
-		assert.Nil(t, decoded.Task)
-		assert.Equal(t, "hello", decoded.Message.Parts[0].TextContent())
+		require.NotNil(t, decoded.GetMessage())
+		assert.Nil(t, decoded.GetTask())
+		assert.Equal(t, "hello", decoded.GetMessage().Parts[0].TextContent())
 	})
 
 	t.Run("with task", func(t *testing.T) {
@@ -173,9 +173,9 @@ func TestSendMessageResponseJSON(t *testing.T) {
 		var decoded SendMessageResponse
 		err = json.Unmarshal(data, &decoded)
 		require.NoError(t, err)
-		assert.Nil(t, decoded.Message)
-		require.NotNil(t, decoded.Task)
-		assert.Equal(t, "t1", decoded.Task.ID)
+		assert.Nil(t, decoded.GetMessage())
+		require.NotNil(t, decoded.GetTask())
+		assert.Equal(t, "t1", decoded.GetTask().ID)
 	})
 }
 
@@ -194,8 +194,8 @@ func TestStreamResponseJSON(t *testing.T) {
 		var decoded StreamResponse
 		err = json.Unmarshal(data, &decoded)
 		require.NoError(t, err)
-		require.NotNil(t, decoded.StatusUpdate)
-		assert.Equal(t, "t1", decoded.StatusUpdate.TaskID)
+		require.NotNil(t, decoded.GetStatusUpdate())
+		assert.Equal(t, "t1", decoded.GetStatusUpdate().TaskID)
 	})
 
 	t.Run("artifactUpdate", func(t *testing.T) {
@@ -211,15 +211,15 @@ func TestStreamResponseJSON(t *testing.T) {
 		var decoded StreamResponse
 		err = json.Unmarshal(data, &decoded)
 		require.NoError(t, err)
-		require.NotNil(t, decoded.ArtifactUpdate)
-		assert.Equal(t, "a1", decoded.ArtifactUpdate.Artifact.ArtifactID)
+		require.NotNil(t, decoded.GetArtifactUpdate())
+		assert.Equal(t, "a1", decoded.GetArtifactUpdate().Artifact.ArtifactID)
 	})
 
 	t.Run("EventType", func(t *testing.T) {
-		assert.Equal(t, EventStatusUpdate, (&StreamResponse{StatusUpdate: &TaskStatusUpdateEvent{}}).EventType())
-		assert.Equal(t, EventArtifactUpdate, (&StreamResponse{ArtifactUpdate: &TaskArtifactUpdateEvent{}}).EventType())
-		assert.Equal(t, EventTask, (&StreamResponse{Task: &Task{}}).EventType())
-		assert.Equal(t, EventMessage, (&StreamResponse{Message: &Message{}}).EventType())
+		assert.Equal(t, EventStatusUpdate, (&StreamResponse{Result: &TaskStatusUpdateEvent{}}).EventType())
+		assert.Equal(t, EventArtifactUpdate, (&StreamResponse{Result: &TaskArtifactUpdateEvent{}}).EventType())
+		assert.Equal(t, EventTask, (&StreamResponse{Result: &Task{}}).EventType())
+		assert.Equal(t, EventMessage, (&StreamResponse{Result: &Message{}}).EventType())
 		assert.Equal(t, "", (&StreamResponse{}).EventType())
 	})
 }

--- a/server/options.go
+++ b/server/options.go
@@ -65,6 +65,7 @@ func WithCORSEnabled(enabled bool) Option {
 func WithJSONRPCEndpoint(path string) Option {
 	return func(s *A2AServer) {
 		s.jsonRPCEndpoint = path
+		s.pathsExplicitlySet = true
 	}
 }
 
@@ -79,6 +80,53 @@ func WithJSONRPCEndpoint(path string) Option {
 func WithCompatHandler(h http.Handler) Option {
 	return func(s *A2AServer) {
 		s.compatHandler = h
+	}
+}
+
+// WithAgentCard sets the server's default agent card. For a single-agent server
+// this is the card served at /.well-known/agent-card.json, and its URL also
+// supplies the base path when no path option is set. For a multi-tenant server
+// (WithTenantCard / WithTenantCardProvider) it is optional and, when given,
+// becomes the default "directory" card served when no "?tenant=" is present.
+//
+// At least one of WithAgentCard, WithTenantCard or WithTenantCardProvider must be
+// supplied to NewA2AServer.
+func WithAgentCard(card AgentCard) Option {
+	return func(s *A2AServer) {
+		// Ensure the served card carries a v1.0-conformant supportedInterfaces list,
+		// deriving it from the deprecated URL/PreferredTransport fields when needed.
+		card.NormalizeInterfaces()
+		s.agentCard = card
+		s.agentCardSet = true
+	}
+}
+
+// WithTenantCard registers an AgentCard for a specific tenant, making the server
+// multi-tenant: one process can host several agents distinguished by the v1.0
+// tenant field (carried in the request body). The processor dispatches on
+// ProcessOptions.Tenant, and the agent-card endpoint serves the matching card for
+// "?tenant=<tenant>". This replaces the legacy URL-path template + placeholder
+// card + custom AgentCardHandler mechanism. Call once per tenant.
+func WithTenantCard(tenant string, card AgentCard) Option {
+	return func(s *A2AServer) {
+		if s.tenantCards == nil {
+			s.tenantCards = make(map[string]AgentCard)
+		}
+		card.NormalizeInterfaces()
+		// Stamp the tenant onto the card's interfaces so clients see who to address.
+		for i := range card.SupportedInterfaces {
+			card.SupportedInterfaces[i].Tenant = tenant
+		}
+		s.tenantCards[tenant] = card
+	}
+}
+
+// WithTenantCardProvider resolves a tenant's AgentCard dynamically (e.g. from a
+// database) for when the set of tenants is not known at startup. It is consulted
+// after the static WithTenantCard registry; return an error for an unknown tenant.
+func WithTenantCardProvider(provider func(ctx context.Context, tenant string) (AgentCard, error)) Option {
+	return func(s *A2AServer) {
+		s.tenantCardProvider = provider
 	}
 }
 
@@ -120,6 +168,7 @@ func WithJWKSEndpoint(enabled bool, path string) Option {
 		s.jwksEnabled = enabled
 		if path != "" {
 			s.jwksEndpoint = path
+			s.pathsExplicitlySet = true
 		}
 	}
 }
@@ -170,6 +219,7 @@ func WithBasePath(basePath string) Option {
 		basePath = strings.TrimSuffix(basePath, "/")
 
 		// Set all endpoint paths with the base path prefix.
+		s.pathsExplicitlySet = true
 		s.jsonRPCEndpoint = basePath + "/"
 		s.agentCardPath = basePath + protocol.AgentCardPath
 		s.oldAgentCardPath = basePath + protocol.OldAgentCardPath
@@ -215,15 +265,6 @@ func WithAuthenticatedExtendedCardHandler(handler func(ctx context.Context, base
 func WithFirstTokenPolicy(policy telemetry.FirstTokenPolicy) Option {
 	return func(s *A2AServer) {
 		s.firstTokenPolicy = policy
-	}
-}
-
-// WithFirstTokenMatcher sets custom TTFT detection logic for streaming responses.
-//
-// Deprecated: use WithFirstTokenPolicy.
-func WithFirstTokenMatcher(matcher telemetry.FirstTokenMatcher) Option {
-	return func(s *A2AServer) {
-		s.firstTokenPolicy = telemetry.NewFirstTokenPolicyFromMatcher(matcher)
 	}
 }
 

--- a/server/options_test.go
+++ b/server/options_test.go
@@ -117,19 +117,6 @@ func TestWithFirstTokenPolicy(t *testing.T) {
 	assert.Equal(t, policy, serverOptions.firstTokenPolicy)
 }
 
-func TestWithFirstTokenMatcher(t *testing.T) {
-	serverOptions := &A2AServer{}
-	matcher := func(event *protocol.StreamResponse, isStreaming bool) bool {
-		return isStreaming && event == nil
-	}
-
-	WithFirstTokenMatcher(matcher)(serverOptions)
-
-	require.NotNil(t, serverOptions.firstTokenPolicy)
-	assert.True(t, serverOptions.firstTokenPolicy.IsStreamingFirstToken(nil))
-	assert.True(t, serverOptions.firstTokenPolicy.IsNonStreamingFirstToken(nil))
-}
-
 func TestWithTelemetryMeterProvider(t *testing.T) {
 	provider := noop.NewMeterProvider()
 
@@ -287,7 +274,7 @@ func TestNewA2AServerWithAgentCardURL(t *testing.T) {
 			}
 
 			// Create the server
-			server, err := NewA2AServer(agentCard, taskMgr)
+			server, err := NewA2AServer(taskMgr, WithAgentCard(agentCard))
 			require.NoError(t, err)
 
 			// Verify all paths are correctly configured
@@ -566,7 +553,7 @@ func TestWithBasePathPriority(t *testing.T) {
 			if tt.basePath != "" {
 				opts = append(opts, WithBasePath(tt.basePath))
 			}
-			server, err := NewA2AServer(agentCard, taskMgr, opts...)
+			server, err := NewA2AServer(taskMgr, append([]Option{WithAgentCard(agentCard)}, opts...)...)
 			require.NoError(t, err)
 
 			// Verify all paths are correctly configured

--- a/server/options_test.go
+++ b/server/options_test.go
@@ -348,7 +348,7 @@ type optionsTestTaskManager struct{}
 
 func (m *optionsTestTaskManager) OnSendMessage(ctx context.Context, params protocol.SendMessageParams) (*protocol.SendMessageResponse, error) {
 	return &protocol.SendMessageResponse{
-		Message: &protocol.Message{
+		Result: &protocol.Message{
 			MessageID: "test-message-id",
 			Role:      protocol.MessageRoleAgent,
 			Parts:     []*protocol.Part{protocol.NewTextPart("test response")},

--- a/server/server.go
+++ b/server/server.go
@@ -34,18 +34,31 @@ import (
 // A2AServer implements the HTTP server for the A2A protocol.
 // It handles agent card requests and routes JSON-RPC calls to the TaskManager.
 type A2AServer struct {
-	agentCard        AgentCard               // Metadata for this agent.
+	agentCard        AgentCard               // Default (single-agent) card; optional when multi-tenant.
+	agentCardSet     bool                    // Whether a default card was provided (WithAgentCard).
 	taskManager      taskmanager.TaskManager // Handles task logic.
 	httpServer       *http.Server            // Underlying HTTP server.
 	corsEnabled      bool                    // Flag to enable/disable CORS headers.
 	jsonRPCEndpoint  string                  // Path for the JSON-RPC endpoint.
 	agentCardPath    string                  // Path for the agent card endpoint.
 	oldAgentCardPath string                  // Path for the old agent card endpoint.
-	readTimeout      time.Duration           // HTTP server read timeout.
-	writeTimeout     time.Duration           // HTTP server write timeout.
-	idleTimeout      time.Duration           // HTTP server idle timeout.
-	agentCardHandler http.Handler            // Handler for agent card endpoint.
-	customRouter     HTTPRouter              // Custom router for advanced routing (e.g., Gorilla Mux).
+	// pathsExplicitlySet records whether serving paths were configured via an
+	// option (WithBasePath / WithJSONRPCEndpoint / WithJWKSEndpoint). When false,
+	// the base path is derived from the agent card URL. This replaces a fragile
+	// "did the paths change from their defaults?" heuristic.
+	pathsExplicitlySet bool
+	// tenantCards is the static tenant -> AgentCard registry (WithTenantCards).
+	// tenantCardProvider resolves a tenant's card dynamically (WithTenantCardProvider).
+	// When either is set the server is multi-tenant: it routes by params.Tenant
+	// (carried in the request body) and serves per-tenant cards, instead of the
+	// legacy URL-path / placeholder-card mechanism.
+	tenantCards        map[string]AgentCard
+	tenantCardProvider func(ctx context.Context, tenant string) (AgentCard, error)
+	readTimeout        time.Duration // HTTP server read timeout.
+	writeTimeout       time.Duration // HTTP server write timeout.
+	idleTimeout        time.Duration // HTTP server idle timeout.
+	agentCardHandler   http.Handler  // Handler for agent card endpoint.
+	customRouter       HTTPRouter    // Custom router for advanced routing (e.g., Gorilla Mux).
 
 	// compatHandler, when set, handles JSON-RPC requests whose method name is
 	// not a v1.0 method (e.g. the legacy slash-delimited names). It is invoked
@@ -71,18 +84,19 @@ type A2AServer struct {
 	telemetryOwnsProvider  bool
 }
 
-// NewA2AServer creates a new A2AServer instance with the given agent card
-// and task manager implementation.
-// Exported function.
-func NewA2AServer(agentCard AgentCard, taskManager taskmanager.TaskManager, opts ...Option) (*A2AServer, error) {
+// NewA2AServer creates a new A2AServer instance with the given task manager.
+//
+// The agent card is configured via options rather than a positional argument:
+// use WithAgentCard for a single-agent server, or WithTenantCard /
+// WithTenantCardProvider for a multi-tenant server (one process hosting several
+// agents, distinguished by the v1.0 tenant field). At least one of these must be
+// provided. WithAgentCard is also accepted alongside the tenant options, where it
+// becomes the default ("directory") card served when no "?tenant=" is given.
+func NewA2AServer(taskManager taskmanager.TaskManager, opts ...Option) (*A2AServer, error) {
 	if taskManager == nil {
 		return nil, errors.New("NewA2AServer requires a non-nil taskManager")
 	}
-	// Ensure the served card carries a v1.0-conformant supportedInterfaces list,
-	// deriving it from the deprecated URL/PreferredTransport fields when needed.
-	agentCard.NormalizeInterfaces()
 	server := &A2AServer{
-		agentCard:        agentCard,
 		taskManager:      taskManager,
 		corsEnabled:      true, // Enable CORS by default for easier development.
 		jsonRPCEndpoint:  protocol.DefaultJSONRPCPath,
@@ -95,25 +109,26 @@ func NewA2AServer(agentCard AgentCard, taskManager taskmanager.TaskManager, opts
 		jwksEndpoint:     protocol.JWKSPath,
 	}
 
-	// Store the original paths before applying options.
-	originalJSONRPCEndpoint := server.jsonRPCEndpoint
-	originalAgentCardPath := server.agentCardPath
-	originalJWKSEndpoint := server.jwksEndpoint
-
-	// Apply options first (WithBasePath has higher priority).
+	// Apply options. WithAgentCard sets the default card; path-setting options
+	// (WithBasePath / WithJSONRPCEndpoint / WithJWKSEndpoint) set pathsExplicitlySet.
 	for _, opt := range opts {
 		opt(server)
 	}
 
-	// If paths haven't been changed by options (e.g., WithBasePath),
-	// then extract base path from agent card URL as fallback.
-	if server.jsonRPCEndpoint == originalJSONRPCEndpoint &&
-		server.agentCardPath == originalAgentCardPath &&
-		server.jwksEndpoint == originalJWKSEndpoint {
+	// Require at least one card source so discovery and routing have something to serve.
+	if !server.agentCardSet && len(server.tenantCards) == 0 && server.tenantCardProvider == nil {
+		return nil, errors.New(
+			"NewA2AServer requires an agent card: use WithAgentCard, WithTenantCard, or WithTenantCardProvider")
+	}
 
-		basePath := extractBasePathFromURL(agentCard.PrimaryURL())
-		if basePath != "" {
-			// Configure endpoints with the extracted base path.
+	// When the serving paths were not set explicitly, derive a base path from the
+	// default agent card URL (the common "direct serve under a subpath" case, where
+	// the advertised URL path == the serving path). Use WithBasePath to override
+	// this when they differ (e.g. behind a reverse proxy that rewrites the path).
+	// A pure multi-tenant server (no default card) defaults to the root paths;
+	// tenant cards share that single endpoint and use WithBasePath when needed.
+	if !server.pathsExplicitlySet && server.agentCardSet {
+		if basePath := extractBasePathFromURL(server.agentCard.PrimaryURL()); basePath != "" {
 			server.jsonRPCEndpoint = basePath + "/"
 			server.agentCardPath = basePath + protocol.AgentCardPath
 			server.jwksEndpoint = basePath + protocol.JWKSPath
@@ -131,6 +146,7 @@ func NewA2AServer(agentCard AgentCard, taskManager taskmanager.TaskManager, opts
 			}
 		}
 	}
+
 	return server, nil
 }
 
@@ -264,22 +280,19 @@ func (s *A2AServer) Handler() http.Handler {
 		router.Handle(s.jwksEndpoint, http.HandlerFunc(s.pushAuth.HandleJWKS))
 	}
 
-	// Main JSON-RPC endpoint (configurable path) with optional authentication.
-	// When a compat handler is configured, dispatch non-v1 (legacy) methods to
-	// it from within the same handler so the authentication middleware below
-	// covers both protocol generations.
+	// Default JSON-RPC transport (configurable path). When a compat handler is
+	// configured, dispatch non-v1 (legacy) methods to it from within the same
+	// handler so the authentication middleware below covers both generations.
 	var jsonRPCHandler http.Handler = http.HandlerFunc(s.handleJSONRPC)
 	if s.compatHandler != nil {
 		jsonRPCHandler = s.dispatchByProtocol(jsonRPCHandler, s.compatHandler)
 	}
+
+	// Mount the JSON-RPC endpoint inside the authentication middleware chain.
 	if len(s.middleWare) > 0 {
-		// Apply authentication middleware chain to JSON-RPC endpoint.
-		chain := MiddlewareChain(s.middleWare)
-		router.Handle(s.jsonRPCEndpoint, chain.Wrap(jsonRPCHandler))
-	} else {
-		// No authentication required.
-		router.Handle(s.jsonRPCEndpoint, jsonRPCHandler)
+		jsonRPCHandler = MiddlewareChain(s.middleWare).Wrap(jsonRPCHandler)
 	}
+	router.Handle(s.jsonRPCEndpoint, jsonRPCHandler)
 	return router
 }
 
@@ -326,12 +339,50 @@ func (s *A2AServer) handleAgentCard(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
 		return
 	}
+	// Multi-tenant: serve the card for "?tenant=<tenant>"; empty -> default card.
+	card, ok := s.resolveAgentCard(r.Context(), r.URL.Query().Get("tenant"))
+	if !ok {
+		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+		return
+	}
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	if err := json.NewEncoder(w).Encode(s.agentCard); err != nil {
+	if err := json.NewEncoder(w).Encode(card); err != nil {
 		log.Errorf("Failed to encode agent card: %v", err)
 		// Avoid writing JSON-RPC error here; it's a standard HTTP endpoint.
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 	}
+}
+
+// resolveAgentCard returns the AgentCard for the given tenant (from "?tenant=").
+// An empty tenant yields the default card. On a multi-tenant server (WithTenantCard
+// / WithTenantCardProvider) an unknown tenant yields ok=false (404).
+func (s *A2AServer) resolveAgentCard(ctx context.Context, tenant string) (AgentCard, bool) {
+	if tenant == "" {
+		// No default card configured (pure multi-tenant): nothing to serve without a tenant.
+		if !s.agentCardSet {
+			return AgentCard{}, false
+		}
+		return s.agentCard, true
+	}
+	if c, ok := s.tenantCards[tenant]; ok {
+		return c, true
+	}
+	if s.tenantCardProvider != nil {
+		c, err := s.tenantCardProvider(ctx, tenant)
+		if err != nil {
+			return AgentCard{}, false
+		}
+		return c, true
+	}
+	if len(s.tenantCards) > 0 {
+		// Multi-tenant server, but no such tenant.
+		return AgentCard{}, false
+	}
+	// Single-agent server: ignore an unexpected tenant param, serve the default.
+	if !s.agentCardSet {
+		return AgentCard{}, false
+	}
+	return s.agentCard, true
 }
 
 // handleJSONRPC is the main handler for all JSON-RPC 2.0 requests.
@@ -603,7 +654,17 @@ func (s *A2AServer) writeJSONRPCError(w http.ResponseWriter, id interface{}, err
 		httpStatus = http.StatusNotFound
 	case jsonrpc.CodeInvalidParams:
 		httpStatus = http.StatusBadRequest
-		// Add other mappings for custom server errors (-32000 to -32099) if desired.
+	case taskmanager.ErrCodeTaskNotFound:
+		httpStatus = http.StatusNotFound
+	case taskmanager.ErrCodeTaskNotCancelable,
+		taskmanager.ErrCodePushNotificationNotSupported,
+		taskmanager.ErrCodeUnsupportedOperation,
+		taskmanager.ErrCodeContentTypeNotSupported,
+		taskmanager.ErrCodeAuthenticatedExtendedCardNotConfigured,
+		taskmanager.ErrCodeExtensionSupportRequired,
+		taskmanager.ErrCodeVersionNotSupported:
+		httpStatus = http.StatusBadRequest
+		// ErrCodeInvalidAgentResponse and other internal errors keep the 500 default.
 	}
 	w.WriteHeader(httpStatus)
 	if encodeErr := json.NewEncoder(w).Encode(response); encodeErr != nil {
@@ -631,7 +692,6 @@ func (s *A2AServer) handleTasksPushNotificationSet(
 		s.writeJSONRPCError(w, request.ID, err)
 		return
 	}
-	// Validate required fields.
 	if params.TaskID == "" {
 		s.writeJSONRPCError(w, request.ID, jsonrpc.ErrInvalidParams("task ID is required"))
 		return
@@ -640,23 +700,18 @@ func (s *A2AServer) handleTasksPushNotificationSet(
 		s.writeJSONRPCError(w, request.ID, jsonrpc.ErrInvalidParams("push notification URL is required"))
 		return
 	}
-	// Set JWKS endpoint information for push notification authentication.
+	// Inject the JWKS URL so the agent can publish the key used to sign push notifications.
 	if s.jwksEnabled && s.pushAuth != nil {
-		jwksURL := s.composeJWKSURL()
-		log.Infof("JWKS URL for push notifications: %s", jwksURL)
 		if params.Metadata == nil {
 			params.Metadata = make(map[string]interface{})
 		}
-		params.Metadata["jwksUrl"] = jwksURL
+		params.Metadata["jwksUrl"] = s.composeJWKSURL()
 	}
-
-	// Delegate to the task manager.
 	result, err := s.taskManager.OnPushNotificationSet(ctx, params)
 	if err != nil {
 		s.handleTaskManagerError(w, request.ID, err, "OnPushNotificationSet", params.TaskID)
 		return
 	}
-
 	s.writeJSONRPCResponse(w, request.ID, result)
 }
 
@@ -699,12 +754,11 @@ func (s *A2AServer) handleTasksPushNotificationGet(
 	if taskID == "" {
 		taskID = params.ID
 	}
+
 	if taskID == "" {
 		s.writeJSONRPCError(w, request.ID, jsonrpc.ErrInvalidParams("task ID is required"))
 		return
 	}
-
-	// Delegate to the task manager.
 	result, err := s.taskManager.OnPushNotificationGet(ctx, protocol.TaskIDParams{
 		RPCID:    params.RPCID,
 		ID:       taskID,
@@ -805,11 +859,10 @@ func (s *A2AServer) handleMessageStream(ctx context.Context, w http.ResponseWrit
 	// Get the event channel from the task manager.
 	eventsChan, err := s.taskManager.OnSendMessageStream(ctx, params)
 	if err != nil {
-		log.Errorf("Error calling OnSendMessageStream for message %s: %v", params.RPCID, err)
 		tracker.setError("subscribe_failed")
 		tracker.record(ctx)
-		s.writeJSONRPCError(w, request.ID,
-			jsonrpc.ErrInternalError(fmt.Sprintf("failed to subscribe to message events: %v", err)))
+		// Preserves a core *jsonrpc.Error (e.g. invalid params) and wraps the rest.
+		s.handleTaskManagerError(w, request.ID, err, "OnSendMessageStream", params.RPCID)
 		return
 	}
 
@@ -932,29 +985,22 @@ func (s *A2AServer) handleAgentGetAuthenticatedExtendedCard(
 	w http.ResponseWriter,
 	request jsonrpc.Request,
 ) {
-	// Check if the agent supports authenticated extended cards (v1.0
-	// capabilities.extendedAgentCard or the deprecated top-level flag).
 	if !s.agentCard.ExtendedAgentCardEnabled() {
-		log.Warnf("Authenticated extended card not configured (Request ID: %v)", request.ID)
-		s.writeJSONRPCError(w, request.ID, taskmanager.ErrAuthenticatedExtendedCardNotConfigured())
+		rpcErr := taskmanager.ErrAuthenticatedExtendedCardNotConfigured()
+		log.Warnf("Authenticated extended card unavailable (Request ID: %v): %v", request.ID, rpcErr)
+		s.writeJSONRPCError(w, request.ID, rpcErr)
 		return
 	}
-
-	baseCard := s.agentCard
-
-	// Apply dynamic modifications if a card modifier is configured
-	var cardToServe AgentCard
+	cardToServe := s.agentCard
 	if s.authenticatedCardHandler != nil {
-		modifiedCard, err := s.authenticatedCardHandler(ctx, baseCard)
+		var err error
+		cardToServe, err = s.authenticatedCardHandler(ctx, s.agentCard)
 		if err != nil {
 			log.Errorf("Error applying authenticated card handler: %v", err)
 			s.writeJSONRPCError(w, request.ID,
 				jsonrpc.ErrInternalError(fmt.Sprintf("failed to handle extended card: %v", err)))
 			return
 		}
-		cardToServe = modifiedCard
-	} else {
-		cardToServe = baseCard
 	}
 
 	log.Debugf("Serving authenticated extended card (Request ID: %v)", request.ID)

--- a/server/server_handlers_test.go
+++ b/server/server_handlers_test.go
@@ -399,8 +399,8 @@ func TestA2AServer_Resubscribe(t *testing.T) {
 			Final:     true,
 		}
 		mockTM.SubscribeEvents = []protocol.StreamResponse{
-			{StatusUpdate: &workingEvent},
-			{StatusUpdate: &completedEvent},
+			{Result: &workingEvent},
+			{Result: &completedEvent},
 		}
 		mockTM.SubscribeError = nil
 

--- a/server/server_handlers_test.go
+++ b/server/server_handlers_test.go
@@ -36,7 +36,7 @@ func stringPtr(s string) *string {
 // Returns the test server and the A2A server for use in tests.
 func setupTestServer(t *testing.T, tm taskmanager.TaskManager, opts ...Option) (*httptest.Server, *A2AServer) {
 	agentCard := defaultAgentCard()
-	a2aServer, err := NewA2AServer(agentCard, tm, opts...)
+	a2aServer, err := NewA2AServer(tm, append([]Option{WithAgentCard(agentCard)}, opts...)...)
 	require.NoError(t, err)
 	testServer := httptest.NewServer(http.HandlerFunc(a2aServer.handleJSONRPC))
 	t.Cleanup(func() {
@@ -209,7 +209,7 @@ func TestA2AServer_AuthMiddleware(t *testing.T) {
 	authProvider := auth.NewAPIKeyAuthProvider(keyMap, "X-API-Key")
 
 	// Create server with authentication
-	a2aServer, err := NewA2AServer(agentCard, mockTM, WithAuthProvider(authProvider))
+	a2aServer, err := NewA2AServer(mockTM, WithAgentCard(agentCard), WithAuthProvider(authProvider))
 	require.NoError(t, err)
 
 	// Create test server with the full handler
@@ -269,7 +269,7 @@ func TestA2AServer_PushNotifications(t *testing.T) {
 	agentCard := defaultAgentCard()
 
 	// Create server with JWKS enabled - fix function name
-	a2aServer, err := NewA2AServer(agentCard, mockTM, WithJWKSEndpoint(true, ""))
+	a2aServer, err := NewA2AServer(mockTM, WithAgentCard(agentCard), WithJWKSEndpoint(true, ""))
 	require.NoError(t, err)
 
 	// Create test server with the full handler
@@ -378,7 +378,7 @@ func TestA2AServer_PushNotifications(t *testing.T) {
 func TestA2AServer_Resubscribe(t *testing.T) {
 	mockTM := newMockTaskManager()
 	agentCard := defaultAgentCard()
-	a2aServer, err := NewA2AServer(agentCard, mockTM)
+	a2aServer, err := NewA2AServer(mockTM, WithAgentCard(agentCard))
 	require.NoError(t, err)
 
 	// Create test server
@@ -481,7 +481,7 @@ func TestA2AServer_Resubscribe(t *testing.T) {
 func TestA2AServer_StartStop(t *testing.T) {
 	mockTM := newMockTaskManager()
 	agentCard := defaultAgentCard()
-	a2aServer, err := NewA2AServer(agentCard, mockTM)
+	a2aServer, err := NewA2AServer(mockTM, WithAgentCard(agentCard))
 	require.NoError(t, err)
 
 	// Start the server in a goroutine
@@ -556,7 +556,7 @@ func TestA2AServer_V1Operations(t *testing.T) {
 // newTestServer builds an httptest server serving the full A2A router.
 func newTestServer(t *testing.T, tm taskmanager.TaskManager) *httptest.Server {
 	t.Helper()
-	srv, err := NewA2AServer(defaultAgentCard(), tm)
+	srv, err := NewA2AServer(tm, WithAgentCard(defaultAgentCard()))
 	require.NoError(t, err)
 	return httptest.NewServer(srv.Handler())
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -29,6 +29,7 @@ import (
 	"trpc.group/trpc-go/trpc-a2a-go/v2/internal/sse"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager/memory"
 )
 
 // Helper to create a default AgentCard for tests.
@@ -99,7 +100,7 @@ func TestA2AServer_HandleAgentCard(t *testing.T) {
 	// The server normalizes the card to a v1.0-conformant supportedInterfaces
 	// list; normalize the expected copy the same way for comparison.
 	agentCard.NormalizeInterfaces()
-	a2aServer, err := NewA2AServer(agentCard, mockTM)
+	a2aServer, err := NewA2AServer(mockTM, WithAgentCard(agentCard))
 	require.NoError(t, err)
 	testServer := httptest.NewServer(http.HandlerFunc(a2aServer.handleAgentCard))
 	defer testServer.Close()
@@ -154,7 +155,7 @@ func TestA2AServer_shutdownTelemetry(t *testing.T) {
 
 func TestA2AServer_Start_ShutdownTelemetryOnListenError(t *testing.T) {
 	provider := &shutdownAwareMeterProvider{MeterProvider: noop.NewMeterProvider()}
-	srv, err := NewA2AServer(defaultAgentCard(), newMockTaskManager())
+	srv, err := NewA2AServer(newMockTaskManager(), WithAgentCard(defaultAgentCard()))
 	require.NoError(t, err)
 	srv.telemetryMeterProvider = provider
 	srv.telemetryOwnsProvider = true
@@ -206,7 +207,7 @@ func TestA2AServer_InitTelemetry_WithInjectedProvider(t *testing.T) {
 func TestA2AServer_HandleJSONRPC_Methods(t *testing.T) {
 	mockTM := newMockTaskManager()
 	agentCard := defaultAgentCard()
-	a2aServer, err := NewA2AServer(agentCard, mockTM)
+	a2aServer, err := NewA2AServer(mockTM, WithAgentCard(agentCard))
 	require.NoError(t, err)
 	testServer := httptest.NewServer(http.HandlerFunc(a2aServer.handleJSONRPC))
 	defer testServer.Close()
@@ -347,7 +348,7 @@ func TestA2AServer_HandleJSONRPC_Methods(t *testing.T) {
 func TestA2ASrv_HandleMessageStream_SSE(t *testing.T) {
 	mockTM := newMockTaskManager()
 	agentCard := defaultAgentCard()
-	a2aServer, err := NewA2AServer(agentCard, mockTM)
+	a2aServer, err := NewA2AServer(mockTM, WithAgentCard(agentCard))
 	require.NoError(t, err)
 	testServer := httptest.NewServer(http.HandlerFunc(a2aServer.handleJSONRPC))
 	defer testServer.Close()
@@ -821,7 +822,7 @@ func TestServer_WithPushNotificationAuthenticator(t *testing.T) {
 
 	// Create a task processor and manager
 	processor := &mockProcessor{}
-	tm, err := taskmanager.NewMemoryTaskManager(processor)
+	tm, err := memory.NewTaskManager(processor)
 	require.NoError(t, err)
 
 	// Create server with authenticator
@@ -831,8 +832,8 @@ func TestServer_WithPushNotificationAuthenticator(t *testing.T) {
 	}
 
 	server, err := NewA2AServer(
-		card,
 		tm,
+		WithAgentCard(card),
 		WithPushNotificationAuthenticator(authenticator),
 	)
 	require.NoError(t, err)
@@ -919,7 +920,7 @@ func TestA2AServer_HandleAgentGetAuthenticatedExtendedCard(t *testing.T) {
 			agentCard := defaultAgentCard()
 			agentCard.SupportsAuthenticatedExtendedCard = tt.supportsExtendedCard
 
-			a2aServer, err := NewA2AServer(agentCard, mockTM)
+			a2aServer, err := NewA2AServer(mockTM, WithAgentCard(agentCard))
 			require.NoError(t, err)
 
 			if tt.authenticatedCardHandler != nil {
@@ -1012,7 +1013,7 @@ func TestA2AServer_ComposeJWKSURL(t *testing.T) {
 			agentCard := defaultAgentCard()
 			agentCard.URL = tt.agentCardURL
 
-			a2aServer, err := NewA2AServer(agentCard, mockTM)
+			a2aServer, err := NewA2AServer(mockTM, WithAgentCard(agentCard))
 			require.NoError(t, err)
 			a2aServer.jwksEndpoint = tt.jwksEndpoint
 
@@ -1046,7 +1047,7 @@ func TestCompatHandler_CoveredByMiddleware(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	srv, err := NewA2AServer(defaultAgentCard(), mockTM,
+	srv, err := NewA2AServer(mockTM, WithAgentCard(defaultAgentCard()),
 		WithMiddleWare(blockMiddleware{}),
 		WithCompatHandler(compat),
 	)
@@ -1084,7 +1085,7 @@ func TestServer_BasePathFromSupportedInterfaces(t *testing.T) {
 		DefaultInputModes:  []string{"text"},
 		DefaultOutputModes: []string{"text"},
 	}
-	srv, err := NewA2AServer(card, newMockTaskManager())
+	srv, err := NewA2AServer(newMockTaskManager(), WithAgentCard(card))
 	require.NoError(t, err)
 	assert.Equal(t, "/agent/api/", srv.jsonRPCEndpoint,
 		"base path should come from SupportedInterfaces[0].URL")

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -217,7 +217,7 @@ func TestA2AServer_HandleJSONRPC_Methods(t *testing.T) {
 	// --- Test message/send ---
 	t.Run("message/send success", func(t *testing.T) {
 		mockTM.sendMessageResponse = &protocol.SendMessageResponse{
-			Message: &protocol.Message{
+			Result: &protocol.Message{
 				MessageID: "msg-1",
 				Role:      protocol.MessageRoleUser,
 				Parts:     []*protocol.Part{protocol.NewTextPart("Response message")},
@@ -239,11 +239,11 @@ func TestA2AServer_HandleJSONRPC_Methods(t *testing.T) {
 
 		// Remarshal result interface{} to bytes
 		resultBytes, err := json.Marshal(resp.Result)
-		require.NoError(t, err, "Failed to remarshal result for SendMessageResponse unmarshalling")
+		require.NoError(t, err, "Failed to remarshal result for MessageResult unmarshalling")
 		var resultMsg protocol.SendMessageResponse
 		err = json.Unmarshal(resultBytes, &resultMsg)
-		require.NoError(t, err, "Failed to unmarshal SendMessageResponse from remarshalled result")
-		assert.True(t, resultMsg.Message != nil || resultMsg.Task != nil)
+		require.NoError(t, err, "Failed to unmarshal MessageResult from remarshalled result")
+		assert.True(t, resultMsg.GetMessage() != nil || resultMsg.GetTask() != nil)
 	})
 
 	t.Run("message/send error", func(t *testing.T) {
@@ -381,9 +381,9 @@ func TestA2ASrv_HandleMessageStream_SSE(t *testing.T) {
 	}
 	// Configure mock events for message streaming
 	mockTM.sendMessageStreamEvents = []protocol.StreamResponse{
-		{StatusUpdate: &event1},
-		{ArtifactUpdate: &event2},
-		{StatusUpdate: &event3},
+		{Result: &event1},
+		{Result: &event2},
+		{Result: &event3},
 	}
 	mockTM.sendMessageStreamError = nil
 
@@ -453,7 +453,7 @@ func TestA2ASrv_HandleMessageStream_SSE(t *testing.T) {
 
 		var event protocol.StreamResponse
 		if err := json.Unmarshal(eventBytes, &event); err != nil {
-			t.Fatalf("Failed to unmarshal StreamResponse: %v. Data: %s", err, string(eventBytes))
+			t.Fatalf("Failed to unmarshal StreamingMessageEvent: %v. Data: %s", err, string(eventBytes))
 		}
 
 		receivedEvents = append(receivedEvents, event)
@@ -466,8 +466,8 @@ func TestA2ASrv_HandleMessageStream_SSE(t *testing.T) {
 	require.Greater(t, len(receivedEvents), 0, "Should have received at least one event")
 	var lastStatusEvent *protocol.TaskStatusUpdateEvent
 	for i := len(receivedEvents) - 1; i >= 0; i-- {
-		if receivedEvents[i].StatusUpdate != nil {
-			lastStatusEvent = receivedEvents[i].StatusUpdate
+		if receivedEvents[i].GetStatusUpdate() != nil {
+			lastStatusEvent = receivedEvents[i].GetStatusUpdate()
 			break
 		}
 	}
@@ -537,7 +537,7 @@ func (m *mockTaskManager) OnSendMessage(
 	// Default behavior: create a simple message response
 	msg := request.Message
 	return &protocol.SendMessageResponse{
-		Message: &msg,
+		Result: &msg,
 	}, nil
 }
 
@@ -575,7 +575,7 @@ func (m *mockTaskManager) OnSendMessageStream(
 		go func() {
 			defer close(eventCh)
 			event := protocol.StreamResponse{
-				Message: &msg,
+				Result: &msg,
 			}
 			select {
 			case <-ctx.Done():
@@ -739,7 +739,7 @@ func (m *mockTaskManager) OnResubscribe(
 		go func() {
 			defer close(eventCh)
 			streamEvent := protocol.StreamResponse{
-				StatusUpdate: &protocol.TaskStatusUpdateEvent{
+				Result: &protocol.TaskStatusUpdateEvent{
 					TaskID: params.ID,
 					Final:  true,
 					Status: protocol.TaskStatus{
@@ -799,7 +799,7 @@ func (m *mockProcessor) ProcessMessage(
 	// Simple echo processor for testing
 	msg := message
 	return &taskmanager.MessageProcessingResult{
-		Result: &protocol.SendMessageResponse{Message: &msg},
+		Result: &protocol.SendMessageResponse{Result: &msg},
 	}, nil
 }
 

--- a/server/tenant_test.go
+++ b/server/tenant_test.go
@@ -1,0 +1,96 @@
+// Tencent is pleased to support the open source community by making trpc-a2a-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-a2a-go is licensed under the Apache License Version 2.0.
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
+)
+
+// fetchCardName GETs the agent-card endpoint (optionally with ?tenant=) and
+// returns the HTTP status and the served card's Name.
+func fetchCardName(t *testing.T, base, tenant string) (int, string) {
+	t.Helper()
+	url := base + protocol.AgentCardPath
+	if tenant != "" {
+		url += "?tenant=" + tenant
+	}
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET card: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return resp.StatusCode, ""
+	}
+	var card AgentCard
+	if err := json.NewDecoder(resp.Body).Decode(&card); err != nil {
+		t.Fatalf("decode card: %v", err)
+	}
+	return resp.StatusCode, card.Name
+}
+
+// TestTenantCard_StaticRegistry verifies WithTenantCard: the agent-card endpoint
+// serves the right card per "?tenant=", the default card with no tenant, and 404
+// for an unknown tenant on a multi-tenant server.
+func TestTenantCard_StaticRegistry(t *testing.T) {
+	def := AgentCard{Name: "Default", URL: "http://localhost"}
+	srv, err := NewA2AServer(newMockTaskManager(), WithAgentCard(def),
+		WithTenantCard("chatAgent", AgentCard{Name: "ChatAgent"}),
+		WithTenantCard("workerAgent", AgentCard{Name: "WorkerAgent"}),
+	)
+	if err != nil {
+		t.Fatalf("NewA2AServer: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	if code, name := fetchCardName(t, ts.URL, "chatAgent"); code != 200 || name != "ChatAgent" {
+		t.Errorf("tenant=chatAgent: code=%d name=%q", code, name)
+	}
+	if code, name := fetchCardName(t, ts.URL, "workerAgent"); code != 200 || name != "WorkerAgent" {
+		t.Errorf("tenant=workerAgent: code=%d name=%q", code, name)
+	}
+	if code, name := fetchCardName(t, ts.URL, ""); code != 200 || name != "Default" {
+		t.Errorf("no tenant: code=%d name=%q, want Default", code, name)
+	}
+	if code, _ := fetchCardName(t, ts.URL, "ghost"); code != http.StatusNotFound {
+		t.Errorf("unknown tenant: code=%d, want 404", code)
+	}
+}
+
+// TestTenantCard_DynamicProvider verifies WithTenantCardProvider resolves tenants
+// not known at startup, and 404s on an unknown one.
+func TestTenantCard_DynamicProvider(t *testing.T) {
+	srv, err := NewA2AServer(newMockTaskManager(),
+		WithAgentCard(AgentCard{Name: "Default", URL: "http://localhost"}),
+		WithTenantCardProvider(func(_ context.Context, tenant string) (AgentCard, error) {
+			if tenant == "dyn-42" {
+				return AgentCard{Name: "Dynamic-" + tenant}, nil
+			}
+			return AgentCard{}, errors.New("unknown tenant")
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewA2AServer: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	if code, name := fetchCardName(t, ts.URL, "dyn-42"); code != 200 || name != "Dynamic-dyn-42" {
+		t.Errorf("dynamic tenant: code=%d name=%q", code, name)
+	}
+	if code, _ := fetchCardName(t, ts.URL, "nope"); code != http.StatusNotFound {
+		t.Errorf("unknown dynamic tenant: code=%d, want 404", code)
+	}
+}

--- a/taskmanager/errors.go
+++ b/taskmanager/errors.go
@@ -33,6 +33,8 @@ const (
 	ErrCodeContentTypeNotSupported                int = -32005 // Incompatible content types
 	ErrCodeInvalidAgentResponse                   int = -32006 // Invalid agent response
 	ErrCodeAuthenticatedExtendedCardNotConfigured int = -32007 // Authenticated extended card not configured
+	ErrCodeExtensionSupportRequired               int = -32008 // A required extension was not opted into by the client
+	ErrCodeVersionNotSupported                    int = -32009 // The requested A2A protocol version is not supported
 )
 
 // ErrCodePushNotificationNotConfigured is deprecated: Use ErrCodePushNotificationNotSupported instead
@@ -54,6 +56,10 @@ var (
 	ErrInvalidAgentResponseSentinel = errors.New("invalid agent response")
 	// ErrAuthenticatedExtendedCardNotConfiguredSentinel is a sentinel error for authenticated extended card not configured
 	ErrAuthenticatedExtendedCardNotConfiguredSentinel = errors.New("authenticated extended card not configured")
+	// ErrExtensionSupportRequiredSentinel is a sentinel error for a required extension not opted into
+	ErrExtensionSupportRequiredSentinel = errors.New("extension support required")
+	// ErrVersionNotSupportedSentinel is a sentinel error for an unsupported A2A protocol version
+	ErrVersionNotSupportedSentinel = errors.New("version not supported")
 )
 
 // A2A specific error functions
@@ -126,4 +132,24 @@ func ErrAuthenticatedExtendedCardNotConfigured() *jsonrpc.Error {
 		Message: "Authenticated extended card not configured",
 		Data:    "This agent does not have an authenticated extended card configured",
 	}).WithWrappedError(ErrAuthenticatedExtendedCardNotConfiguredSentinel)
+}
+
+// ErrExtensionSupportRequired creates a JSON-RPC error for a required extension the client did not opt into.
+// The returned error wraps ErrExtensionSupportRequiredSentinel for use with errors.Is().
+func ErrExtensionSupportRequired(extensionURI string) *jsonrpc.Error {
+	return (&jsonrpc.Error{
+		Code:    ErrCodeExtensionSupportRequired,
+		Message: "Extension support required",
+		Data:    fmt.Sprintf("Required extension '%s' was not opted into by the client", extensionURI),
+	}).WithWrappedError(ErrExtensionSupportRequiredSentinel)
+}
+
+// ErrVersionNotSupported creates a JSON-RPC error for an unsupported A2A protocol version.
+// The returned error wraps ErrVersionNotSupportedSentinel for use with errors.Is().
+func ErrVersionNotSupported(requested string) *jsonrpc.Error {
+	return (&jsonrpc.Error{
+		Code:    ErrCodeVersionNotSupported,
+		Message: "Version not supported",
+		Data:    fmt.Sprintf("Requested A2A protocol version '%s' is not supported by this agent", requested),
+	}).WithWrappedError(ErrVersionNotSupportedSentinel)
 }

--- a/taskmanager/interface.go
+++ b/taskmanager/interface.go
@@ -33,6 +33,12 @@ type ProcessOptions struct {
 	// If true, the user should return event streams through the StreamingEvents channel
 	// If false, the user should return a single result through Result
 	Streaming bool
+
+	// Tenant is the A2A v1.0 tenant the request is addressed to (from
+	// params.Tenant). It lets one process host multiple agents: the processor
+	// dispatches on it instead of relying on URL-path routing. Empty for
+	// single-agent / v0 requests.
+	Tenant string
 }
 
 // CancellableTask is a task that can be cancelled

--- a/taskmanager/interface.go
+++ b/taskmanager/interface.go
@@ -164,7 +164,7 @@ type TaskManager interface {
 	) (*protocol.SendMessageResponse, error)
 
 	// OnSendMessageStream handles a request corresponding to the 'message/stream' RPC method.
-	// It creates a new message and returns a channel for receiving StreamResponse updates (streaming).
+	// It creates a new message and returns a channel for receiving StreamingMessageEvent updates (streaming).
 	// It initiates asynchronous processing via the MessageProcessor.
 	// The channel will be closed when the message reaches a final state or an error occurs during setup/processing.
 	OnSendMessageStream(

--- a/taskmanager/list_tasks_test.go
+++ b/taskmanager/list_tasks_test.go
@@ -61,7 +61,7 @@ func TestTaskMatchesListFilter(t *testing.T) {
 	}
 }
 
-func ltIntPtr(i int) *int   { return &i }
+func ltIntPtr(i int) *int    { return &i }
 func ltBoolPtr(b bool) *bool { return &b }
 
 func ltSampleTasks() []*protocol.Task {

--- a/taskmanager/memory/memory.go
+++ b/taskmanager/memory/memory.go
@@ -6,7 +6,7 @@
 
 // Package messageprocessor provides implementations for processing A2A messages.
 
-package taskmanager
+package memory
 
 import (
 	"context"
@@ -17,6 +17,7 @@ import (
 
 	"trpc.group/trpc-go/trpc-a2a-go/v2/log"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
 )
 
 const defaultMaxHistoryLength = 100
@@ -33,17 +34,17 @@ type ConversationHistory struct {
 	LastAccessTime time.Time
 }
 
-// MemoryCancellableTask is a task that can be cancelled
-type MemoryCancellableTask struct {
+// CancellableTask is a task that can be cancelled
+type CancellableTask struct {
 	task       protocol.Task
 	cancelFunc context.CancelFunc
 	ctx        context.Context
 }
 
 // NewCancellableTask creates a new cancellable task
-func NewCancellableTask(task protocol.Task) *MemoryCancellableTask {
+func NewCancellableTask(task protocol.Task) *CancellableTask {
 	cancelCtx, cancel := context.WithCancel(context.Background())
-	return &MemoryCancellableTask{
+	return &CancellableTask{
 		task:       task,
 		cancelFunc: cancel,
 		ctx:        cancelCtx,
@@ -51,56 +52,56 @@ func NewCancellableTask(task protocol.Task) *MemoryCancellableTask {
 }
 
 // Cancel cancels the task
-func (t *MemoryCancellableTask) Cancel() {
+func (t *CancellableTask) Cancel() {
 	t.cancelFunc()
 }
 
 // Task returns the task
-func (t *MemoryCancellableTask) Task() *protocol.Task {
+func (t *CancellableTask) Task() *protocol.Task {
 	return &t.task
 }
 
-// MemoryTaskSubscriberOpts is the options for the MemoryTaskSubscriber
-type MemoryTaskSubscriberOpts struct {
+// TaskSubscriberOpts is the options for the TaskSubscriber
+type TaskSubscriberOpts struct {
 	sendHook     func(event protocol.StreamResponse) error
 	blockingSend bool
 }
 
-// MemoryTaskSubscriberOption is the option for the MemoryTaskSubscriber
-type MemoryTaskSubscriberOption func(s *MemoryTaskSubscriberOpts)
+// TaskSubscriberOption is the option for the TaskSubscriber
+type TaskSubscriberOption func(s *TaskSubscriberOpts)
 
 // WithSubscriberSendHook sets the send hook for the task subscriber
-func WithSubscriberSendHook(hook func(event protocol.StreamResponse) error) MemoryTaskSubscriberOption {
-	return func(s *MemoryTaskSubscriberOpts) {
+func WithSubscriberSendHook(hook func(event protocol.StreamResponse) error) TaskSubscriberOption {
+	return func(s *TaskSubscriberOpts) {
 		s.sendHook = hook
 	}
 }
 
 // WithSubscriberBlockingSend sets the blocking send flag for the task subscriber
-func WithSubscriberBlockingSend(blockingSend bool) MemoryTaskSubscriberOption {
-	return func(s *MemoryTaskSubscriberOpts) {
+func WithSubscriberBlockingSend(blockingSend bool) TaskSubscriberOption {
+	return func(s *TaskSubscriberOpts) {
 		s.blockingSend = blockingSend
 	}
 }
 
-// MemoryTaskSubscriber is a subscriber for a task
-type MemoryTaskSubscriber struct {
+// TaskSubscriber is a subscriber for a task
+type TaskSubscriber struct {
 	taskID         string
 	eventQueue     chan protocol.StreamResponse
 	done           chan struct{}
 	lastAccessTime time.Time
 	closed         atomic.Bool
 	mu             sync.RWMutex
-	opts           MemoryTaskSubscriberOpts
+	opts           TaskSubscriberOpts
 }
 
-// NewMemoryTaskSubscriber creates a new task subscriber with specified buffer length
-func NewMemoryTaskSubscriber(
+// NewTaskSubscriber creates a new task subscriber with specified buffer length
+func NewTaskSubscriber(
 	taskID string,
 	bufSize int,
-	opts ...MemoryTaskSubscriberOption,
-) *MemoryTaskSubscriber {
-	subscriberOpts := MemoryTaskSubscriberOpts{
+	opts ...TaskSubscriberOption,
+) *TaskSubscriber {
+	subscriberOpts := TaskSubscriberOpts{
 		sendHook: nil,
 	}
 	for _, opt := range opts {
@@ -111,7 +112,7 @@ func NewMemoryTaskSubscriber(
 		bufSize = defaultSubscriberBufferSize // default buffer size
 	}
 	eventQueue := make(chan protocol.StreamResponse, bufSize)
-	return &MemoryTaskSubscriber{
+	return &TaskSubscriber{
 		taskID:         taskID,
 		eventQueue:     eventQueue,
 		done:           make(chan struct{}),
@@ -122,7 +123,7 @@ func NewMemoryTaskSubscriber(
 }
 
 // Close closes the task subscriber
-func (s *MemoryTaskSubscriber) Close() {
+func (s *TaskSubscriber) Close() {
 	if !s.closed.CompareAndSwap(false, true) {
 		return
 	}
@@ -134,17 +135,17 @@ func (s *MemoryTaskSubscriber) Close() {
 }
 
 // Channel returns the channel of the task subscriber
-func (s *MemoryTaskSubscriber) Channel() <-chan protocol.StreamResponse {
+func (s *TaskSubscriber) Channel() <-chan protocol.StreamResponse {
 	return s.eventQueue
 }
 
 // Closed returns true if the task subscriber is closed
-func (s *MemoryTaskSubscriber) Closed() bool {
+func (s *TaskSubscriber) Closed() bool {
 	return s.closed.Load()
 }
 
 // Send sends an event to the task subscriber
-func (s *MemoryTaskSubscriber) Send(event protocol.StreamResponse) error {
+func (s *TaskSubscriber) Send(event protocol.StreamResponse) error {
 	if s.Closed() {
 		return fmt.Errorf("task subscriber is closed")
 	}
@@ -183,19 +184,19 @@ func (s *MemoryTaskSubscriber) Send(event protocol.StreamResponse) error {
 }
 
 // GetLastAccessTime returns the last access time
-func (s *MemoryTaskSubscriber) GetLastAccessTime() time.Time {
+func (s *TaskSubscriber) GetLastAccessTime() time.Time {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.lastAccessTime
 }
 
-// MemoryTaskManager is the implementation of the MemoryTaskManager interface
-type MemoryTaskManager struct {
+// TaskManager is the implementation of the TaskManager interface
+type TaskManager struct {
 	// mu protects the following fields
 	mu sync.RWMutex
 
 	// Processor is the user-provided message Processor
-	Processor MessageProcessor
+	Processor taskmanager.MessageProcessor
 
 	// Messages stores all Messages, indexed by messageID
 	// key: messageID, value: Message
@@ -210,7 +211,7 @@ type MemoryTaskManager struct {
 
 	// Tasks stores the task information, indexed by taskID
 	// key: taskID, value: Task
-	Tasks map[string]*MemoryCancellableTask
+	Tasks map[string]*CancellableTask
 
 	// taskMu protects the Tasks field
 	taskMu sync.RWMutex
@@ -218,14 +219,14 @@ type MemoryTaskManager struct {
 	// Subscribers stores the task subscribers
 	// key: taskID, value: TaskSubscriber list
 	// supports all event types: Message, Task, TaskStatusUpdateEvent, TaskArtifactUpdateEvent
-	Subscribers map[string][]*MemoryTaskSubscriber
+	Subscribers map[string][]*TaskSubscriber
 
 	// PushNotifications stores the push notification configurations
 	// key: taskID, value: push notification configuration
 	PushNotifications map[string]protocol.TaskPushNotificationConfig
 
 	// options
-	options *MemoryTaskManagerOptions
+	options *TaskManagerOptions
 
 	// stopCleanup signals the cleanup goroutine to stop
 	stopCleanup chan struct{}
@@ -234,26 +235,26 @@ type MemoryTaskManager struct {
 	closeOnce sync.Once
 }
 
-// NewMemoryTaskManager creates a new MemoryTaskManager instance
-func NewMemoryTaskManager(processor MessageProcessor, opts ...MemoryTaskManagerOption) (*MemoryTaskManager, error) {
+// NewTaskManager creates a new TaskManager instance
+func NewTaskManager(processor taskmanager.MessageProcessor, opts ...TaskManagerOption) (*TaskManager, error) {
 	if processor == nil {
 		return nil, fmt.Errorf("processor cannot be nil")
 	}
 
 	// Apply default options
-	options := DefaultMemoryTaskManagerOptions()
+	options := DefaultTaskManagerOptions()
 
 	// Apply user options
 	for _, opt := range opts {
 		opt(options)
 	}
 
-	manager := &MemoryTaskManager{
+	manager := &TaskManager{
 		Processor:         processor,
 		Messages:          make(map[string]protocol.Message),
 		Conversations:     make(map[string]*ConversationHistory),
-		Tasks:             make(map[string]*MemoryCancellableTask),
-		Subscribers:       make(map[string][]*MemoryTaskSubscriber),
+		Tasks:             make(map[string]*CancellableTask),
+		Subscribers:       make(map[string][]*TaskSubscriber),
 		PushNotifications: make(map[string]protocol.TaskPushNotificationConfig),
 		options:           options,
 		stopCleanup:       make(chan struct{}),
@@ -287,11 +288,11 @@ func NewMemoryTaskManager(processor MessageProcessor, opts ...MemoryTaskManagerO
 // =============================================================================
 
 // OnSendMessage handles the message/tasks request
-func (m *MemoryTaskManager) OnSendMessage(
+func (m *TaskManager) OnSendMessage(
 	ctx context.Context,
 	request protocol.SendMessageParams,
 ) (*protocol.SendMessageResponse, error) {
-	log.Debugf("MemoryTaskManager: OnSendMessage for message %s", request.Message.MessageID)
+	log.Debugf("TaskManager: OnSendMessage for message %s", request.Message.MessageID)
 
 	// process the request message
 	m.processRequestMessage(&request.Message)
@@ -299,9 +300,10 @@ func (m *MemoryTaskManager) OnSendMessage(
 	// process Configuration
 	options := m.processConfiguration(request.Configuration)
 	options.Streaming = false // non-streaming processing
+	options.Tenant = request.Tenant
 
 	// create MessageHandle
-	handle := &memoryTaskHandler{
+	handle := &taskHandler{
 		manager:                m,
 		messageID:              request.Message.MessageID,
 		ctx:                    ctx,
@@ -336,20 +338,21 @@ func (m *MemoryTaskManager) OnSendMessage(
 }
 
 // OnSendMessageStream handles message/stream requests
-func (m *MemoryTaskManager) OnSendMessageStream(
+func (m *TaskManager) OnSendMessageStream(
 	ctx context.Context,
 	request protocol.SendMessageParams,
 ) (<-chan protocol.StreamResponse, error) {
-	log.Debugf("MemoryTaskManager: OnSendMessageStream for message %s", request.Message.MessageID)
+	log.Debugf("TaskManager: OnSendMessageStream for message %s", request.Message.MessageID)
 
 	m.processRequestMessage(&request.Message)
 
 	// Process Configuration
 	options := m.processConfiguration(request.Configuration)
 	options.Streaming = true // streaming mode
+	options.Tenant = request.Tenant
 
 	// Create streaming MessageHandle
-	handle := &memoryTaskHandler{
+	handle := &taskHandler{
 		manager:                m,
 		messageID:              request.Message.MessageID,
 		ctx:                    ctx,
@@ -371,12 +374,12 @@ func (m *MemoryTaskManager) OnSendMessageStream(
 }
 
 // OnGetTask handles the tasks/get request
-func (m *MemoryTaskManager) OnGetTask(ctx context.Context, params protocol.TaskQueryParams) (*protocol.Task, error) {
+func (m *TaskManager) OnGetTask(ctx context.Context, params protocol.TaskQueryParams) (*protocol.Task, error) {
 	m.taskMu.RLock()
 	task, exists := m.Tasks[params.ID]
 	if !exists {
 		m.taskMu.RUnlock()
-		return nil, ErrTaskNotFound(params.ID)
+		return nil, taskmanager.ErrTaskNotFound(params.ID)
 	}
 
 	// return a copy of the task
@@ -402,18 +405,18 @@ func (m *MemoryTaskManager) OnGetTask(ctx context.Context, params protocol.TaskQ
 }
 
 // OnCancelTask handles the tasks/cancel request
-func (m *MemoryTaskManager) OnCancelTask(ctx context.Context, params protocol.TaskIDParams) (*protocol.Task, error) {
+func (m *TaskManager) OnCancelTask(ctx context.Context, params protocol.TaskIDParams) (*protocol.Task, error) {
 	m.taskMu.Lock()
 	task, exists := m.Tasks[params.ID]
 	if !exists {
 		m.taskMu.Unlock()
-		return nil, ErrTaskNotFound(params.ID)
+		return nil, taskmanager.ErrTaskNotFound(params.ID)
 	}
 
 	taskCopy := *task.Task()
 	m.taskMu.Unlock()
 
-	handle := &memoryTaskHandler{
+	handle := &taskHandler{
 		manager:                m,
 		ctx:                    ctx,
 		subscriberBufSize:      m.options.TaskSubscriberBufSize,
@@ -427,7 +430,7 @@ func (m *MemoryTaskManager) OnCancelTask(ctx context.Context, params protocol.Ta
 }
 
 // OnPushNotificationSet handles tasks/pushNotificationConfig/set requests
-func (m *MemoryTaskManager) OnPushNotificationSet(
+func (m *TaskManager) OnPushNotificationSet(
 	ctx context.Context,
 	params protocol.TaskPushNotificationConfig,
 ) (*protocol.TaskPushNotificationConfig, error) {
@@ -436,12 +439,12 @@ func (m *MemoryTaskManager) OnPushNotificationSet(
 
 	// Store push notification configuration
 	m.PushNotifications[params.TaskID] = params
-	log.Debugf("MemoryTaskManager: Push notification config set for task %s", params.TaskID)
+	log.Debugf("TaskManager: Push notification config set for task %s", params.TaskID)
 	return &params, nil
 }
 
 // OnPushNotificationGet handles tasks/pushNotificationConfig/get requests
-func (m *MemoryTaskManager) OnPushNotificationGet(
+func (m *TaskManager) OnPushNotificationGet(
 	ctx context.Context,
 	params protocol.TaskIDParams,
 ) (*protocol.TaskPushNotificationConfig, error) {
@@ -450,7 +453,7 @@ func (m *MemoryTaskManager) OnPushNotificationGet(
 
 	config, exists := m.PushNotifications[params.ID]
 	if !exists {
-		return nil, ErrTaskNotFound(params.ID)
+		return nil, taskmanager.ErrTaskNotFound(params.ID)
 	}
 
 	return &config, nil
@@ -461,32 +464,32 @@ func (m *MemoryTaskManager) OnPushNotificationGet(
 const unlimitedHistoryLength = 1 << 30
 
 // OnListTasks handles the v1.0 ListTasks request with filtering and offset-based pagination.
-func (m *MemoryTaskManager) OnListTasks(
+func (m *TaskManager) OnListTasks(
 	ctx context.Context,
 	params protocol.ListTasksParams,
 ) (*protocol.ListTasksResult, error) {
-	afterTime, err := ParseListTasksStatusTimestampAfter(params.StatusTimestampAfter)
+	afterTime, err := taskmanager.ParseListTasksStatusTimestampAfter(params.StatusTimestampAfter)
 	if err != nil {
 		return nil, err
 	}
 
-	// Hold the read lock through pagination: PaginateTasks copies each returned
+	// Hold the read lock through pagination: taskmanager.PaginateTasks copies each returned
 	// task, so the lock guards those copies against concurrent mutation.
 	m.taskMu.RLock()
 	defer m.taskMu.RUnlock()
 	var filtered []*protocol.Task
 	for _, ct := range m.Tasks {
-		if task := ct.Task(); TaskMatchesListFilter(task, params, afterTime) {
+		if task := ct.Task(); taskmanager.TaskMatchesListFilter(task, params, afterTime) {
 			filtered = append(filtered, task)
 		}
 	}
-	return PaginateTasks(filtered, params)
+	return taskmanager.PaginateTasks(filtered, params)
 }
 
 // OnPushNotificationList handles the v1.0 ListTaskPushNotificationConfigs request.
 // The in-memory manager stores at most one configuration per task, so the result
 // contains zero or one entries.
-func (m *MemoryTaskManager) OnPushNotificationList(
+func (m *TaskManager) OnPushNotificationList(
 	ctx context.Context,
 	params protocol.ListTaskPushNotificationConfigsParams,
 ) (*protocol.ListTaskPushNotificationConfigsResult, error) {
@@ -504,7 +507,7 @@ func (m *MemoryTaskManager) OnPushNotificationList(
 
 // OnPushNotificationDelete handles the v1.0 DeleteTaskPushNotificationConfig request.
 // Deleting a non-existent configuration is a no-op.
-func (m *MemoryTaskManager) OnPushNotificationDelete(
+func (m *TaskManager) OnPushNotificationDelete(
 	ctx context.Context,
 	params protocol.DeleteTaskPushNotificationConfigParams,
 ) error {
@@ -512,12 +515,12 @@ func (m *MemoryTaskManager) OnPushNotificationDelete(
 	defer m.mu.Unlock()
 
 	delete(m.PushNotifications, params.TaskID)
-	log.Debugf("MemoryTaskManager: Push notification config deleted for task %s", params.TaskID)
+	log.Debugf("TaskManager: Push notification config deleted for task %s", params.TaskID)
 	return nil
 }
 
 // OnResubscribe handles tasks/resubscribe requests
-func (m *MemoryTaskManager) OnResubscribe(
+func (m *TaskManager) OnResubscribe(
 	ctx context.Context,
 	params protocol.TaskIDParams,
 ) (<-chan protocol.StreamResponse, error) {
@@ -525,9 +528,16 @@ func (m *MemoryTaskManager) OnResubscribe(
 	defer m.taskMu.Unlock()
 
 	// Check if task exists
-	_, exists := m.Tasks[params.ID]
+	task, exists := m.Tasks[params.ID]
 	if !exists {
-		return nil, ErrTaskNotFound(params.ID)
+		return nil, taskmanager.ErrTaskNotFound(params.ID)
+	}
+
+	// v1.0: a subscription is only valid for a non-terminal task; a task already
+	// in a terminal state must be rejected with UnsupportedOperationError.
+	if isFinalState(task.Task().Status.State) {
+		return nil, taskmanager.ErrUnsupportedOperation(
+			fmt.Sprintf("subscribe to task %s in terminal state %s", params.ID, task.Task().Status.State))
 	}
 
 	bufSize := m.options.TaskSubscriberBufSize
@@ -535,16 +545,25 @@ func (m *MemoryTaskManager) OnResubscribe(
 		bufSize = defaultSubscriberBufferSize
 	}
 
-	subscriber := NewMemoryTaskSubscriber(
+	subscriber := NewTaskSubscriber(
 		params.ID,
 		bufSize,
 		WithSubscriberBlockingSend(m.options.TaskSubscriberBlockingSend),
 		WithSubscriberSendHook(m.sendStreamingEventHook(params.ID)),
 	)
 
+	// v1.0: the first stream event must be the current Task snapshot. Send it
+	// before publishing the subscriber so it always precedes live updates (we
+	// hold taskMu, so notifySubscribers cannot interleave).
+	snapshot := *task.Task()
+	if err := subscriber.Send(protocol.StreamResponse{Task: &snapshot}); err != nil {
+		subscriber.Close()
+		return nil, err
+	}
+
 	// Add to subscribers list
 	if _, exists := m.Subscribers[params.ID]; !exists {
-		m.Subscribers[params.ID] = make([]*MemoryTaskSubscriber, 0)
+		m.Subscribers[params.ID] = make([]*TaskSubscriber, 0)
 	}
 	m.Subscribers[params.ID] = append(m.Subscribers[params.ID], subscriber)
 
@@ -556,7 +575,7 @@ func (m *MemoryTaskManager) OnResubscribe(
 // =============================================================================
 
 // storeMessage stores messages
-func (m *MemoryTaskManager) storeMessage(message protocol.Message) {
+func (m *TaskManager) storeMessage(message protocol.Message) {
 	m.conversationMu.Lock()
 	defer m.conversationMu.Unlock()
 
@@ -590,7 +609,7 @@ func (m *MemoryTaskManager) storeMessage(message protocol.Message) {
 }
 
 // getConversationHistory gets conversation history of specified length
-func (m *MemoryTaskManager) getConversationHistory(contextID string, length int) []protocol.Message {
+func (m *TaskManager) getConversationHistory(contextID string, length int) []protocol.Message {
 	m.conversationMu.RLock()
 	defer m.conversationMu.RUnlock()
 
@@ -628,8 +647,8 @@ func isFinalState(state protocol.TaskState) bool {
 // =============================================================================
 
 // processConfiguration processes and normalizes Configuration
-func (m *MemoryTaskManager) processConfiguration(config *protocol.SendMessageConfiguration) ProcessOptions {
-	result := ProcessOptions{
+func (m *TaskManager) processConfiguration(config *protocol.SendMessageConfiguration) taskmanager.ProcessOptions {
+	result := taskmanager.ProcessOptions{
 		// v1.0 default: returnImmediately=false means the request blocks until a
 		// terminal/interrupted state, so a missing configuration is blocking.
 		Blocking:      true,
@@ -662,7 +681,7 @@ func (m *MemoryTaskManager) processConfiguration(config *protocol.SendMessageCon
 }
 
 // processRequestMessage processes the request message, add messageID and contextID if not set
-func (m *MemoryTaskManager) processRequestMessage(message *protocol.Message) {
+func (m *TaskManager) processRequestMessage(message *protocol.Message) {
 	if message.MessageID == "" {
 		message.MessageID = protocol.GenerateMessageID()
 	}
@@ -676,7 +695,7 @@ func (m *MemoryTaskManager) processRequestMessage(message *protocol.Message) {
 }
 
 // sendStreamingEventHook is a hook for sending streaming events
-func (m *MemoryTaskManager) sendStreamingEventHook(ctxID string) func(event protocol.StreamResponse) error {
+func (m *TaskManager) sendStreamingEventHook(ctxID string) func(event protocol.StreamResponse) error {
 	return func(event protocol.StreamResponse) error {
 		if event.StatusUpdate != nil && event.StatusUpdate.ContextID == "" {
 			event.StatusUpdate.ContextID = ctxID
@@ -695,7 +714,7 @@ func (m *MemoryTaskManager) sendStreamingEventHook(ctxID string) func(event prot
 }
 
 // processReplyMessage processes the reply message, add messageID and contextID if not set
-func (m *MemoryTaskManager) processReplyMessage(ctxID *string, message *protocol.Message) {
+func (m *TaskManager) processReplyMessage(ctxID *string, message *protocol.Message) {
 	message.ContextID = ctxID
 	message.Role = protocol.MessageRoleAgent
 
@@ -711,7 +730,7 @@ func (m *MemoryTaskManager) processReplyMessage(ctxID *string, message *protocol
 	m.storeMessage(*message)
 }
 
-func (m *MemoryTaskManager) checkTaskExists(taskID string) bool {
+func (m *TaskManager) checkTaskExists(taskID string) bool {
 	m.taskMu.RLock()
 	defer m.taskMu.RUnlock()
 	_, exists := m.Tasks[taskID]
@@ -719,7 +738,7 @@ func (m *MemoryTaskManager) checkTaskExists(taskID string) bool {
 }
 
 // notifySubscribers notifies all subscribers of the task
-func (m *MemoryTaskManager) notifySubscribers(taskID string, event protocol.StreamResponse) {
+func (m *TaskManager) notifySubscribers(taskID string, event protocol.StreamResponse) {
 	m.taskMu.RLock()
 	subs, exists := m.Subscribers[taskID]
 	if !exists || len(subs) == 0 {
@@ -727,13 +746,13 @@ func (m *MemoryTaskManager) notifySubscribers(taskID string, event protocol.Stre
 		return
 	}
 
-	subsCopy := make([]*MemoryTaskSubscriber, len(subs))
+	subsCopy := make([]*TaskSubscriber, len(subs))
 	copy(subsCopy, subs)
 	m.taskMu.RUnlock()
 
 	log.Debugf("Notifying %d subscribers for task %s", len(subsCopy), taskID)
 
-	var failedSubscribers []*MemoryTaskSubscriber
+	var failedSubscribers []*TaskSubscriber
 
 	for _, sub := range subsCopy {
 		if sub.Closed() {
@@ -756,7 +775,7 @@ func (m *MemoryTaskManager) notifySubscribers(taskID string, event protocol.Stre
 }
 
 // cleanupFailedSubscribers cleans up failed or closed subscribers
-func (m *MemoryTaskManager) cleanupFailedSubscribers(taskID string, failedSubscribers []*MemoryTaskSubscriber) {
+func (m *TaskManager) cleanupFailedSubscribers(taskID string, failedSubscribers []*TaskSubscriber) {
 	m.taskMu.Lock()
 
 	subs, exists := m.Subscribers[taskID]
@@ -766,8 +785,8 @@ func (m *MemoryTaskManager) cleanupFailedSubscribers(taskID string, failedSubscr
 	}
 
 	// Filter out failed subscribers
-	filteredSubs := make([]*MemoryTaskSubscriber, 0, len(subs))
-	removedSubs := make([]*MemoryTaskSubscriber, 0, len(failedSubscribers))
+	filteredSubs := make([]*TaskSubscriber, 0, len(subs))
+	removedSubs := make([]*TaskSubscriber, 0, len(failedSubscribers))
 
 	for _, sub := range subs {
 		shouldRemove := false
@@ -800,7 +819,7 @@ func (m *MemoryTaskManager) cleanupFailedSubscribers(taskID string, failedSubscr
 }
 
 // cleanSubscribers closes and removes all subscribers for a task.
-func (m *MemoryTaskManager) cleanSubscribers(taskID string) {
+func (m *TaskManager) cleanSubscribers(taskID string) {
 	m.taskMu.Lock()
 
 	subs, exists := m.Subscribers[taskID]
@@ -818,19 +837,19 @@ func (m *MemoryTaskManager) cleanSubscribers(taskID string) {
 }
 
 // addSubscriber adds a subscriber
-func (m *MemoryTaskManager) addSubscriber(taskID string, sub *MemoryTaskSubscriber) {
+func (m *TaskManager) addSubscriber(taskID string, sub *TaskSubscriber) {
 	m.taskMu.Lock()
 	defer m.taskMu.Unlock()
 
 	if _, exists := m.Subscribers[taskID]; !exists {
-		m.Subscribers[taskID] = make([]*MemoryTaskSubscriber, 0)
+		m.Subscribers[taskID] = make([]*TaskSubscriber, 0)
 	}
 	m.Subscribers[taskID] = append(m.Subscribers[taskID], sub)
 }
 
 // CleanExpiredConversations cleans up expired conversation history
 // maxAge: the maximum lifetime of the conversation, conversations not accessed beyond this time will be cleaned up
-func (m *MemoryTaskManager) CleanExpiredConversations(maxAge time.Duration) int {
+func (m *TaskManager) CleanExpiredConversations(maxAge time.Duration) int {
 	m.conversationMu.Lock()
 	defer m.conversationMu.Unlock()
 
@@ -867,7 +886,7 @@ func (m *MemoryTaskManager) CleanExpiredConversations(maxAge time.Duration) int 
 // cleanExpiredTasks cleans up tasks that have been in a terminal state longer than maxAge.
 // It removes the task, its subscribers, and associated push notification configs.
 // A maxAge of 0 disables cleanup and returns immediately.
-func (m *MemoryTaskManager) cleanExpiredTasks(maxAge time.Duration) int {
+func (m *TaskManager) cleanExpiredTasks(maxAge time.Duration) int {
 	if maxAge <= 0 {
 		return 0
 	}
@@ -875,7 +894,7 @@ func (m *MemoryTaskManager) cleanExpiredTasks(maxAge time.Duration) int {
 
 	now := time.Now()
 	expiredTaskIDs := make([]string, 0)
-	subsToClose := make([]*MemoryTaskSubscriber, 0)
+	subsToClose := make([]*TaskSubscriber, 0)
 
 	for taskID, task := range m.Tasks {
 		if !isFinalState(task.Task().Status.State) {
@@ -930,7 +949,7 @@ func (m *MemoryTaskManager) cleanExpiredTasks(maxAge time.Duration) int {
 // It cancels any in-flight (non-terminal) tasks and closes their subscribers
 // without emitting a terminal event, so streaming clients observe the channel
 // close directly. It is safe to call Close multiple times; it always returns nil.
-func (m *MemoryTaskManager) Close() error {
+func (m *TaskManager) Close() error {
 	m.closeOnce.Do(func() {
 		// Signal the cleanup goroutine to stop and wait for it to exit so that no
 		// tick runs concurrently with the teardown below.
@@ -938,16 +957,16 @@ func (m *MemoryTaskManager) Close() error {
 		m.cleanupWg.Wait()
 
 		m.taskMu.Lock()
-		subsToClose := make([]*MemoryTaskSubscriber, 0)
+		subsToClose := make([]*TaskSubscriber, 0)
 		for _, subs := range m.Subscribers {
 			subsToClose = append(subsToClose, subs...)
 		}
-		m.Subscribers = make(map[string][]*MemoryTaskSubscriber)
+		m.Subscribers = make(map[string][]*TaskSubscriber)
 
 		for _, task := range m.Tasks {
 			task.Cancel()
 		}
-		m.Tasks = make(map[string]*MemoryCancellableTask)
+		m.Tasks = make(map[string]*CancellableTask)
 		m.taskMu.Unlock()
 
 		// Close subscribers outside taskMu so a stuck blocking send can never
@@ -960,7 +979,7 @@ func (m *MemoryTaskManager) Close() error {
 }
 
 // GetConversationStats gets conversation statistics
-func (m *MemoryTaskManager) GetConversationStats() map[string]interface{} {
+func (m *TaskManager) GetConversationStats() map[string]interface{} {
 	m.conversationMu.RLock()
 	defer m.conversationMu.RUnlock()
 

--- a/taskmanager/memory/memory.go
+++ b/taskmanager/memory/memory.go
@@ -330,8 +330,8 @@ func (m *TaskManager) OnSendMessage(
 		return nil, fmt.Errorf("processor returned nil result for non-streaming request")
 	}
 
-	if result.Result.Message != nil {
-		m.processReplyMessage(request.Message.ContextID, result.Result.Message)
+	if result.Result.GetMessage() != nil {
+		m.processReplyMessage(request.Message.ContextID, result.Result.GetMessage())
 	}
 
 	return result.Result, nil
@@ -556,7 +556,7 @@ func (m *TaskManager) OnResubscribe(
 	// before publishing the subscriber so it always precedes live updates (we
 	// hold taskMu, so notifySubscribers cannot interleave).
 	snapshot := *task.Task()
-	if err := subscriber.Send(protocol.StreamResponse{Task: &snapshot}); err != nil {
+	if err := subscriber.Send(protocol.StreamResponse{Result: &snapshot}); err != nil {
 		subscriber.Close()
 		return nil, err
 	}
@@ -697,17 +697,17 @@ func (m *TaskManager) processRequestMessage(message *protocol.Message) {
 // sendStreamingEventHook is a hook for sending streaming events
 func (m *TaskManager) sendStreamingEventHook(ctxID string) func(event protocol.StreamResponse) error {
 	return func(event protocol.StreamResponse) error {
-		if event.StatusUpdate != nil && event.StatusUpdate.ContextID == "" {
-			event.StatusUpdate.ContextID = ctxID
+		if event.GetStatusUpdate() != nil && event.GetStatusUpdate().ContextID == "" {
+			event.GetStatusUpdate().ContextID = ctxID
 		}
-		if event.ArtifactUpdate != nil && event.ArtifactUpdate.ContextID == "" {
-			event.ArtifactUpdate.ContextID = ctxID
+		if event.GetArtifactUpdate() != nil && event.GetArtifactUpdate().ContextID == "" {
+			event.GetArtifactUpdate().ContextID = ctxID
 		}
-		if event.Message != nil {
-			m.processReplyMessage(&ctxID, event.Message)
+		if event.GetMessage() != nil {
+			m.processReplyMessage(&ctxID, event.GetMessage())
 		}
-		if event.Task != nil && event.Task.ContextID == "" {
-			event.Task.ContextID = ctxID
+		if event.GetTask() != nil && event.GetTask().ContextID == "" {
+			event.GetTask().ContextID = ctxID
 		}
 		return nil
 	}

--- a/taskmanager/memory/memory_handler.go
+++ b/taskmanager/memory/memory_handler.go
@@ -4,7 +4,7 @@
 //
 // trpc-a2a-go is licensed under the Apache License Version 2.0.
 
-package taskmanager
+package memory
 
 import (
 	"context"
@@ -14,15 +14,16 @@ import (
 
 	"trpc.group/trpc-go/trpc-a2a-go/v2/log"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
 )
 
 // =============================================================================
 // MessageHandle Implementation
 // =============================================================================
 
-// memoryTaskHandler implements TaskHandler interface
-type memoryTaskHandler struct {
-	manager                *MemoryTaskManager
+// taskHandler implements taskmanager.TaskHandler interface
+type taskHandler struct {
+	manager                *TaskManager
 	messageID              string
 	metadata               map[string]interface{}
 	ctx                    context.Context
@@ -30,10 +31,10 @@ type memoryTaskHandler struct {
 	subscriberBlockingSend bool
 }
 
-var _ TaskHandler = (*memoryTaskHandler)(nil)
+var _ taskmanager.TaskHandler = (*taskHandler)(nil)
 
 // UpdateTaskState updates task state
-func (h *memoryTaskHandler) UpdateTaskState(
+func (h *taskHandler) UpdateTaskState(
 	taskID *string,
 	state protocol.TaskState,
 	message *protocol.Message,
@@ -47,7 +48,7 @@ func (h *memoryTaskHandler) UpdateTaskState(
 	if !exists {
 		h.manager.taskMu.Unlock()
 		log.Warnf("UpdateTaskState called for non-existent task %s", *taskID)
-		return ErrTaskNotFound(*taskID)
+		return taskmanager.ErrTaskNotFound(*taskID)
 	}
 
 	originalTask := task.Task()
@@ -82,12 +83,12 @@ func (h *memoryTaskHandler) UpdateTaskState(
 }
 
 // SubscribeTask subscribes to the task
-func (h *memoryTaskHandler) SubscribeTask(taskID *string) (TaskSubscriber, error) {
+func (h *taskHandler) SubscribeTask(taskID *string) (taskmanager.TaskSubscriber, error) {
 	if taskID == nil || *taskID == "" {
 		return nil, fmt.Errorf("taskID cannot be nil or empty")
 	}
 	if !h.manager.checkTaskExists(*taskID) {
-		return nil, ErrTaskNotFound(*taskID)
+		return nil, taskmanager.ErrTaskNotFound(*taskID)
 	}
 	ctxID := h.GetContextID()
 	sendHook := h.manager.sendStreamingEventHook(ctxID)
@@ -95,7 +96,7 @@ func (h *memoryTaskHandler) SubscribeTask(taskID *string) (TaskSubscriber, error
 	if bufSize <= 0 {
 		bufSize = defaultSubscriberBufferSize
 	}
-	subscriber := NewMemoryTaskSubscriber(
+	subscriber := NewTaskSubscriber(
 		*taskID,
 		bufSize,
 		WithSubscriberSendHook(sendHook),
@@ -106,7 +107,7 @@ func (h *memoryTaskHandler) SubscribeTask(taskID *string) (TaskSubscriber, error
 }
 
 // AddArtifact adds artifact to specified task
-func (h *memoryTaskHandler) AddArtifact(
+func (h *taskHandler) AddArtifact(
 	taskID *string,
 	artifact protocol.Artifact,
 	isFinal bool,
@@ -120,7 +121,7 @@ func (h *memoryTaskHandler) AddArtifact(
 	task, exists := h.manager.Tasks[*taskID]
 	if !exists {
 		h.manager.taskMu.Unlock()
-		return ErrTaskNotFound(*taskID)
+		return taskmanager.ErrTaskNotFound(*taskID)
 	}
 	task.Task().Artifacts = append(task.Task().Artifacts, artifact)
 	h.manager.taskMu.Unlock()
@@ -142,7 +143,7 @@ func (h *memoryTaskHandler) AddArtifact(
 }
 
 // GetTask gets task
-func (h *memoryTaskHandler) GetTask(taskID *string) (CancellableTask, error) {
+func (h *taskHandler) GetTask(taskID *string) (taskmanager.CancellableTask, error) {
 	if taskID == nil || *taskID == "" {
 		return nil, fmt.Errorf("taskID cannot be nil or empty")
 	}
@@ -152,7 +153,7 @@ func (h *memoryTaskHandler) GetTask(taskID *string) (CancellableTask, error) {
 
 	task, exists := h.manager.Tasks[*taskID]
 	if !exists {
-		return nil, ErrTaskNotFound(*taskID)
+		return nil, taskmanager.ErrTaskNotFound(*taskID)
 	}
 
 	// return task copy to avoid external modification
@@ -166,7 +167,7 @@ func (h *memoryTaskHandler) GetTask(taskID *string) (CancellableTask, error) {
 		copy(taskCopy.History, task.Task().History)
 	}
 
-	return &MemoryCancellableTask{
+	return &CancellableTask{
 		task:       taskCopy,
 		cancelFunc: task.cancelFunc,
 		ctx:        task.ctx,
@@ -174,7 +175,7 @@ func (h *memoryTaskHandler) GetTask(taskID *string) (CancellableTask, error) {
 }
 
 // GetContextID gets context ID
-func (h *memoryTaskHandler) GetContextID() string {
+func (h *taskHandler) GetContextID() string {
 	h.manager.conversationMu.RLock()
 	defer h.manager.conversationMu.RUnlock()
 
@@ -185,7 +186,7 @@ func (h *memoryTaskHandler) GetContextID() string {
 }
 
 // GetMetadata returns the metadata of the current request.
-func (h *memoryTaskHandler) GetMetadata() (map[string]interface{}, error) {
+func (h *taskHandler) GetMetadata() (map[string]interface{}, error) {
 	if h.metadata == nil {
 		return nil, errors.New("metadata is nil")
 	}
@@ -194,7 +195,7 @@ func (h *memoryTaskHandler) GetMetadata() (map[string]interface{}, error) {
 }
 
 // GetMessageHistory gets message history
-func (h *memoryTaskHandler) GetMessageHistory() []protocol.Message {
+func (h *taskHandler) GetMessageHistory() []protocol.Message {
 	h.manager.conversationMu.RLock()
 	defer h.manager.conversationMu.RUnlock()
 
@@ -226,7 +227,7 @@ func (h *memoryTaskHandler) GetMessageHistory() []protocol.Message {
 }
 
 // BuildTask creates a new task and returns task object
-func (h *memoryTaskHandler) BuildTask(specificTaskID *string, contextID *string) (string, error) {
+func (h *taskHandler) BuildTask(specificTaskID *string, contextID *string) (string, error) {
 	h.manager.taskMu.Lock()
 	defer h.manager.taskMu.Unlock()
 
@@ -275,7 +276,7 @@ func (h *memoryTaskHandler) BuildTask(specificTaskID *string, contextID *string)
 }
 
 // CancelTask cancels the task.
-func (h *memoryTaskHandler) CleanTask(taskID *string) error {
+func (h *taskHandler) CleanTask(taskID *string) error {
 	if taskID == nil || *taskID == "" {
 		return fmt.Errorf("taskID cannot be nil or empty")
 	}
@@ -284,7 +285,7 @@ func (h *memoryTaskHandler) CleanTask(taskID *string) error {
 	task, exists := h.manager.Tasks[*taskID]
 	if !exists {
 		h.manager.taskMu.Unlock()
-		return ErrTaskNotFound(*taskID)
+		return taskmanager.ErrTaskNotFound(*taskID)
 	}
 
 	// Cancel the task and remove from Tasks map while holding the lock

--- a/taskmanager/memory/memory_handler_test.go
+++ b/taskmanager/memory/memory_handler_test.go
@@ -4,7 +4,7 @@
 //
 // trpc-a2a-go is licensed under the Apache License Version 2.0.
 
-package taskmanager
+package memory
 
 import (
 	"context"
@@ -15,9 +15,9 @@ import (
 )
 
 // setupTestHandler creates a test handler for use in tests
-func setupTestHandler(t *testing.T) (*memoryTaskHandler, *MemoryTaskManager) {
+func setupTestHandler(t *testing.T) (*taskHandler, *TaskManager) {
 	processor := &MockMessageProcessor{}
-	manager, err := NewMemoryTaskManager(processor)
+	manager, err := NewTaskManager(processor)
 	if err != nil {
 		t.Fatalf("Failed to create manager: %v", err)
 	}
@@ -32,7 +32,7 @@ func setupTestHandler(t *testing.T) (*memoryTaskHandler, *MemoryTaskManager) {
 
 	manager.storeMessage(message)
 
-	handler := &memoryTaskHandler{
+	handler := &taskHandler{
 		manager:   manager,
 		messageID: message.MessageID,
 		ctx:       ctx,
@@ -214,7 +214,7 @@ func TestMemoryTaskHandler_GetMessageHistory(t *testing.T) {
 	manager.storeMessage(contextMessage)
 
 	// Create handler with context message
-	contextHandler := &memoryTaskHandler{
+	contextHandler := &taskHandler{
 		manager:   manager,
 		messageID: contextMessage.MessageID,
 		ctx:       context.Background(),
@@ -307,7 +307,7 @@ func TestMemoryTaskHandler_GetContextID(t *testing.T) {
 	manager.storeMessage(contextMessage)
 
 	// Create handler with context message
-	contextHandler := &memoryTaskHandler{
+	contextHandler := &taskHandler{
 		manager:   manager,
 		messageID: contextMessage.MessageID,
 		ctx:       context.Background(),
@@ -323,13 +323,13 @@ func TestMemoryTaskHandler_GetContextID(t *testing.T) {
 
 func TestTaskHandlerErrors(t *testing.T) {
 	processor := &MockMessageProcessor{}
-	manager, err := NewMemoryTaskManager(processor)
+	manager, err := NewTaskManager(processor)
 	if err != nil {
 		t.Fatalf("Failed to create manager: %v", err)
 	}
 
 	ctx := context.Background()
-	handler := &memoryTaskHandler{
+	handler := &taskHandler{
 		manager:   manager,
 		messageID: "non-existent-message",
 		ctx:       ctx,

--- a/taskmanager/memory/memory_options.go
+++ b/taskmanager/memory/memory_options.go
@@ -4,15 +4,15 @@
 //
 // trpc-a2a-go is licensed under the Apache License Version 2.0.
 
-// Package taskmanager provides configuration options for MemoryTaskManager.
-package taskmanager
+// Package taskmanager provides configuration options for TaskManager.
+package memory
 
 import (
 	"time"
 )
 
-// MemoryTaskManagerOptions contains configuration options for MemoryTaskManager.
-type MemoryTaskManagerOptions struct {
+// TaskManagerOptions contains configuration options for TaskManager.
+type TaskManagerOptions struct {
 	// MaxHistoryLength is the maximum number of messages to keep in conversation history.
 	MaxHistoryLength int
 
@@ -37,9 +37,9 @@ type MemoryTaskManagerOptions struct {
 	TaskSubscriberBlockingSend bool
 }
 
-// DefaultMemoryTaskManagerOptions returns the default configuration options.
-func DefaultMemoryTaskManagerOptions() *MemoryTaskManagerOptions {
-	return &MemoryTaskManagerOptions{
+// DefaultTaskManagerOptions returns the default configuration options.
+func DefaultTaskManagerOptions() *TaskManagerOptions {
+	return &TaskManagerOptions{
 		MaxHistoryLength:           defaultMaxHistoryLength,
 		ConversationTTL:            defaultConversationTTL,
 		TaskTTL:                    defaultTaskTTL,
@@ -50,12 +50,12 @@ func DefaultMemoryTaskManagerOptions() *MemoryTaskManagerOptions {
 	}
 }
 
-// MemoryTaskManagerOption defines a function type for configuring MemoryTaskManager.
-type MemoryTaskManagerOption func(*MemoryTaskManagerOptions)
+// TaskManagerOption defines a function type for configuring TaskManager.
+type TaskManagerOption func(*TaskManagerOptions)
 
 // WithMaxHistoryLength sets the maximum number of messages to keep in conversation history.
-func WithMaxHistoryLength(length int) MemoryTaskManagerOption {
-	return func(opts *MemoryTaskManagerOptions) {
+func WithMaxHistoryLength(length int) TaskManagerOption {
+	return func(opts *TaskManagerOptions) {
 		if length > 0 {
 			opts.MaxHistoryLength = length
 		}
@@ -65,8 +65,8 @@ func WithMaxHistoryLength(length int) MemoryTaskManagerOption {
 // WithConversationTTL sets the conversation TTL, enabling automatic cleanup.
 // ttl: the maximum lifetime of the conversation
 // cleanupInterval: the interval time for cleanup check
-func WithConversationTTL(ttl, cleanupInterval time.Duration) MemoryTaskManagerOption {
-	return func(opts *MemoryTaskManagerOptions) {
+func WithConversationTTL(ttl, cleanupInterval time.Duration) TaskManagerOption {
+	return func(opts *TaskManagerOptions) {
 		if ttl > 0 && cleanupInterval > 0 {
 			opts.ConversationTTL = ttl
 			opts.CleanupInterval = cleanupInterval
@@ -79,8 +79,8 @@ func WithConversationTTL(ttl, cleanupInterval time.Duration) MemoryTaskManagerOp
 // When enabled, tasks in terminal states (completed/failed/canceled/rejected) will be
 // automatically removed after the specified duration. A TTL of 0 disables task cleanup.
 // A positive ttl also enables the cleanup goroutine, mirroring WithConversationTTL.
-func WithTaskTTL(ttl time.Duration) MemoryTaskManagerOption {
-	return func(opts *MemoryTaskManagerOptions) {
+func WithTaskTTL(ttl time.Duration) TaskManagerOption {
+	return func(opts *TaskManagerOptions) {
 		opts.TaskTTL = ttl
 		if ttl > 0 {
 			opts.EnableCleanup = true
@@ -89,8 +89,8 @@ func WithTaskTTL(ttl time.Duration) MemoryTaskManagerOption {
 }
 
 // WithTaskSubscriberBufferSize sets the buffer size for task subscriber channels.
-func WithTaskSubscriberBufferSize(size int) MemoryTaskManagerOption {
-	return func(opts *MemoryTaskManagerOptions) {
+func WithTaskSubscriberBufferSize(size int) TaskManagerOption {
+	return func(opts *TaskManagerOptions) {
 		if size > 0 {
 			opts.TaskSubscriberBufSize = size
 		}
@@ -98,8 +98,8 @@ func WithTaskSubscriberBufferSize(size int) MemoryTaskManagerOption {
 }
 
 // WithTaskSubscriberBlockingSend sets the blocking send flag for the task subscriber
-func WithTaskSubscriberBlockingSend(blockingSend bool) MemoryTaskManagerOption {
-	return func(opts *MemoryTaskManagerOptions) {
+func WithTaskSubscriberBlockingSend(blockingSend bool) TaskManagerOption {
+	return func(opts *TaskManagerOptions) {
 		opts.TaskSubscriberBlockingSend = blockingSend
 	}
 }

--- a/taskmanager/memory/memory_test.go
+++ b/taskmanager/memory/memory_test.go
@@ -4,22 +4,24 @@
 //
 // trpc-a2a-go is licensed under the Apache License Version 2.0.
 
-package taskmanager
+package memory
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
 )
 
-// MockMessageProcessor implements MessageProcessor for testing
+// MockMessageProcessor implements taskmanager.MessageProcessor for testing
 type MockMessageProcessor struct {
-	ProcessMessageFunc func(ctx context.Context, message protocol.Message, options ProcessOptions, handle TaskHandler) (*MessageProcessingResult, error)
+	ProcessMessageFunc func(ctx context.Context, message protocol.Message, options taskmanager.ProcessOptions, handle taskmanager.TaskHandler) (*taskmanager.MessageProcessingResult, error)
 }
 
-func (m *MockMessageProcessor) ProcessMessage(ctx context.Context, message protocol.Message, options ProcessOptions, handle TaskHandler) (*MessageProcessingResult, error) {
+func (m *MockMessageProcessor) ProcessMessage(ctx context.Context, message protocol.Message, options taskmanager.ProcessOptions, handle taskmanager.TaskHandler) (*taskmanager.MessageProcessingResult, error) {
 	if m.ProcessMessageFunc != nil {
 		return m.ProcessMessageFunc(ctx, message, options, handle)
 	}
@@ -32,7 +34,7 @@ func (m *MockMessageProcessor) ProcessMessage(ctx context.Context, message proto
 		},
 	}
 
-	return &MessageProcessingResult{
+	return &taskmanager.MessageProcessingResult{
 		Result: &protocol.SendMessageResponse{Message: response},
 	}, nil
 }
@@ -47,11 +49,11 @@ func getTextFromMessage(message protocol.Message) string {
 	return ""
 }
 
-func TestNewMemoryTaskManager(t *testing.T) {
+func TestNewTaskManager(t *testing.T) {
 	tests := []struct {
 		name      string
-		processor MessageProcessor
-		options   []MemoryTaskManagerOption
+		processor taskmanager.MessageProcessor
+		options   []TaskManagerOption
 		wantErr   bool
 	}{
 		{
@@ -68,7 +70,7 @@ func TestNewMemoryTaskManager(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			manager, err := NewMemoryTaskManager(tt.processor, tt.options...)
+			manager, err := NewTaskManager(tt.processor, tt.options...)
 
 			if tt.wantErr {
 				if err == nil {
@@ -98,9 +100,9 @@ func TestNewMemoryTaskManager(t *testing.T) {
 	}
 }
 
-func TestMemoryTaskManager_OnSendMessage(t *testing.T) {
+func TestTaskManager_OnSendMessage(t *testing.T) {
 	processor := &MockMessageProcessor{}
-	manager, err := NewMemoryTaskManager(processor)
+	manager, err := NewTaskManager(processor)
 	if err != nil {
 		t.Fatalf("Failed to create manager: %v", err)
 	}
@@ -179,9 +181,9 @@ func TestMemoryTaskManager_OnSendMessage(t *testing.T) {
 	}
 }
 
-func TestMemoryTaskManager_OnSendMessageStream(t *testing.T) {
+func TestTaskManager_OnSendMessageStream(t *testing.T) {
 	processor := &MockMessageProcessor{
-		ProcessMessageFunc: func(ctx context.Context, message protocol.Message, options ProcessOptions, handle TaskHandler) (*MessageProcessingResult, error) {
+		ProcessMessageFunc: func(ctx context.Context, message protocol.Message, options taskmanager.ProcessOptions, handle taskmanager.TaskHandler) (*taskmanager.MessageProcessingResult, error) {
 			// Create a task for streaming
 			taskID, err := handle.BuildTask(nil, message.ContextID)
 			if err != nil {
@@ -210,13 +212,13 @@ func TestMemoryTaskManager_OnSendMessageStream(t *testing.T) {
 				handle.UpdateTaskState(&taskID, protocol.TaskStateCompleted, finalMessage)
 			}()
 
-			return &MessageProcessingResult{
+			return &taskmanager.MessageProcessingResult{
 				StreamingEvents: subscriber,
 			}, nil
 		},
 	}
 
-	manager, err := NewMemoryTaskManager(processor)
+	manager, err := NewTaskManager(processor)
 	if err != nil {
 		t.Fatalf("Failed to create manager: %v", err)
 	}
@@ -288,9 +290,9 @@ CheckEvents:
 	}
 }
 
-func TestMemoryTaskManager_OnGetTask(t *testing.T) {
+func TestTaskManager_OnGetTask(t *testing.T) {
 	processor := &MockMessageProcessor{
-		ProcessMessageFunc: func(ctx context.Context, message protocol.Message, options ProcessOptions, handle TaskHandler) (*MessageProcessingResult, error) {
+		ProcessMessageFunc: func(ctx context.Context, message protocol.Message, options taskmanager.ProcessOptions, handle taskmanager.TaskHandler) (*taskmanager.MessageProcessingResult, error) {
 			// Create a task for testing
 			taskID, err := handle.BuildTask(nil, message.ContextID)
 			if err != nil {
@@ -303,12 +305,12 @@ func TestMemoryTaskManager_OnGetTask(t *testing.T) {
 				return nil, err
 			}
 
-			return &MessageProcessingResult{
+			return &taskmanager.MessageProcessingResult{
 				Result: &protocol.SendMessageResponse{Task: task.Task()},
 			}, nil
 		},
 	}
-	manager, err := NewMemoryTaskManager(processor)
+	manager, err := NewTaskManager(processor)
 	if err != nil {
 		t.Fatalf("Failed to create manager: %v", err)
 	}
@@ -398,9 +400,9 @@ func TestMemoryTaskManager_OnGetTask(t *testing.T) {
 	}
 }
 
-func TestMemoryTaskManager_OnCancelTask(t *testing.T) {
+func TestTaskManager_OnCancelTask(t *testing.T) {
 	processor := &MockMessageProcessor{
-		ProcessMessageFunc: func(ctx context.Context, message protocol.Message, options ProcessOptions, handle TaskHandler) (*MessageProcessingResult, error) {
+		ProcessMessageFunc: func(ctx context.Context, message protocol.Message, options taskmanager.ProcessOptions, handle taskmanager.TaskHandler) (*taskmanager.MessageProcessingResult, error) {
 			// Create a task for testing cancellation
 			taskID, err := handle.BuildTask(nil, message.ContextID)
 			if err != nil {
@@ -413,12 +415,12 @@ func TestMemoryTaskManager_OnCancelTask(t *testing.T) {
 				return nil, err
 			}
 
-			return &MessageProcessingResult{
+			return &taskmanager.MessageProcessingResult{
 				Result: &protocol.SendMessageResponse{Task: task.Task()},
 			}, nil
 		},
 	}
-	manager, err := NewMemoryTaskManager(processor)
+	manager, err := NewTaskManager(processor)
 	if err != nil {
 		t.Fatalf("Failed to create manager: %v", err)
 	}
@@ -467,9 +469,9 @@ func TestMemoryTaskManager_OnCancelTask(t *testing.T) {
 	}
 }
 
-func TestMemoryTaskManager_PushNotifications(t *testing.T) {
+func TestTaskManager_PushNotifications(t *testing.T) {
 	processor := &MockMessageProcessor{}
-	manager, err := NewMemoryTaskManager(processor)
+	manager, err := NewTaskManager(processor)
 	if err != nil {
 		t.Fatalf("Failed to create manager: %v", err)
 	}
@@ -586,15 +588,15 @@ func TestTaskSubscriber(t *testing.T) {
 		name     string
 		taskID   string
 		capacity int
-		setup    func(*MemoryTaskSubscriber)             // Setup function to perform actions
-		validate func(*testing.T, *MemoryTaskSubscriber) // Validation function
+		setup    func(*TaskSubscriber)             // Setup function to perform actions
+		validate func(*testing.T, *TaskSubscriber) // Validation function
 	}{
 		{
 			name:     "create subscriber",
 			taskID:   "test-task",
 			capacity: 5,
-			setup:    func(s *MemoryTaskSubscriber) {},
-			validate: func(t *testing.T, s *MemoryTaskSubscriber) {
+			setup:    func(s *TaskSubscriber) {},
+			validate: func(t *testing.T, s *TaskSubscriber) {
 				if s.taskID != "test-task" {
 					t.Errorf("Expected task ID %s, got %s", "test-task", s.taskID)
 				}
@@ -607,7 +609,7 @@ func TestTaskSubscriber(t *testing.T) {
 			name:     "send and receive event",
 			taskID:   "test-task-2",
 			capacity: 5,
-			setup: func(s *MemoryTaskSubscriber) {
+			setup: func(s *TaskSubscriber) {
 				event := protocol.NewStreamResponseMessage(&protocol.Message{
 					Role: protocol.MessageRoleAgent,
 					Parts: []*protocol.Part{
@@ -619,7 +621,7 @@ func TestTaskSubscriber(t *testing.T) {
 					t.Errorf("Unexpected error sending event: %v", err)
 				}
 			},
-			validate: func(t *testing.T, s *MemoryTaskSubscriber) {
+			validate: func(t *testing.T, s *TaskSubscriber) {
 				select {
 				case receivedEvent := <-s.eventQueue:
 					if receivedEvent.Message == nil {
@@ -634,10 +636,10 @@ func TestTaskSubscriber(t *testing.T) {
 			name:     "close subscriber",
 			taskID:   "test-task-3",
 			capacity: 5,
-			setup: func(s *MemoryTaskSubscriber) {
+			setup: func(s *TaskSubscriber) {
 				s.Close()
 			},
-			validate: func(t *testing.T, s *MemoryTaskSubscriber) {
+			validate: func(t *testing.T, s *TaskSubscriber) {
 				if !s.Closed() {
 					t.Error("Expected subscriber to be closed")
 				}
@@ -654,7 +656,7 @@ func TestTaskSubscriber(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			subscriber := NewMemoryTaskSubscriber(tt.taskID, tt.capacity)
+			subscriber := NewTaskSubscriber(tt.taskID, tt.capacity)
 
 			tt.setup(subscriber)
 			tt.validate(t, subscriber)
@@ -662,8 +664,8 @@ func TestTaskSubscriber(t *testing.T) {
 	}
 }
 
-func TestMemoryTaskSubscriber_CloseUnblocksBlockingSend(t *testing.T) {
-	subscriber := NewMemoryTaskSubscriber(
+func TestTaskSubscriber_CloseUnblocksBlockingSend(t *testing.T) {
+	subscriber := NewTaskSubscriber(
 		"blocking-send-task",
 		1,
 		WithSubscriberBlockingSend(true),
@@ -697,7 +699,7 @@ func TestMemoryTaskSubscriber_CloseUnblocksBlockingSend(t *testing.T) {
 func TestCancellableTask(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	task := &MemoryCancellableTask{
+	task := &CancellableTask{
 		task: protocol.Task{
 			ID:     "test-task",
 			Status: protocol.TaskStatus{State: protocol.TaskStateSubmitted},
@@ -717,7 +719,7 @@ func TestCancellableTask(t *testing.T) {
 	}
 }
 
-func TestMemoryTaskManager_UpdateTaskState_CleansSubscribersOnFinalState(t *testing.T) {
+func TestTaskManager_UpdateTaskState_CleansSubscribersOnFinalState(t *testing.T) {
 	handler, manager := setupTestHandler(t)
 
 	taskID, err := handler.BuildTask(nil, nil)
@@ -764,8 +766,8 @@ func TestMemoryTaskManager_UpdateTaskState_CleansSubscribersOnFinalState(t *test
 	// TaskStatusUpdateEvent has to arrive before the channel close.
 	var gotFinal bool
 	for _, ev := range events {
-		if statusEvt := ev.StatusUpdate; statusEvt != nil &&
-			statusEvt.Final && statusEvt.Status.State == protocol.TaskStateCompleted {
+		if ev.StatusUpdate != nil &&
+			ev.StatusUpdate.Final && ev.StatusUpdate.Status.State == protocol.TaskStateCompleted {
 			gotFinal = true
 		}
 	}
@@ -783,23 +785,23 @@ func TestMemoryTaskManager_UpdateTaskState_CleansSubscribersOnFinalState(t *test
 	}
 }
 
-func TestMemoryTaskManager_cleanupFailedSubscribersClosesRemovedSubscribers(t *testing.T) {
+func TestTaskManager_cleanupFailedSubscribersClosesRemovedSubscribers(t *testing.T) {
 	processor := &MockMessageProcessor{}
-	manager, err := NewMemoryTaskManager(processor)
+	manager, err := NewTaskManager(processor)
 	if err != nil {
 		t.Fatalf("Failed to create manager: %v", err)
 	}
 	defer manager.Close()
 
 	taskID := "failed-subscriber-task"
-	failedSub := NewMemoryTaskSubscriber(taskID, 10)
-	activeSub := NewMemoryTaskSubscriber(taskID, 10)
+	failedSub := NewTaskSubscriber(taskID, 10)
+	activeSub := NewTaskSubscriber(taskID, 10)
 
 	manager.taskMu.Lock()
-	manager.Subscribers[taskID] = []*MemoryTaskSubscriber{failedSub, activeSub}
+	manager.Subscribers[taskID] = []*TaskSubscriber{failedSub, activeSub}
 	manager.taskMu.Unlock()
 
-	manager.cleanupFailedSubscribers(taskID, []*MemoryTaskSubscriber{failedSub})
+	manager.cleanupFailedSubscribers(taskID, []*TaskSubscriber{failedSub})
 
 	if !failedSub.Closed() {
 		t.Error("Expected failed subscriber to be closed")
@@ -817,9 +819,9 @@ func TestMemoryTaskManager_cleanupFailedSubscribersClosesRemovedSubscribers(t *t
 	}
 }
 
-func TestMemoryTaskManager_cleanExpiredTasks(t *testing.T) {
+func TestTaskManager_cleanExpiredTasks(t *testing.T) {
 	processor := &MockMessageProcessor{}
-	manager, err := NewMemoryTaskManager(processor)
+	manager, err := NewTaskManager(processor)
 	if err != nil {
 		t.Fatalf("Failed to create manager: %v", err)
 	}
@@ -837,8 +839,8 @@ func TestMemoryTaskManager_cleanExpiredTasks(t *testing.T) {
 
 	manager.taskMu.Lock()
 	manager.Tasks["expired-task"] = cancellableTask
-	manager.Subscribers["expired-task"] = []*MemoryTaskSubscriber{
-		NewMemoryTaskSubscriber("expired-task", 10),
+	manager.Subscribers["expired-task"] = []*TaskSubscriber{
+		NewTaskSubscriber("expired-task", 10),
 	}
 	manager.taskMu.Unlock()
 
@@ -905,9 +907,9 @@ func TestMemoryTaskManager_cleanExpiredTasks(t *testing.T) {
 	}
 }
 
-func TestMemoryTaskManager_TaskTTLCleanupGoroutine(t *testing.T) {
+func TestTaskManager_TaskTTLCleanupGoroutine(t *testing.T) {
 	processor := &MockMessageProcessor{}
-	manager, err := NewMemoryTaskManager(
+	manager, err := NewTaskManager(
 		processor,
 		WithConversationTTL(time.Hour, 5*time.Millisecond),
 		WithTaskTTL(time.Nanosecond),
@@ -918,7 +920,7 @@ func TestMemoryTaskManager_TaskTTLCleanupGoroutine(t *testing.T) {
 	defer manager.Close()
 
 	taskID := "auto-expired-task"
-	sub := NewMemoryTaskSubscriber(taskID, 10)
+	sub := NewTaskSubscriber(taskID, 10)
 	task := protocol.Task{
 		ID: taskID,
 		Status: protocol.TaskStatus{
@@ -929,7 +931,7 @@ func TestMemoryTaskManager_TaskTTLCleanupGoroutine(t *testing.T) {
 
 	manager.taskMu.Lock()
 	manager.Tasks[taskID] = NewCancellableTask(task)
-	manager.Subscribers[taskID] = []*MemoryTaskSubscriber{sub}
+	manager.Subscribers[taskID] = []*TaskSubscriber{sub}
 	manager.taskMu.Unlock()
 
 	manager.mu.Lock()
@@ -968,9 +970,9 @@ func TestMemoryTaskManager_TaskTTLCleanupGoroutine(t *testing.T) {
 	}
 }
 
-func TestMemoryTaskManager_Close(t *testing.T) {
+func TestTaskManager_Close(t *testing.T) {
 	processor := &MockMessageProcessor{}
-	manager, err := NewMemoryTaskManager(processor)
+	manager, err := NewTaskManager(processor)
 	if err != nil {
 		t.Fatalf("Failed to create manager: %v", err)
 	}
@@ -984,11 +986,11 @@ func TestMemoryTaskManager_Close(t *testing.T) {
 		},
 	}
 	cancellableTask := NewCancellableTask(task)
-	sub := NewMemoryTaskSubscriber("close-test-task", 10)
+	sub := NewTaskSubscriber("close-test-task", 10)
 
 	manager.taskMu.Lock()
 	manager.Tasks["close-test-task"] = cancellableTask
-	manager.Subscribers["close-test-task"] = []*MemoryTaskSubscriber{sub}
+	manager.Subscribers["close-test-task"] = []*TaskSubscriber{sub}
 	manager.taskMu.Unlock()
 
 	manager.Close()
@@ -1008,9 +1010,9 @@ func TestMemoryTaskManager_Close(t *testing.T) {
 	}
 }
 
-func TestMemoryTaskManager_Close_Idempotent(t *testing.T) {
+func TestTaskManager_Close_Idempotent(t *testing.T) {
 	processor := &MockMessageProcessor{}
-	manager, err := NewMemoryTaskManager(processor)
+	manager, err := NewTaskManager(processor)
 	if err != nil {
 		t.Fatalf("Failed to create manager: %v", err)
 	}
@@ -1021,14 +1023,14 @@ func TestMemoryTaskManager_Close_Idempotent(t *testing.T) {
 }
 
 func TestWithTaskTTL(t *testing.T) {
-	opts := DefaultMemoryTaskManagerOptions()
+	opts := DefaultTaskManagerOptions()
 
 	if opts.TaskTTL != 0 {
 		t.Errorf("Expected default TaskTTL=0 (disabled), got %v", opts.TaskTTL)
 	}
 
 	// A positive TTL also enables the cleanup goroutine, mirroring WithConversationTTL.
-	fresh := &MemoryTaskManagerOptions{}
+	fresh := &TaskManagerOptions{}
 	WithTaskTTL(30 * time.Minute)(fresh)
 	if fresh.TaskTTL != 30*time.Minute {
 		t.Errorf("Expected TaskTTL=30m, got %v", fresh.TaskTTL)
@@ -1038,7 +1040,7 @@ func TestWithTaskTTL(t *testing.T) {
 	}
 
 	// A zero TTL disables task cleanup and must not flip EnableCleanup on.
-	disabled := &MemoryTaskManagerOptions{}
+	disabled := &TaskManagerOptions{}
 	WithTaskTTL(0)(disabled)
 	if disabled.TaskTTL != 0 {
 		t.Errorf("Expected TaskTTL=0 after explicit disable, got %v", disabled.TaskTTL)
@@ -1060,10 +1062,10 @@ func boolPtr(b bool) *bool {
 	return &b
 }
 
-// TestMemoryTaskManager_OnListTasks covers the v1.0 ListTasks filtering and pagination.
-func TestMemoryTaskManager_OnListTasks(t *testing.T) {
+// TestTaskManager_OnListTasks covers the v1.0 ListTasks filtering and pagination.
+func TestTaskManager_OnListTasks(t *testing.T) {
 	processor := &MockMessageProcessor{}
-	manager, err := NewMemoryTaskManager(processor)
+	manager, err := NewTaskManager(processor)
 	if err != nil {
 		t.Fatalf("Failed to create manager: %v", err)
 	}
@@ -1142,10 +1144,10 @@ func TestMemoryTaskManager_OnListTasks(t *testing.T) {
 	}
 }
 
-// TestMemoryTaskManager_PushNotificationListDelete covers the v1.0 list/delete push-config methods.
-func TestMemoryTaskManager_PushNotificationListDelete(t *testing.T) {
+// TestTaskManager_PushNotificationListDelete covers the v1.0 list/delete push-config methods.
+func TestTaskManager_PushNotificationListDelete(t *testing.T) {
 	processor := &MockMessageProcessor{}
-	manager, err := NewMemoryTaskManager(processor)
+	manager, err := NewTaskManager(processor)
 	if err != nil {
 		t.Fatalf("Failed to create manager: %v", err)
 	}
@@ -1180,5 +1182,82 @@ func TestMemoryTaskManager_PushNotificationListDelete(t *testing.T) {
 	// Deleting again is a no-op.
 	if err := manager.OnPushNotificationDelete(ctx, protocol.DeleteTaskPushNotificationConfigParams{TaskID: "task-1"}); err != nil {
 		t.Fatalf("Idempotent delete failed: %v", err)
+	}
+}
+
+// TestTaskManager_OnResubscribe_NonTerminalEmitsSnapshot verifies the v1.0
+// requirement that subscribing to a live task delivers the current Task snapshot
+// as the first stream event.
+func TestTaskManager_OnResubscribe_NonTerminalEmitsSnapshot(t *testing.T) {
+	manager, err := NewTaskManager(&MockMessageProcessor{})
+	if err != nil {
+		t.Fatalf("Failed to create manager: %v", err)
+	}
+	defer manager.Close()
+	ctx := context.Background()
+
+	task := protocol.Task{
+		ID:        "live-task",
+		ContextID: "ctx-1",
+		Status:    protocol.TaskStatus{State: protocol.TaskStateWorking, Timestamp: time.Now().UTC().Format(time.RFC3339)},
+	}
+	manager.taskMu.Lock()
+	manager.Tasks[task.ID] = NewCancellableTask(task)
+	manager.taskMu.Unlock()
+
+	ch, err := manager.OnResubscribe(ctx, protocol.TaskIDParams{ID: task.ID})
+	if err != nil {
+		t.Fatalf("OnResubscribe on live task failed: %v", err)
+	}
+
+	select {
+	case ev, ok := <-ch:
+		if !ok {
+			t.Fatal("subscriber channel closed before snapshot")
+		}
+		if ev.Task == nil {
+			t.Fatalf("Expected first event to be a Task snapshot, got %+v", ev)
+		}
+		if ev.Task.ID != task.ID || ev.Task.Status.State != protocol.TaskStateWorking {
+			t.Errorf("Snapshot mismatch: got id=%s state=%s", ev.Task.ID, ev.Task.Status.State)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the Task snapshot event")
+	}
+}
+
+// TestTaskManager_OnResubscribe_TerminalRejected verifies the v1.0
+// requirement that subscribing to a terminal task returns UnsupportedOperationError.
+func TestTaskManager_OnResubscribe_TerminalRejected(t *testing.T) {
+	manager, err := NewTaskManager(&MockMessageProcessor{})
+	if err != nil {
+		t.Fatalf("Failed to create manager: %v", err)
+	}
+	defer manager.Close()
+	ctx := context.Background()
+
+	for _, state := range []protocol.TaskState{
+		protocol.TaskStateCompleted, protocol.TaskStateFailed,
+		protocol.TaskStateCanceled, protocol.TaskStateRejected,
+	} {
+		task := protocol.Task{
+			ID:     "terminal-" + string(state),
+			Status: protocol.TaskStatus{State: state, Timestamp: time.Now().UTC().Format(time.RFC3339)},
+		}
+		manager.taskMu.Lock()
+		manager.Tasks[task.ID] = NewCancellableTask(task)
+		manager.taskMu.Unlock()
+
+		ch, err := manager.OnResubscribe(ctx, protocol.TaskIDParams{ID: task.ID})
+		if err == nil {
+			t.Errorf("state %s: expected UnsupportedOperation error, got nil", state)
+			continue
+		}
+		if ch != nil {
+			t.Errorf("state %s: expected nil channel on rejection", state)
+		}
+		if !errors.Is(err, taskmanager.ErrUnsupportedOperationSentinel) {
+			t.Errorf("state %s: expected taskmanager.ErrUnsupportedOperation, got %v", state, err)
+		}
 	}
 }

--- a/taskmanager/memory/memory_test.go
+++ b/taskmanager/memory/memory_test.go
@@ -35,7 +35,7 @@ func (m *MockMessageProcessor) ProcessMessage(ctx context.Context, message proto
 	}
 
 	return &taskmanager.MessageProcessingResult{
-		Result: &protocol.SendMessageResponse{Message: response},
+		Result: &protocol.SendMessageResponse{Result: response},
 	}, nil
 }
 
@@ -163,14 +163,14 @@ func TestTaskManager_OnSendMessage(t *testing.T) {
 			}
 
 			// Check if result contains a message
-			if result.Message != nil {
-				if result.Message.MessageID == "" {
+			if result.GetMessage() != nil {
+				if result.GetMessage().MessageID == "" {
 					t.Error("Expected message ID to be set")
 				}
 
 				// Check that message is in storage
 				manager.mu.RLock()
-				_, exists := manager.Messages[result.Message.MessageID]
+				_, exists := manager.Messages[result.GetMessage().MessageID]
 				manager.mu.RUnlock()
 
 				if !exists {
@@ -279,7 +279,7 @@ CheckEvents:
 	// Should have received some events
 	hasStatusUpdate := false
 	for _, event := range events {
-		if event.StatusUpdate != nil {
+		if event.GetStatusUpdate() != nil {
 			hasStatusUpdate = true
 			break
 		}
@@ -306,7 +306,7 @@ func TestTaskManager_OnGetTask(t *testing.T) {
 			}
 
 			return &taskmanager.MessageProcessingResult{
-				Result: &protocol.SendMessageResponse{Task: task.Task()},
+				Result: &protocol.SendMessageResponse{Result: task.Task()},
 			}, nil
 		},
 	}
@@ -333,8 +333,8 @@ func TestTaskManager_OnGetTask(t *testing.T) {
 	}
 
 	var existingTaskID string
-	if result.Task != nil {
-		existingTaskID = result.Task.ID
+	if result.GetTask() != nil {
+		existingTaskID = result.GetTask().ID
 	} else {
 		t.Fatal("Expected task result but got nil")
 	}
@@ -416,7 +416,7 @@ func TestTaskManager_OnCancelTask(t *testing.T) {
 			}
 
 			return &taskmanager.MessageProcessingResult{
-				Result: &protocol.SendMessageResponse{Task: task.Task()},
+				Result: &protocol.SendMessageResponse{Result: task.Task()},
 			}, nil
 		},
 	}
@@ -444,8 +444,8 @@ func TestTaskManager_OnCancelTask(t *testing.T) {
 
 	// Extract task from result
 	var taskID string
-	if result.Task != nil {
-		taskID = result.Task.ID
+	if result.GetTask() != nil {
+		taskID = result.GetTask().ID
 	} else {
 		t.Fatal("Expected task result but got nil")
 	}
@@ -624,7 +624,7 @@ func TestTaskSubscriber(t *testing.T) {
 			validate: func(t *testing.T, s *TaskSubscriber) {
 				select {
 				case receivedEvent := <-s.eventQueue:
-					if receivedEvent.Message == nil {
+					if receivedEvent.GetMessage() == nil {
 						t.Error("Expected event message but got nil")
 					}
 				case <-time.After(100 * time.Millisecond):
@@ -766,8 +766,8 @@ func TestTaskManager_UpdateTaskState_CleansSubscribersOnFinalState(t *testing.T)
 	// TaskStatusUpdateEvent has to arrive before the channel close.
 	var gotFinal bool
 	for _, ev := range events {
-		if ev.StatusUpdate != nil &&
-			ev.StatusUpdate.Final && ev.StatusUpdate.Status.State == protocol.TaskStateCompleted {
+		if ev.GetStatusUpdate() != nil &&
+			ev.GetStatusUpdate().Final && ev.GetStatusUpdate().Status.State == protocol.TaskStateCompleted {
 			gotFinal = true
 		}
 	}
@@ -1215,11 +1215,11 @@ func TestTaskManager_OnResubscribe_NonTerminalEmitsSnapshot(t *testing.T) {
 		if !ok {
 			t.Fatal("subscriber channel closed before snapshot")
 		}
-		if ev.Task == nil {
+		if ev.GetTask() == nil {
 			t.Fatalf("Expected first event to be a Task snapshot, got %+v", ev)
 		}
-		if ev.Task.ID != task.ID || ev.Task.Status.State != protocol.TaskStateWorking {
-			t.Errorf("Snapshot mismatch: got id=%s state=%s", ev.Task.ID, ev.Task.Status.State)
+		if ev.GetTask().ID != task.ID || ev.GetTask().Status.State != protocol.TaskStateWorking {
+			t.Errorf("Snapshot mismatch: got id=%s state=%s", ev.GetTask().ID, ev.GetTask().Status.State)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for the Task snapshot event")

--- a/taskmanager/redis/redis_manager.go
+++ b/taskmanager/redis/redis_manager.go
@@ -117,6 +117,7 @@ func (m *TaskManager) OnSendMessage(
 	// Process configuration.
 	options := m.processConfiguration(request.Configuration)
 	options.Streaming = false // non-streaming processing
+	options.Tenant = request.Tenant
 
 	// Create MessageHandle.
 	handle := &taskHandler{
@@ -169,6 +170,7 @@ func (m *TaskManager) OnSendMessageStream(
 	// Process configuration.
 	options := m.processConfiguration(request.Configuration)
 	options.Streaming = true // streaming mode
+	options.Tenant = request.Tenant
 
 	// Create streaming MessageHandle.
 	handle := &taskHandler{
@@ -412,9 +414,16 @@ func (m *TaskManager) OnResubscribe(
 	params protocol.TaskIDParams,
 ) (<-chan protocol.StreamResponse, error) {
 	// Check if task exists.
-	_, err := m.getTaskInternal(ctx, params.ID)
+	task, err := m.getTaskInternal(ctx, params.ID)
 	if err != nil {
 		return nil, err
+	}
+
+	// v1.0: a subscription is only valid for a non-terminal task; a task already
+	// in a terminal state must be rejected with UnsupportedOperationError.
+	if isFinalState(task.Status.State) {
+		return nil, taskmanager.ErrUnsupportedOperation(
+			fmt.Sprintf("subscribe to task %s in terminal state %s", params.ID, task.Status.State))
 	}
 
 	bufSize := m.options.TaskSubscriberBufSize
@@ -428,6 +437,13 @@ func (m *TaskManager) OnResubscribe(
 		WithSubscriberBlockingSend(m.options.TaskSubscriberBlockingSend),
 		WithSubscriberSendHook(m.sendStreamingEventHook(params.ID)),
 	)
+
+	// v1.0: the first stream event must be the current Task snapshot. getTaskInternal
+	// already returns a fresh copy, so it is safe to hand to the subscriber.
+	if err := subscriber.Send(protocol.StreamResponse{Task: task}); err != nil {
+		subscriber.Close()
+		return nil, err
+	}
 
 	// Add to subscribers list.
 	m.addSubscriber(params.ID, subscriber)

--- a/taskmanager/redis/redis_manager.go
+++ b/taskmanager/redis/redis_manager.go
@@ -147,12 +147,12 @@ func (m *TaskManager) OnSendMessage(
 		return nil, fmt.Errorf("processor returned nil result for non-streaming request")
 	}
 
-	if result.Result.Message != nil {
+	if result.Result.GetMessage() != nil {
 		var contextID string
 		if request.Message.ContextID != nil {
 			contextID = *request.Message.ContextID
 		}
-		m.processReplyMessage(&contextID, result.Result.Message)
+		m.processReplyMessage(&contextID, result.Result.GetMessage())
 	}
 
 	return result.Result, nil
@@ -440,7 +440,7 @@ func (m *TaskManager) OnResubscribe(
 
 	// v1.0: the first stream event must be the current Task snapshot. getTaskInternal
 	// already returns a fresh copy, so it is safe to hand to the subscriber.
-	if err := subscriber.Send(protocol.StreamResponse{Task: task}); err != nil {
+	if err := subscriber.Send(protocol.StreamResponse{Result: task}); err != nil {
 		subscriber.Close()
 		return nil, err
 	}
@@ -524,17 +524,17 @@ func (m *TaskManager) processReplyMessage(ctxID *string, message *protocol.Messa
 // used to set contextID for task status update, task artifact update, message and task events
 func (m *TaskManager) sendStreamingEventHook(ctxID string) func(event protocol.StreamResponse) error {
 	return func(event protocol.StreamResponse) error {
-		if event.StatusUpdate != nil && event.StatusUpdate.ContextID == "" {
-			event.StatusUpdate.ContextID = ctxID
+		if event.GetStatusUpdate() != nil && event.GetStatusUpdate().ContextID == "" {
+			event.GetStatusUpdate().ContextID = ctxID
 		}
-		if event.ArtifactUpdate != nil && event.ArtifactUpdate.ContextID == "" {
-			event.ArtifactUpdate.ContextID = ctxID
+		if event.GetArtifactUpdate() != nil && event.GetArtifactUpdate().ContextID == "" {
+			event.GetArtifactUpdate().ContextID = ctxID
 		}
-		if event.Message != nil {
-			m.processReplyMessage(&ctxID, event.Message)
+		if event.GetMessage() != nil {
+			m.processReplyMessage(&ctxID, event.GetMessage())
 		}
-		if event.Task != nil && event.Task.ContextID == "" {
-			event.Task.ContextID = ctxID
+		if event.GetTask() != nil && event.GetTask().ContextID == "" {
+			event.GetTask().ContextID = ctxID
 		}
 		return nil
 	}

--- a/taskmanager/redis/redis_types_test.go
+++ b/taskmanager/redis/redis_types_test.go
@@ -88,7 +88,7 @@ func TestRedisTaskSubscriber(t *testing.T) {
 	// Test receiving events
 	select {
 	case receivedEvent := <-subscriber.Channel():
-		if receivedEvent.StatusUpdate == nil {
+		if receivedEvent.GetStatusUpdate() == nil {
 			t.Error("Expected status update, got nil")
 		}
 	case <-time.After(100 * time.Millisecond):

--- a/telemetry/tracker.go
+++ b/telemetry/tracker.go
@@ -27,9 +27,9 @@ func (defaultFirstTokenPolicy) IsStreamingFirstToken(event *protocol.StreamRespo
 		return false
 	}
 	switch {
-	case event.StatusUpdate != nil:
-		return event.StatusUpdate.Status.State == protocol.TaskStateWorking && event.StatusUpdate.Status.Message != nil
-	case event.ArtifactUpdate != nil:
+	case event.GetStatusUpdate() != nil:
+		return event.GetStatusUpdate().Status.State == protocol.TaskStateWorking && event.GetStatusUpdate().Status.Message != nil
+	case event.GetArtifactUpdate() != nil:
 		return true
 	default:
 		return false

--- a/tests/e2e_auth_test.go
+++ b/tests/e2e_auth_test.go
@@ -86,9 +86,9 @@ func TestJWTAuthentication(t *testing.T) {
 	})
 
 	require.NoError(t, err, "Authenticated request failed")
-	require.NotNil(t, messageResult.Message, "Message result should not be nil")
+	require.NotNil(t, messageResult.GetMessage(), "Message result should not be nil")
 
-	resultMessage := messageResult.Message
+	resultMessage := messageResult.GetMessage()
 	processedMessage, exists := taskMgr.(*mockTaskManager).messages[resultMessage.MessageID]
 	require.True(t, exists, "Failed to get processed message")
 	assert.NotNil(t, processedMessage, "Processed message should not be nil")
@@ -138,9 +138,9 @@ func TestAPIKeyAuthentication(t *testing.T) {
 		Message: createTextMessage("Hello from API key test!"),
 	})
 	require.NoError(t, err, "Authenticated request failed")
-	require.NotNil(t, messageResult.Message, "Message result should not be nil")
+	require.NotNil(t, messageResult.GetMessage(), "Message result should not be nil")
 
-	resultMessage := messageResult.Message
+	resultMessage := messageResult.GetMessage()
 	processedMessage, exists := taskMgr.(*mockTaskManager).messages[resultMessage.MessageID]
 	require.True(t, exists, "Failed to get processed message")
 	assert.NotNil(t, processedMessage, "Processed message should not be nil")
@@ -208,7 +208,7 @@ func TestChainAuthentication(t *testing.T) {
 		Message: createTextMessage("Hello with JWT auth!"),
 	})
 	require.NoError(t, err, "JWT authenticated request failed")
-	assert.NotNil(t, messageResult.Message, "Message result should not be nil")
+	assert.NotNil(t, messageResult.GetMessage(), "Message result should not be nil")
 
 	// Test with API key authentication
 	apiKeyTransport := &authRoundTripper{
@@ -228,7 +228,7 @@ func TestChainAuthentication(t *testing.T) {
 		Message: createTextMessage("Hello with API key auth!"),
 	})
 	require.NoError(t, err, "API key authenticated request failed")
-	assert.NotNil(t, messageResult2.Message, "Message result should not be nil")
+	assert.NotNil(t, messageResult2.GetMessage(), "Message result should not be nil")
 }
 
 // TestPushNotificationAuthentication tests push notification authentication.

--- a/tests/e2e_auth_test.go
+++ b/tests/e2e_auth_test.go
@@ -258,8 +258,8 @@ func TestPushNotificationAuthentication(t *testing.T) {
 
 	// Create agent server with JWKS endpoint
 	agentServer, err := server.NewA2AServer(
-		agentCard,
 		agentTaskMgr,
+		server.WithAgentCard(agentCard),
 		server.WithJWKSEndpoint(true, "/.well-known/jwks.json"),
 	)
 	require.NoError(t, err, "Failed to create agent server")
@@ -449,8 +449,8 @@ func setupAuthServer(t *testing.T, provider auth.Provider) (taskmanager.TaskMana
 	}
 
 	a2aServer, err := server.NewA2AServer(
-		agentCard,
 		taskMgr,
+		server.WithAgentCard(agentCard),
 		server.WithAuthProvider(provider),
 	)
 	require.NoError(t, err, "Failed to create A2A server")

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -357,7 +357,7 @@ func collectAllStreamingEvents(eventChan <-chan protocol.StreamResponse) []proto
 			}
 			events = append(events, event)
 
-			if event.StatusUpdate != nil && event.StatusUpdate.IsFinal() {
+			if event.GetStatusUpdate() != nil && event.GetStatusUpdate().IsFinal() {
 				time.Sleep(50 * time.Millisecond)
 				select {
 				case lastEvent, ok := <-eventChan:
@@ -476,7 +476,7 @@ func checkStreamingEvents(t *testing.T, events []protocol.StreamResponse) {
 	hasCompletedStatus := false
 
 	for _, event := range events {
-		if su := event.StatusUpdate; su != nil {
+		if su := event.GetStatusUpdate(); su != nil {
 			if su.Status.State == protocol.TaskStateWorking {
 				hasWorkingStatus = true
 				require.NotNil(t, su.Status.Message, "Working status should have a message")
@@ -492,7 +492,7 @@ func checkStreamingEvents(t *testing.T, events []protocol.StreamResponse) {
 				require.Contains(t, text, "!dlrow olleH", "Completed status should contain reversed text")
 			}
 		}
-		if au := event.ArtifactUpdate; au != nil {
+		if au := event.GetArtifactUpdate(); au != nil {
 			hasArtifact = true
 			require.NotNil(t, au.Artifact.Name, "Artifact should have a name")
 			require.Equal(t, "Processed Text", *au.Artifact.Name, "Artifact name should match")
@@ -541,8 +541,8 @@ func TestE2E_MessageAPI_NonStreaming(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify the result contains a task
-	require.NotNil(t, result.Task, "Result should contain a task")
-	task := result.Task
+	require.NotNil(t, result.GetTask(), "Result should contain a task")
+	task := result.GetTask()
 
 	// Wait a bit for the task to complete
 	time.Sleep(500 * time.Millisecond)

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -22,6 +22,7 @@ import (
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/server"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager/memory"
 )
 
 // stringPtr is a helper to get a pointer to a string.
@@ -172,80 +173,80 @@ func (p *testProcessor) processTask(
 
 // testBasicTaskManager is a simple TaskManager for basic tests.
 type testBasicTaskManager struct {
-	*taskmanager.MemoryTaskManager
+	*memory.TaskManager
 }
 
 // newTestBasicTaskManager creates an instance for testing.
 func newTestBasicTaskManager(t *testing.T) *testBasicTaskManager {
 	processor := &testProcessor{}
-	memTm, err := taskmanager.NewMemoryTaskManager(processor)
-	require.NoError(t, err, "Failed to create MemoryTaskManager for testBasicTaskManager")
+	memTm, err := memory.NewTaskManager(processor)
+	require.NoError(t, err, "Failed to create TaskManager for testBasicTaskManager")
 	return &testBasicTaskManager{
-		MemoryTaskManager: memTm,
+		TaskManager: memTm,
 	}
 }
 
-// OnSendMessage delegates to the composed MemoryTaskManager.
+// OnSendMessage delegates to the composed TaskManager.
 func (m *testBasicTaskManager) OnSendMessage(
 	ctx context.Context,
 	params protocol.SendMessageParams,
 ) (*protocol.SendMessageResponse, error) {
 	log.Printf("[Test TM Wrapper] OnSendMessage called for %s, delegating to base.", params.Message.MessageID)
-	return m.MemoryTaskManager.OnSendMessage(ctx, params)
+	return m.TaskManager.OnSendMessage(ctx, params)
 }
 
-// OnSendMessageStream delegates to the composed MemoryTaskManager.
+// OnSendMessageStream delegates to the composed TaskManager.
 func (m *testBasicTaskManager) OnSendMessageStream(
 	ctx context.Context,
 	params protocol.SendMessageParams,
 ) (<-chan protocol.StreamResponse, error) {
 	log.Printf("[Test TM Wrapper] OnSendMessageStream called for %s, delegating to base.", params.Message.MessageID)
-	return m.MemoryTaskManager.OnSendMessageStream(ctx, params)
+	return m.TaskManager.OnSendMessageStream(ctx, params)
 }
 
-// OnResubscribe delegates to the composed MemoryTaskManager.
+// OnResubscribe delegates to the composed TaskManager.
 func (m *testBasicTaskManager) OnResubscribe(
 	ctx context.Context,
 	params protocol.TaskIDParams,
 ) (<-chan protocol.StreamResponse, error) {
 	log.Printf("[Test TM Wrapper] OnResubscribe called for %s, delegating to base.", params.ID)
-	return m.MemoryTaskManager.OnResubscribe(ctx, params)
+	return m.TaskManager.OnResubscribe(ctx, params)
 }
 
-// OnPushNotificationSet delegates to the composed MemoryTaskManager.
+// OnPushNotificationSet delegates to the composed TaskManager.
 func (m *testBasicTaskManager) OnPushNotificationSet(
 	ctx context.Context,
 	params protocol.TaskPushNotificationConfig,
 ) (*protocol.TaskPushNotificationConfig, error) {
 	log.Printf("[Test TM Wrapper] OnPushNotificationSet called for %s, delegating to base.", params.TaskID)
-	return m.MemoryTaskManager.OnPushNotificationSet(ctx, params)
+	return m.TaskManager.OnPushNotificationSet(ctx, params)
 }
 
-// OnPushNotificationGet delegates to the composed MemoryTaskManager.
+// OnPushNotificationGet delegates to the composed TaskManager.
 func (m *testBasicTaskManager) OnPushNotificationGet(
 	ctx context.Context,
 	params protocol.TaskIDParams,
 ) (*protocol.TaskPushNotificationConfig, error) {
 	log.Printf("[Test TM Wrapper] OnPushNotificationGet called for %s, delegating to base.", params.ID)
-	return m.MemoryTaskManager.OnPushNotificationGet(ctx, params)
+	return m.TaskManager.OnPushNotificationGet(ctx, params)
 }
 
-// OnGetTask delegates to the composed MemoryTaskManager.
+// OnGetTask delegates to the composed TaskManager.
 func (m *testBasicTaskManager) OnGetTask(
 	ctx context.Context,
 	params protocol.TaskQueryParams,
 ) (*protocol.Task, error) {
 	log.Printf("[Test TM Wrapper] OnGetTask called for %s, delegating to base.", params.ID)
-	return m.MemoryTaskManager.OnGetTask(ctx, params)
+	return m.TaskManager.OnGetTask(ctx, params)
 }
 
-// OnCancelTask delegates to the composed MemoryTaskManager.
+// OnCancelTask delegates to the composed TaskManager.
 func (m *testBasicTaskManager) OnCancelTask(
 	ctx context.Context,
 	params protocol.TaskIDParams,
 ) (*protocol.Task, error) {
 	log.Printf("[Test TM Wrapper] OnCancelTask called for %s, delegating to base.", params.ID)
-	return m.MemoryTaskManager.OnCancelTask(ctx, params)
+	return m.TaskManager.OnCancelTask(ctx, params)
 }
 
 // testHelper contains common utilities and setup for e2e tests.
@@ -264,7 +265,7 @@ func newTestHelper(t *testing.T, processor taskmanager.MessageProcessor) *testHe
 	// Create task manager
 	var tm taskmanager.TaskManager
 	if processor != nil {
-		memTm, err := taskmanager.NewMemoryTaskManager(processor)
+		memTm, err := memory.NewTaskManager(processor)
 		require.NoError(t, err)
 		tm = memTm
 	} else {
@@ -274,7 +275,7 @@ func newTestHelper(t *testing.T, processor taskmanager.MessageProcessor) *testHe
 	// Create server
 	port := getFreePort(t)
 	agentCard := createDefaultTestAgentCard()
-	a2aServer, err := server.NewA2AServer(agentCard, tm)
+	a2aServer, err := server.NewA2AServer(tm, server.WithAgentCard(agentCard))
 	require.NoError(t, err)
 
 	// Start server in goroutine


### PR DESCRIPTION
Builds on the A2A v1.0 base migration (release/spec-v1) with the server-side refactors.

## Changes
- **Tenant-native multi-agent**: host several agents in one process and route by the v1.0 `tenant` field (carried in the request body) via `WithTenantCard` (static) and `WithTenantCardProvider` (dynamic), replacing the URL-path + placeholder-card + custom card-handler hack.
- **Optional agent card**: `NewA2AServer` now takes only the task manager; the card is supplied via `WithAgentCard`, `WithTenantCard`, or `WithTenantCardProvider` (at least one required, validated at construction). A pure multi-tenant server no longer needs a placeholder card.
- **Base-path derivation**: derive the base path from the card URL only when serving paths are not set explicitly (replaces a fragile snapshot heuristic; `WithBasePath` still overrides for reverse-proxy cases).
- **taskmanager/memory package**: move the in-memory manager into its own package (`memory.NewTaskManager`), aligned with the redis manager layout; carry the tenant through `ProcessOptions` for both memory and redis.
- **examples**: rewrite `multi_endpoint` to tenant-native; update every call site to the new constructor signature.

## Notes
- Breaking API: `NewA2AServer` signature change and the `taskmanager/memory` move. All in-repo call sites and examples are updated.
- Verified: `go build ./...`, `go vet ./...`, and `server` / `tests` / `taskmanager` test suites pass; the `examples` and `taskmanager/redis` modules build.