### PR TITLE
protocol: add NewAgentText; drop taskmanager.ReplyText

### DIFF
--- a/examples/auth/server/main.go
+++ b/examples/auth/server/main.go
@@ -348,7 +348,7 @@ func (p *echoMessageProcessor) ProcessMessage(
 	}
 
 	// A pure message reply: no task comes into existence this round.
-	handle.Reply(taskmanager.ReplyText(fmt.Sprintf("Echo: %s", responseText)))
+	handle.Reply(protocol.NewAgentText(fmt.Sprintf("Echo: %s", responseText)))
 	return handle.Events(), nil
 }
 

--- a/examples/basic/server/main.go
+++ b/examples/basic/server/main.go
@@ -74,7 +74,7 @@ func (p *basicMessageProcessor) ProcessMessage(
 	text := extractText(ec.Message)
 	if text == "" {
 		// A pure message reply: no task comes into existence this round.
-		handle.Reply(taskmanager.ReplyText("input message must contain text"))
+		handle.Reply(protocol.NewAgentText("input message must contain text"))
 		return handle.Events(), nil
 	}
 
@@ -100,7 +100,7 @@ func (p *basicMessageProcessor) ProcessMessage(
 		// Suspend the task awaiting the processing mode: the follow-up
 		// message arrives as a new round with ExecContext.Task set.
 		p.multiTurnSessions[contextID] = multiTurnSession{stage: 1}
-		handle.UpdateTaskState(protocol.TaskStateInputRequired, taskmanager.ReplyText(
+		handle.UpdateTaskState(protocol.TaskStateInputRequired, protocol.NewAgentText(
 			"This is a multi-step interaction. Please select a processing mode:\n"+
 				"- reverse: Reverses the text\n"+
 				"- uppercase: Converts text to uppercase\n"+
@@ -109,10 +109,10 @@ func (p *basicMessageProcessor) ProcessMessage(
 	case modeInputExample:
 		p.multiTurnSessions[contextID] = multiTurnSession{stage: 2, mode: modeReverse}
 		handle.UpdateTaskState(protocol.TaskStateInputRequired,
-			taskmanager.ReplyText("Please provide more information to continue:"))
+			protocol.NewAgentText("Please provide more information to continue:"))
 	case modeHelp:
 		// Plain answers need no task either.
-		handle.Reply(taskmanager.ReplyText(p.processTextWithMode(content, command)))
+		handle.Reply(protocol.NewAgentText(p.processTextWithMode(content, command)))
 	default:
 		p.processCommand(handle, contextID, command, content)
 	}
@@ -145,7 +145,7 @@ func (p *basicMessageProcessor) processCommand(
 			"contextID":    contextID,
 		},
 	}, true)
-	handle.UpdateTaskState(protocol.TaskStateCompleted, taskmanager.ReplyText(result))
+	handle.UpdateTaskState(protocol.TaskStateCompleted, protocol.NewAgentText(result))
 }
 
 // continueMultiTurnSession processes the next step of a multi-turn interaction.
@@ -164,7 +164,7 @@ func (p *basicMessageProcessor) continueMultiTurnSession(
 
 		// Ask for the text to process
 		handle.UpdateTaskState(protocol.TaskStateInputRequired,
-			taskmanager.ReplyText("Please enter the text you want to process:"))
+			protocol.NewAgentText("Please enter the text you want to process:"))
 	case 2:
 		// Second response received - this is the text to process
 		session.text = text
@@ -187,7 +187,7 @@ func (p *basicMessageProcessor) continueMultiTurnSession(
 				"contextID":    contextID,
 			},
 		}, true)
-		handle.UpdateTaskState(protocol.TaskStateCompleted, taskmanager.ReplyText(result))
+		handle.UpdateTaskState(protocol.TaskStateCompleted, protocol.NewAgentText(result))
 	}
 }
 

--- a/examples/compat/server/main.go
+++ b/examples/compat/server/main.go
@@ -51,7 +51,7 @@ func (p *reverseProcessor) ProcessMessage(
 	text := extractText(ec.Message)
 	if text == "" {
 		// A pure message reply: no task comes into existence this round.
-		handle.Reply(taskmanager.ReplyText("input message must contain text"))
+		handle.Reply(protocol.NewAgentText("input message must contain text"))
 		handle.Close()
 		return handle.Events(), nil
 	}
@@ -79,7 +79,7 @@ func (p *reverseProcessor) ProcessMessage(
 			Parts:      []*protocol.Part{protocol.NewTextPart(result)},
 		}, true)
 		handle.UpdateTaskState(protocol.TaskStateCompleted,
-			taskmanager.ReplyText(fmt.Sprintf("Reversed: %s", result)))
+			protocol.NewAgentText(fmt.Sprintf("Reversed: %s", result)))
 	}()
 	return handle.Events(), nil
 }

--- a/examples/jwks/server/main.go
+++ b/examples/jwks/server/main.go
@@ -82,7 +82,7 @@ func (p *pushNotificationMessageProcessor) ProcessMessage(
 	// Move the task to working before returning: this persisted snapshot
 	// answers a returnImmediately unary call while processing continues below.
 	if err := handle.UpdateTaskState(protocol.TaskStateWorking,
-		taskmanager.ReplyText("Task queued for processing...")); err != nil {
+		protocol.NewAgentText("Task queued for processing...")); err != nil {
 		log.Errorf("Failed to send working event: %v", err)
 	}
 
@@ -121,7 +121,7 @@ func (p *pushNotificationMessageProcessor) processTaskAsync(
 	}
 
 	if err := handle.UpdateTaskState(protocol.TaskStateCompleted,
-		taskmanager.ReplyText(completeMsg)); err != nil {
+		protocol.NewAgentText(completeMsg)); err != nil {
 		log.Errorf("Failed to send completed event: %v", err)
 		return
 	}

--- a/examples/multi/creative/main.go
+++ b/examples/multi/creative/main.go
@@ -104,7 +104,7 @@ func (p *creativeWritingProcessor) ProcessMessage(
 		log.Error("Message processing failed: %s", errMsg)
 
 		// Reply with the error message directly
-		handle.Reply(taskmanager.ReplyText(errMsg))
+		handle.Reply(protocol.NewAgentText(errMsg))
 		return handle.Events(), nil
 	}
 
@@ -139,7 +139,7 @@ func (p *creativeWritingProcessor) ProcessMessage(
 		errorMsg := fmt.Sprintf("Failed to generate response: %v", err)
 		log.Error("Message processing failed: %s", errorMsg)
 
-		handle.Reply(taskmanager.ReplyText(errorMsg))
+		handle.Reply(protocol.NewAgentText(errorMsg))
 		return handle.Events(), nil
 	}
 
@@ -148,7 +148,7 @@ func (p *creativeWritingProcessor) ProcessMessage(
 	p.cache.AddMessage(sessionID, fmt.Sprintf("Assistant: %s", response))
 
 	// Reply with the generated text
-	handle.Reply(taskmanager.ReplyText(response))
+	handle.Reply(protocol.NewAgentText(response))
 	return handle.Events(), nil
 }
 

--- a/examples/multi/exchange/main.go
+++ b/examples/multi/exchange/main.go
@@ -69,7 +69,7 @@ func (p *exchangeProcessor) ProcessMessage(
 		log.Error("Message processing failed: %s", errMsg)
 
 		// Reply with the error message directly
-		handle.Reply(taskmanager.ReplyText(errMsg))
+		handle.Reply(protocol.NewAgentText(errMsg))
 		return handle.Events(), nil
 	}
 
@@ -132,7 +132,7 @@ func (p *exchangeProcessor) ProcessMessage(
 		completion, err := llms.GenerateFromSinglePrompt(ctx, p.llm, prompt)
 		if err == nil && !strings.Contains(strings.ToLower(completion), "exchange rate") {
 			// The LLM indicated this wasn't about exchange rates
-			handle.Reply(taskmanager.ReplyText(completion))
+			handle.Reply(protocol.NewAgentText(completion))
 			return handle.Events(), nil
 		}
 	}
@@ -141,7 +141,7 @@ func (p *exchangeProcessor) ProcessMessage(
 	result, err := getExchangeRate(fromCurrency, toCurrency, date)
 	if err != nil {
 		log.Error("Exchange rate error: %v", err)
-		handle.Reply(taskmanager.ReplyText(fmt.Sprintf("Error processing request: %v", err)))
+		handle.Reply(protocol.NewAgentText(fmt.Sprintf("Error processing request: %v", err)))
 		return handle.Events(), nil
 	}
 
@@ -152,7 +152,7 @@ func (p *exchangeProcessor) ProcessMessage(
 	log.Info("Responding with: %s", finalResponse)
 
 	// Reply with the formatted result
-	handle.Reply(taskmanager.ReplyText(finalResponse))
+	handle.Reply(protocol.NewAgentText(finalResponse))
 	return handle.Events(), nil
 }
 

--- a/examples/multi/reimbursement/main.go
+++ b/examples/multi/reimbursement/main.go
@@ -47,7 +47,7 @@ func (p *reimbursementProcessor) ProcessMessage(
 		log.Error("Message processing failed: %s", errMsg)
 
 		// Reply with the error message directly
-		handle.Reply(taskmanager.ReplyText(errMsg))
+		handle.Reply(protocol.NewAgentText(errMsg))
 		return handle.Events(), nil
 	}
 
@@ -109,7 +109,7 @@ func (p *reimbursementProcessor) ProcessMessage(
 
 		// Reply with the request for more information; no task comes into
 		// existence for an incomplete request.
-		handle.Reply(taskmanager.ReplyText(result))
+		handle.Reply(protocol.NewAgentText(result))
 		return handle.Events(), nil
 	}
 
@@ -143,7 +143,7 @@ func (p *reimbursementProcessor) ProcessMessage(
 		Parts:       []*protocol.Part{protocol.NewTextPart(string(reimbursementJSON))},
 	}, true)
 
-	handle.UpdateTaskState(protocol.TaskStateCompleted, taskmanager.ReplyText(result))
+	handle.UpdateTaskState(protocol.TaskStateCompleted, protocol.NewAgentText(result))
 	return handle.Events(), nil
 }
 

--- a/examples/multi/root/main.go
+++ b/examples/multi/root/main.go
@@ -51,7 +51,7 @@ func (p *rootAgentProcessor) ProcessMessage(
 		log.Error("Message processing failed: %s", errMsg)
 
 		// Reply with the error message directly
-		handle.Reply(taskmanager.ReplyText(errMsg))
+		handle.Reply(protocol.NewAgentText(errMsg))
 		return handle.Events(), nil
 	}
 
@@ -61,7 +61,7 @@ func (p *rootAgentProcessor) ProcessMessage(
 	subagent, err := p.routeTaskToSubagent(ctx, text)
 	if err != nil {
 		log.Error("Error routing task: %v", err)
-		handle.Reply(taskmanager.ReplyText(fmt.Sprintf("Failed to process your request: %v", err)))
+		handle.Reply(protocol.NewAgentText(fmt.Sprintf("Failed to process your request: %v", err)))
 		return handle.Events(), nil
 	}
 
@@ -87,12 +87,12 @@ func (p *rootAgentProcessor) ProcessMessage(
 
 	if err != nil {
 		log.Error("Error from subagent: %v", err)
-		handle.Reply(taskmanager.ReplyText(fmt.Sprintf("Failed to get response from subagent: %v", err)))
+		handle.Reply(protocol.NewAgentText(fmt.Sprintf("Failed to get response from subagent: %v", err)))
 		return handle.Events(), nil
 	}
 
 	// Reply with the aggregated subagent response
-	handle.Reply(taskmanager.ReplyText(result))
+	handle.Reply(protocol.NewAgentText(result))
 	return handle.Events(), nil
 }
 

--- a/examples/redis/server/main.go
+++ b/examples/redis/server/main.go
@@ -81,7 +81,7 @@ func (p *ToLowerProcessor) ProcessMessage(
 	if inputText == "" {
 		// A pure message reply: no task comes into existence this round.
 		defer handle.Close()
-		handle.Reply(taskmanager.ReplyText("Error: No text found in message"))
+		handle.Reply(protocol.NewAgentText("Error: No text found in message"))
 		return handle.Events(), nil
 	}
 
@@ -121,7 +121,7 @@ func extractTextFromMessage(message protocol.Message) string {
 // without a terminal state, letting the framework persist CANCELED.
 func (p *ToLowerProcessor) processText(ctx context.Context, inputText string, handle *taskmanager.TaskHandle) {
 	// Step 1: Starting processing
-	err := handle.UpdateTaskState(protocol.TaskStateWorking, taskmanager.ReplyText(msgStarting))
+	err := handle.UpdateTaskState(protocol.TaskStateWorking, protocol.NewAgentText(msgStarting))
 	if err != nil {
 		log.Printf("Failed to update task state: %v", err)
 		return
@@ -134,7 +134,7 @@ func (p *ToLowerProcessor) processText(ctx context.Context, inputText string, ha
 
 	// Step 2: Analysis phase
 	err = handle.UpdateTaskState(protocol.TaskStateWorking,
-		taskmanager.ReplyText(fmt.Sprintf(msgAnalyzing, len(inputText))))
+		protocol.NewAgentText(fmt.Sprintf(msgAnalyzing, len(inputText))))
 	if err != nil {
 		log.Printf("Failed to update task state: %v", err)
 		return
@@ -146,7 +146,7 @@ func (p *ToLowerProcessor) processText(ctx context.Context, inputText string, ha
 	}
 
 	// Step 3: Processing phase
-	err = handle.UpdateTaskState(protocol.TaskStateWorking, taskmanager.ReplyText(msgProcessing))
+	err = handle.UpdateTaskState(protocol.TaskStateWorking, protocol.NewAgentText(msgProcessing))
 	if err != nil {
 		log.Printf("Failed to update task state: %v", err)
 		return
@@ -161,7 +161,7 @@ func (p *ToLowerProcessor) processText(ctx context.Context, inputText string, ha
 	result := strings.ToLower(inputText)
 
 	// Step 4: Creating artifact
-	err = handle.UpdateTaskState(protocol.TaskStateWorking, taskmanager.ReplyText(msgArtifact))
+	err = handle.UpdateTaskState(protocol.TaskStateWorking, protocol.NewAgentText(msgArtifact))
 	if err != nil {
 		log.Printf("Failed to update task state: %v", err)
 		return
@@ -197,7 +197,7 @@ func (p *ToLowerProcessor) processText(ctx context.Context, inputText string, ha
 	// round terminal replaces the former CleanTask: the framework owns the
 	// task lifecycle (set redis.WithExpireTime to bound retention).
 	err = handle.UpdateTaskState(protocol.TaskStateCompleted,
-		taskmanager.ReplyText(fmt.Sprintf(msgCompleted, inputText, result)))
+		protocol.NewAgentText(fmt.Sprintf(msgCompleted, inputText, result)))
 	if err != nil {
 		log.Printf("Failed to complete task: %v", err)
 	}

--- a/examples/simple/server/main.go
+++ b/examples/simple/server/main.go
@@ -42,7 +42,7 @@ func (e *simpleMessageProcessor) ProcessMessage(
 		text := extractText(ec.Message)
 		if text == "" {
 			// A pure-message reply: no task comes into existence for this round.
-			out <- taskmanager.ReplyText("input message must contain text.")
+			out <- protocol.NewAgentText("input message must contain text.")
 			return
 		}
 
@@ -69,7 +69,7 @@ func (e *simpleMessageProcessor) ProcessMessage(
 		out <- &protocol.TaskStatusUpdateEvent{
 			Status: protocol.TaskStatus{
 				State:   protocol.TaskStateCompleted,
-				Message: taskmanager.ReplyText(fmt.Sprintf("Processed result: %s", result)),
+				Message: protocol.NewAgentText(fmt.Sprintf("Processed result: %s", result)),
 			},
 		}
 	}()

--- a/examples/streaming/server/main.go
+++ b/examples/streaming/server/main.go
@@ -55,7 +55,7 @@ func (p *streamingMessageProcessor) ProcessMessage(
 		log.Errorf("Message processing failed: %s", errMsg)
 
 		// A pure message reply: no task comes into existence this round.
-		handle.Reply(taskmanager.ReplyText(errMsg))
+		handle.Reply(protocol.NewAgentText(errMsg))
 		handle.Close()
 		return handle.Events(), nil
 	}
@@ -67,7 +67,7 @@ func (p *streamingMessageProcessor) ProcessMessage(
 		defer handle.Close()
 
 		if err := handle.UpdateTaskState(protocol.TaskStateWorking,
-			taskmanager.ReplyText("Starting to process your streaming data...")); err != nil {
+			protocol.NewAgentText("Starting to process your streaming data...")); err != nil {
 			log.Errorf("Failed to send working event: %v", err)
 			return
 		}
@@ -91,7 +91,7 @@ func (p *streamingMessageProcessor) ProcessMessage(
 				i+1, totalChunks, chunk, processedChunk)
 
 			if err := handle.UpdateTaskState(protocol.TaskStateWorking,
-				taskmanager.ReplyText(progressMsg)); err != nil {
+				protocol.NewAgentText(progressMsg)); err != nil {
 				log.Errorf("Failed to send working event: %v", err)
 				return
 			}
@@ -121,7 +121,7 @@ func (p *streamingMessageProcessor) ProcessMessage(
 
 		// Final completion status ends the round; the message/send caller
 		// receives this final task snapshot (with its artifacts).
-		if err := handle.UpdateTaskState(protocol.TaskStateCompleted, taskmanager.ReplyText(
+		if err := handle.UpdateTaskState(protocol.TaskStateCompleted, protocol.NewAgentText(
 			fmt.Sprintf("Completed processing all %d chunks successfully!", totalChunks))); err != nil {
 			log.Errorf("Failed to update task state: %v", err)
 			return

--- a/examples/subpath/main.go
+++ b/examples/subpath/main.go
@@ -32,7 +32,7 @@ func (p *simpleProcessor) ProcessMessage(
 	defer handle.Close()
 
 	// Simply return a text response: a pure message reply, no task materializes.
-	handle.Reply(taskmanager.ReplyText("Hello from subpath agent!"))
+	handle.Reply(protocol.NewAgentText("Hello from subpath agent!"))
 	return handle.Events(), nil
 }
 

--- a/examples/tenant/server/main.go
+++ b/examples/tenant/server/main.go
@@ -87,9 +87,9 @@ func (p *multiAgentProcessor) ProcessMessage(
 
 	switch ec.Tenant {
 	case "chatAgent":
-		handle.Reply(taskmanager.ReplyText("Hello from chat agent!"))
+		handle.Reply(protocol.NewAgentText("Hello from chat agent!"))
 	case "workerAgent":
-		handle.Reply(taskmanager.ReplyText("Hello from worker agent!"))
+		handle.Reply(protocol.NewAgentText("Hello from worker agent!"))
 	default:
 		// Returning an error means the round failed to start: it is mapped to
 		// a JSON-RPC error, no task comes into existence.

--- a/protocol/types.go
+++ b/protocol/types.go
@@ -548,6 +548,14 @@ func NewMessageWithContext(role MessageRole, parts []*Part, taskID, contextID *s
 	}
 }
 
+// NewAgentText creates an agent-role Message carrying a single text part. It is
+// a shorthand for building the status or reply messages an agent emits from a
+// plain string.
+func NewAgentText(text string) *Message {
+	message := NewMessage(MessageRoleAgent, []*Part{NewTextPart(text)})
+	return &message
+}
+
 // NewArtifactWithID creates a new Artifact with a generated ID.
 func NewArtifactWithID(name, description *string, parts []*Part) *Artifact {
 	return &Artifact{

--- a/taskmanager/handle.go
+++ b/taskmanager/handle.go
@@ -39,7 +39,7 @@ const liveBuffer = 8
 //		h.UpdateTaskState(protocol.TaskStateWorking, nil)
 //		// ... work ...
 //		h.AddArtifact(artifact, true)
-//		h.UpdateTaskState(protocol.TaskStateCompleted, taskmanager.ReplyText("done"))
+//		h.UpdateTaskState(protocol.TaskStateCompleted, protocol.NewAgentText("done"))
 //		return h.Events(), nil
 //	}
 //
@@ -179,14 +179,4 @@ func (h *TaskHandle) AddArtifact(artifact protocol.Artifact, lastChunk bool) err
 // Reply emits a direct message reply (the former pure-Message result path).
 func (h *TaskHandle) Reply(message *protocol.Message) error {
 	return h.emit(message)
-}
-
-// ReplyText builds an agent text message, for Reply or as the message
-// attached to UpdateTaskState.
-func ReplyText(text string) *protocol.Message {
-	message := protocol.NewMessage(
-		protocol.MessageRoleAgent,
-		[]*protocol.Part{protocol.NewTextPart(text)},
-	)
-	return &message
 }

--- a/taskmanager/handle_test.go
+++ b/taskmanager/handle_test.go
@@ -95,7 +95,7 @@ func TestTaskHandle_DeferClosePattern(t *testing.T) {
 		h := NewTaskHandle(context.Background(), &ExecContext{TaskID: "task-1"})
 		defer h.Close()
 		h.UpdateTaskState(protocol.TaskStateWorking, nil)
-		h.UpdateTaskState(protocol.TaskStateCompleted, ReplyText("done"))
+		h.UpdateTaskState(protocol.TaskStateCompleted, protocol.NewAgentText("done"))
 		return h.Events()
 	}
 
@@ -170,7 +170,7 @@ func TestTaskHandle_EmitSucceedsAfterCancel(t *testing.T) {
 	h := NewTaskHandle(ctx, &ExecContext{TaskID: "task-1"})
 
 	// Pre-Events emits always succeed, canceled or not.
-	if err := h.UpdateTaskState(protocol.TaskStateCompleted, ReplyText("done")); err != nil {
+	if err := h.UpdateTaskState(protocol.TaskStateCompleted, protocol.NewAgentText("done")); err != nil {
 		t.Fatalf("queued emit after cancel must succeed (terminal wins), got %v", err)
 	}
 	// Live emits with buffer space succeed too.

--- a/taskmanager/memory/memory_engine_test.go
+++ b/taskmanager/memory/memory_engine_test.go
@@ -1119,7 +1119,7 @@ func TestEngine_TaskHandleFacade(t *testing.T) {
 					ArtifactID: "art-1",
 					Parts:      []*protocol.Part{protocol.NewTextPart("data")},
 				}, true)
-				h.UpdateTaskState(protocol.TaskStateCompleted, taskmanager.ReplyText("done"))
+				h.UpdateTaskState(protocol.TaskStateCompleted, protocol.NewAgentText("done"))
 			}()
 			return h.Events(), nil
 		})
@@ -1145,7 +1145,7 @@ func TestEngine_SynchronousTaskHandle(t *testing.T) {
 		func(ctx context.Context, ec *taskmanager.ExecContext) (<-chan protocol.StreamEvent, error) {
 			h := taskmanager.NewTaskHandle(ctx, ec)
 			defer h.Close()
-			h.Reply(taskmanager.ReplyText("sync answer"))
+			h.Reply(protocol.NewAgentText("sync answer"))
 			return h.Events(), nil
 		})
 	manager := newTestManager(t, processor)


### PR DESCRIPTION
## What

Moves the agent text-message shorthand out of `taskmanager` and into `protocol`.

- `protocol.NewAgentText(text)` — a new constructor next to `NewMessage` /
  `NewTextPart`, building an agent-role single-text-part message.
- Removes `taskmanager.ReplyText`. A `protocol.Message` constructor did not
  belong in the `taskmanager` package, and the "Reply" name was inaccurate — it
  was used mostly as the message on `UpdateTaskState` status events, not only
  for replies.
- Replaces every `taskmanager.ReplyText(...)` with `protocol.NewAgentText(...)`
  across the examples and the taskmanager tests.

## Scope

`protocol/types.go`, `taskmanager/handle.go` (+ tests), and 13 example files.
Mechanical rename; no behavior change.

## Notes

- Breaking: `taskmanager.ReplyText` is removed. Acceptable on the v2 alpha line.
- Overlaps with #118 (which still uses `taskmanager.ReplyText` in its new
  files); whichever lands second will be rebased onto the other.

## Testing

`go build ./...`, `go test ./protocol/... ./taskmanager/...`, and the examples
module build are all clean.