### PR TITLE
docs, chore: introduce the v2 branch in the README; align stray copyright headers to Tencent

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 
 This is tRPC group's Go implementation of the [A2A protocol](https://google.github.io/A2A/), enabling different AI agents to discover and collaborate with each other.
 
+> **Looking for A2A protocol v1.0?** It is developed on the [`v2`](https://github.com/trpc-group/trpc-a2a-go/tree/v2) branch.
+>
+> This `main` branch is the **v0.x** line (Go module `trpc.group/trpc-go/trpc-a2a-go`), tracking the A2A v0.2.x spec. The **v1.0** release — Go module `trpc.group/trpc-go/trpc-a2a-go/v2` — implements the A2A v1.0 specification with a redesigned event-stream API and lives on the [`v2`](https://github.com/trpc-group/trpc-a2a-go/tree/v2) branch. See its [README](https://github.com/trpc-group/trpc-a2a-go/blob/v2/README.md) for details.
+
 ## Related Projects
 
 tRPC AI ecosystem

--- a/server/tracker.go
+++ b/server/tracker.go
@@ -1,6 +1,6 @@
 // Tencent is pleased to support the open source community by making trpc-a2a-go available.
 //
-// Copyright (C) 2025 THL A29 Limited, a Tencent company.  All rights reserved.
+// Copyright (C) 2025 Tencent.  All rights reserved.
 //
 // trpc-a2a-go is licensed under the Apache License Version 2.0.
 

--- a/telemetry/metrics/instruments.go
+++ b/telemetry/metrics/instruments.go
@@ -1,6 +1,6 @@
 // Tencent is pleased to support the open source community by making trpc-a2a-go available.
 //
-// Copyright (C) 2025 THL A29 Limited, a Tencent company.  All rights reserved.
+// Copyright (C) 2025 Tencent.  All rights reserved.
 //
 // trpc-a2a-go is licensed under the Apache License Version 2.0.
 

--- a/telemetry/metrics/provider.go
+++ b/telemetry/metrics/provider.go
@@ -1,6 +1,6 @@
 // Tencent is pleased to support the open source community by making trpc-a2a-go available.
 //
-// Copyright (C) 2025 THL A29 Limited, a Tencent company.  All rights reserved.
+// Copyright (C) 2025 Tencent.  All rights reserved.
 //
 // trpc-a2a-go is licensed under the Apache License Version 2.0.
 

--- a/telemetry/tracker.go
+++ b/telemetry/tracker.go
@@ -1,6 +1,6 @@
 // Tencent is pleased to support the open source community by making trpc-a2a-go available.
 //
-// Copyright (C) 2025 THL A29 Limited, a Tencent company.  All rights reserved.
+// Copyright (C) 2025 Tencent.  All rights reserved.
 //
 // trpc-a2a-go is licensed under the Apache License Version 2.0.
 


### PR DESCRIPTION
## What

Two small housekeeping changes on `main` (README/copyright only, no code behavior):

1. **README** — add a note near the top pointing users to the [`v2`](https://github.com/trpc-group/trpc-a2a-go/tree/v2) branch, where the A2A protocol v1.0 release (module `trpc.group/trpc-go/trpc-a2a-go/v2`) is developed, and clarifying that `main` is the v0.x line.
2. **Copyright headers** — four files still carried `Copyright (C) 2025 THL A29 Limited, a Tencent company`; the rest of the tree uses `Copyright (C) 2025 Tencent`. Align them (`server/tracker.go`, `telemetry/metrics/{instruments,provider}.go`, `telemetry/tracker.go`).

The README `## Copyright` section and the `LICENSE` file are unchanged.