### PR TITLE
chore: drop dead golint setting from .golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,6 @@
 linters-settings:
   gocyclo:
     min-complexity: 20
-  goliddjoijnt:
-    min-confidence: 0
   revive:
     rules:
       - name: package-comments


### PR DESCRIPTION
## What

Remove the dead `goliddjoijnt` entry from `.golangci.yml`.

## Why

- `goliddjoijnt` is a typo for `golint`.
- `golint` was removed from golangci-lint a long time ago and is superseded by `revive`, which is already enabled in this config.
- The key matched no active linter, so `linters-settings` silently ignored it. Deleting it is a no-op for lint behavior and just removes the confusion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality checks to use clearer linting rules for package comments and exported names.
  * Removed an invalid lint setting so linting runs are more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->