### PR TITLE
taskmanager: enable memory task auto-cleanup by default

### DIFF
--- a/examples/basic/server/main.go
+++ b/examples/basic/server/main.go
@@ -107,7 +107,12 @@ func (p *basicMessageProcessor) ProcessMessage(
 			return nil, fmt.Errorf("failed to subscribe to task: %w", err)
 		}
 
-		// Process asynchronously with full multi-turn support
+		// Process asynchronously with full multi-turn support.
+		// NOTE: we intentionally do not CleanTask here. A multi-turn task can
+		// park in the input-required state across several turns, so it must
+		// outlive this call. Once it reaches a terminal state the manager reaps
+		// it automatically after TaskTTL (default 1h); for stateful agents like
+		// this one, that framework-side reaping is the intended cleanup path.
 		go p.processMessageAsync(ctx, text, contextID, taskID, handle)
 
 		return &taskmanager.MessageProcessingResult{

--- a/examples/jwks/server/main.go
+++ b/examples/jwks/server/main.go
@@ -98,7 +98,7 @@ func (p *pushNotificationMessageProcessor) ProcessMessage(
 	}
 
 	// Start asynchronous processing
-	go p.processTaskAsync(ctx, taskID, payload, subscriber)
+	go p.processTaskAsync(ctx, handle, taskID, payload, subscriber)
 
 	return &taskmanager.MessageProcessingResult{
 		StreamingEvents: subscriber,
@@ -129,6 +129,7 @@ func (p *pushNotificationMessageProcessor) processDirectly(
 // processTaskAsync handles the actual task processing in a separate goroutine.
 func (p *pushNotificationMessageProcessor) processTaskAsync(
 	ctx context.Context,
+	handle taskmanager.TaskHandler,
 	taskID string,
 	payload map[string]interface{},
 	subscriber taskmanager.TaskSubscriber,
@@ -137,6 +138,12 @@ func (p *pushNotificationMessageProcessor) processTaskAsync(
 		if subscriber != nil {
 			subscriber.Close()
 		}
+		// Release the task now that async processing is complete. This example
+		// drives status through the subscriber instead of UpdateTaskState, so
+		// the stored task never reaches a terminal state and the TaskTTL reaper
+		// (terminal-only) would not collect it — explicit cleanup is required
+		// here to avoid leaking the task.
+		handle.CleanTask(&taskID)
 	}()
 
 	log.Infof("Starting async processing of task: %s", taskID)

--- a/examples/multi/reimbursement/main.go
+++ b/examples/multi/reimbursement/main.go
@@ -8,7 +8,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -134,30 +133,10 @@ func (p *reimbursementProcessor) ProcessMessage(
 		[]protocol.Part{protocol.NewTextPart(result)},
 	)
 
-	// Create result with potential artifact for completed requests
-	processingResult := &taskmanager.MessageProcessingResult{
+	// Return the reimbursement result as a message.
+	return &taskmanager.MessageProcessingResult{
 		Result: &responseMessage,
-	}
-
-	// Add artifact for completed reimbursement requests
-	if len(missing) == 0 {
-		// Build task to get artifact support
-		task, err := handle.BuildTask(nil, nil)
-		if err == nil {
-			// Create reimbursement details artifact
-			reimbursementJSON, _ := json.Marshal(reimbursement)
-			artifact := protocol.Artifact{
-				ArtifactID:  fmt.Sprintf("reimb-%s", reimbursement["request_id"]),
-				Name:        stringPtr("Reimbursement Details"),
-				Description: stringPtr(fmt.Sprintf("Processed reimbursement request %s", reimbursement["request_id"])),
-				Parts:       []protocol.Part{protocol.NewTextPart(string(reimbursementJSON))},
-			}
-
-			_ = handle.AddArtifact(&task, artifact, true, false)
-		}
-	}
-
-	return processingResult, nil
+	}, nil
 }
 
 // newReimbursementProcessor creates a new reimbursement processor

--- a/examples/streaming/server/main.go
+++ b/examples/streaming/server/main.go
@@ -81,6 +81,10 @@ func (p *streamingMessageProcessor) ProcessMessage(
 			if subscriber != nil {
 				subscriber.Close()
 			}
+			// Release the task once streaming is done. Terminal tasks are also
+			// reaped automatically after the manager's TaskTTL, but cleaning up
+			// explicitly frees the task and its resources immediately.
+			handle.CleanTask(&taskID)
 		}()
 
 		msg := protocol.NewMessage(

--- a/taskmanager/memory.go
+++ b/taskmanager/memory.go
@@ -22,7 +22,12 @@ import (
 const defaultMaxHistoryLength = 100
 const defaultCleanupInterval = 30 * time.Second
 const defaultConversationTTL = 1 * time.Hour
-const defaultTaskTTL = 0
+
+// defaultTaskTTL bounds how long a task in a terminal state is retained before
+// it is reaped automatically. A non-zero default means forgetting to call
+// TaskHandler.CleanTask bounds memory instead of leaking it, mirroring the
+// redis backend's key expiration. Set WithTaskTTL(0) to disable.
+const defaultTaskTTL = 1 * time.Hour
 const defaultSubscriberBufferSize = 1024
 
 // ConversationHistory stores conversation history information

--- a/taskmanager/memory_handler.go
+++ b/taskmanager/memory_handler.go
@@ -298,13 +298,16 @@ func (h *memoryTaskHandler) CleanTask(taskID *string) error {
 	task.Cancel()
 	delete(h.manager.Tasks, *taskID)
 
-	// Clean up subscribers while holding the lock to avoid another lock acquisition
-	for _, sub := range h.manager.Subscribers[*taskID] {
-		sub.Close()
-	}
+	// Collect subscribers under the lock but close them after releasing it, so a
+	// stuck blocking send can never wedge taskMu (mirrors cleanExpiredTasks).
+	subsToClose := h.manager.Subscribers[*taskID]
 	delete(h.manager.Subscribers, *taskID)
 
 	h.manager.taskMu.Unlock()
+
+	for _, sub := range subsToClose {
+		sub.Close()
+	}
 
 	// Drop any push notification config for the task. Guarded by the
 	// manager-wide mu, consistent with OnPushNotificationSet/Get and

--- a/taskmanager/memory_handler.go
+++ b/taskmanager/memory_handler.go
@@ -277,7 +277,11 @@ func (h *memoryTaskHandler) BuildTask(specificTaskID *string, contextID *string)
 	return actualTaskID, nil
 }
 
-// CancelTask cancels the task.
+// CleanTask removes the task and all resources associated with it: the task
+// entry, its subscribers, and any push notification config. It should be called
+// when the task is no longer needed. Terminal tasks are also reaped
+// automatically after the configured TaskTTL, so a missed CleanTask bounds
+// memory rather than leaking it.
 func (h *memoryTaskHandler) CleanTask(taskID *string) error {
 	if taskID == nil || *taskID == "" {
 		return fmt.Errorf("taskID cannot be nil or empty")
@@ -301,6 +305,14 @@ func (h *memoryTaskHandler) CleanTask(taskID *string) error {
 	delete(h.manager.Subscribers, *taskID)
 
 	h.manager.taskMu.Unlock()
+
+	// Drop any push notification config for the task. Guarded by the
+	// manager-wide mu, consistent with OnPushNotificationSet/Get and
+	// cleanExpiredTasks. Without this the config leaks even on the manual
+	// cleanup path.
+	h.manager.mu.Lock()
+	delete(h.manager.PushNotifications, *taskID)
+	h.manager.mu.Unlock()
 
 	return nil
 }

--- a/taskmanager/memory_handler_test.go
+++ b/taskmanager/memory_handler_test.go
@@ -177,13 +177,18 @@ func TestMemoryTaskHandler_GetTask(t *testing.T) {
 }
 
 func TestMemoryTaskHandler_CleanTask(t *testing.T) {
-	handler, _ := setupTestHandler(t)
+	handler, manager := setupTestHandler(t)
 
 	// First create a task
 	taskID, err := handler.BuildTask(nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to create task: %v", err)
 	}
+
+	// Register a push notification config so we can verify it is also cleaned.
+	manager.mu.Lock()
+	manager.PushNotifications[taskID] = protocol.TaskPushNotificationConfig{TaskID: taskID}
+	manager.mu.Unlock()
 
 	// Clean the task
 	err = handler.CleanTask(&taskID)
@@ -195,6 +200,15 @@ func TestMemoryTaskHandler_CleanTask(t *testing.T) {
 	_, err = handler.GetTask(&taskID)
 	if err == nil {
 		t.Error("Expected error when getting cleaned task, but got none")
+	}
+
+	// Verify the push notification config was cleaned too (no leak on the
+	// manual cleanup path).
+	manager.mu.RLock()
+	_, pushExists := manager.PushNotifications[taskID]
+	manager.mu.RUnlock()
+	if pushExists {
+		t.Error("Expected push notification config to be cleaned, but it still exists")
 	}
 }
 

--- a/taskmanager/memory_options.go
+++ b/taskmanager/memory_options.go
@@ -21,7 +21,8 @@ type MemoryTaskManagerOptions struct {
 
 	// TaskTTL is the maximum lifetime of tasks in terminal states (completed/failed/canceled/rejected).
 	// Tasks that have been in a terminal state longer than this duration will be automatically cleaned up.
-	// Default is 0 (disabled). Use WithTaskTTL to enable automatic task cleanup.
+	// Default is 1 hour, so a task that is never explicitly cleaned via TaskHandler.CleanTask is still
+	// reaped instead of leaking. Use WithTaskTTL to tune it, or WithTaskTTL(0) to disable auto cleanup.
 	TaskTTL time.Duration
 
 	// CleanupInterval is the interval for cleanup checks.
@@ -79,6 +80,7 @@ func WithConversationTTL(ttl, cleanupInterval time.Duration) MemoryTaskManagerOp
 // When enabled, tasks in terminal states (completed/failed/canceled/rejected) will be
 // automatically removed after the specified duration. A TTL of 0 disables task cleanup.
 // A positive ttl also enables the cleanup goroutine, mirroring WithConversationTTL.
+// If this option is not used, the default TTL is 1 hour (see defaultTaskTTL).
 func WithTaskTTL(ttl time.Duration) MemoryTaskManagerOption {
 	return func(opts *MemoryTaskManagerOptions) {
 		opts.TaskTTL = ttl

--- a/taskmanager/memory_test.go
+++ b/taskmanager/memory_test.go
@@ -1042,8 +1042,11 @@ func TestMemoryTaskManager_Close_Idempotent(t *testing.T) {
 func TestWithTaskTTL(t *testing.T) {
 	opts := DefaultMemoryTaskManagerOptions()
 
-	if opts.TaskTTL != 0 {
-		t.Errorf("Expected default TaskTTL=0 (disabled), got %v", opts.TaskTTL)
+	if opts.TaskTTL != time.Hour {
+		t.Errorf("Expected default TaskTTL=1h, got %v", opts.TaskTTL)
+	}
+	if !opts.EnableCleanup {
+		t.Error("Expected default options to enable cleanup so the default TaskTTL takes effect")
 	}
 
 	// A positive TTL also enables the cleanup goroutine, mirroring WithConversationTTL.


### PR DESCRIPTION
## Problem

The in-memory `TaskManager` expects callers to invoke `TaskHandler.CleanTask`
to release a task once it is no longer needed. In practice this is easy to
forget, and a missed call leaks the task **and** its push notification config
for the lifetime of the process.

A reaper already exists (`cleanExpiredTasks` / `WithTaskTTL`), but it was
**disabled by default** (`TaskTTL = 0`). So out of the box the memory backend
never reclaimed tasks — unlike the redis backend, whose keys expire after 1h.
The result is unbounded growth in long-running servers.

Two smaller gaps compound it:
- `CleanTask` deleted the task and its subscribers but **not** its push
  notification config, so that config leaked even on the manual cleanup path.
- Most examples never called `CleanTask` at all, so users copied a leaking
  pattern.

## Changes

- **Default `TaskTTL` to 1h.** Terminal tasks (completed/failed/canceled/
  rejected) are now reaped automatically, mirroring the redis key expiration
  and the existing conversation TTL. `WithTaskTTL(0)` restores the previous
  never-expire behavior; `WithTaskTTL(d)` tunes it.
- **`CleanTask` now also drops the push notification config** (guarded by the
  manager-wide mutex, consistent with `OnPushNotificationSet/Get` and
  `cleanExpiredTasks`).
- **Examples release tasks consistently:**
  - `streaming` — cleans up in the goroutine `defer` (task reaches a terminal
    state, so TTL would also reap it; explicit cleanup frees it immediately).
  - `jwks` — cleans up in the `defer`; this example drives status through the
    subscriber and never calls `UpdateTaskState`, so the stored task stays
    non-terminal and TTL would **not** reap it — explicit cleanup is required.
  - `reimbursement` — removes dead code that built a throwaway task solely to
    attach an artifact. Because the handler returns a `Message`, that task was
    never handed back to the caller (the client never learns its ID and cannot
    `tasks/get` it), so the artifact was unreachable and the task only leaked
    in the `submitted` state. The handler now simply returns its message.
  - `basic` — documents why a multi-turn task intentionally outlives the call
    (it can park in `input-required` across turns) and relies on framework-side
    TTL reaping.

## Compatibility

This changes the default **observable** behavior of the memory backend: a
terminal task fetched via `tasks/get` more than ~1h after it finished now
returns `NotFound` (previously it lived forever). No API signatures change;
it is source- and binary-compatible. Callers that need the old behavior can
set `WithTaskTTL(0)`, and those needing a longer retention window can pass a
larger duration. The redis backend is unaffected (it already expired at 1h),
so the two backends are now consistent.

Note: this bounds only **terminal** tasks. A task that never reaches a
terminal state (e.g. abandoned in `submitted` / `input-required`) is still
retained, as auto-reaping a possibly-still-running task would be unsafe.

## Testing

- `go test ./taskmanager/...` (incl. `-race`) passes.
- `TestWithTaskTTL` updated for the new default; `TestMemoryTaskHandler_CleanTask`
  extended to assert the push notification config is cleaned.