### PR TITLE
docs, chore: sync README copyright section with main; align copyright headers to Tencent

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ tRPC AI ecosystem
 - [Future Enhancements](#future-enhancements)
 - [Contributing](#contributing)
 - [Acknowledgements](#acknowledgements)
-- [License](#license)
+- [Copyright](#copyright)
 
 ## Quick Start
 
@@ -736,6 +736,6 @@ Contributions and improvement suggestions are welcome! Please ensure your code f
 
 This project's protocol design is based on Google's open-source A2A protocol ([original repository](https://github.com/google/A2A)), following the Apache 2.0 license. This is an unofficial implementation.
 
-## License
+## Copyright
 
-Licensed under the **Apache 2.0 License** - see [LICENSE](LICENSE) file for details.
+The copyright notice pertaining to the Tencent code in this repo was previously in the name of “THL A29 Limited.”  That entity has now been de-registered.  You should treat all previously distributed copies of the code as if the copyright notice was in the name of “Tencent.”

--- a/server/tracker.go
+++ b/server/tracker.go
@@ -1,6 +1,6 @@
 // Tencent is pleased to support the open source community by making trpc-a2a-go available.
 //
-// Copyright (C) 2025 THL A29 Limited, a Tencent company.  All rights reserved.
+// Copyright (C) 2025 Tencent.  All rights reserved.
 //
 // trpc-a2a-go is licensed under the Apache License Version 2.0.
 

--- a/telemetry/metrics/instruments.go
+++ b/telemetry/metrics/instruments.go
@@ -1,6 +1,6 @@
 // Tencent is pleased to support the open source community by making trpc-a2a-go available.
 //
-// Copyright (C) 2025 THL A29 Limited, a Tencent company.  All rights reserved.
+// Copyright (C) 2025 Tencent.  All rights reserved.
 //
 // trpc-a2a-go is licensed under the Apache License Version 2.0.
 

--- a/telemetry/metrics/provider.go
+++ b/telemetry/metrics/provider.go
@@ -1,6 +1,6 @@
 // Tencent is pleased to support the open source community by making trpc-a2a-go available.
 //
-// Copyright (C) 2025 THL A29 Limited, a Tencent company.  All rights reserved.
+// Copyright (C) 2025 Tencent.  All rights reserved.
 //
 // trpc-a2a-go is licensed under the Apache License Version 2.0.
 

--- a/telemetry/tracker.go
+++ b/telemetry/tracker.go
@@ -1,6 +1,6 @@
 // Tencent is pleased to support the open source community by making trpc-a2a-go available.
 //
-// Copyright (C) 2025 THL A29 Limited, a Tencent company.  All rights reserved.
+// Copyright (C) 2025 Tencent.  All rights reserved.
 //
 // trpc-a2a-go is licensed under the Apache License Version 2.0.
 


### PR DESCRIPTION
## What

Bring `v2`'s copyright presentation in line with `main`:

1. **README** — replace the Apache 2.0 `## License` section with `main`'s `## Copyright` note (and the matching TOC entry), so both branches present copyright the same way.
2. **Copyright headers** — four files still carried `Copyright (C) 2025 THL A29 Limited, a Tencent company`; the rest of the tree uses `Copyright (C) 2025 Tencent`. Align them (`server/tracker.go`, `telemetry/metrics/{instruments,provider}.go`, `telemetry/tracker.go`).

The `LICENSE` file already matches `main` and is unchanged. Companion to #116 on `main`.