### PR TITLE
ci: port CodeRabbit review config and lint cleanup to v2

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,61 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+#
+# CodeRabbit AI code review configuration.
+# This file only customizes review behavior. Enabling CodeRabbit itself is done
+# by installing the CodeRabbit GitHub App on the repository/organization; no CI
+# workflow is required.
+
+language: en-US
+
+reviews:
+  # "chill" keeps a balanced signal-to-noise ratio; switch to "assertive" for
+  # stricter nitpicks or "quiet" for the minimum.
+  profile: chill
+  # Post comments only; do not formally block merges with "changes requested".
+  request_changes_workflow: false
+  high_level_summary: true
+  review_status: true
+  collapse_walkthrough: true
+  # Skip the auto-generated poem for a cleaner PR thread.
+  poem: false
+
+  auto_review:
+    enabled: true
+    # Do not spend reviews on draft PRs.
+    drafts: false
+
+  # Do not review generated code (mirrors .golangci.yml and .typos.toml).
+  path_filters:
+    - "!**/*.pb.go"
+    - "!**/*_mock.go"
+    - "!**/*.gen.go"
+    - "!**/*.trpc.go"
+    - "!**/*_string.go"
+    - "!go.sum"
+
+  path_instructions:
+    - path: "**/*.go"
+      instructions: >-
+        Follow the rules in .golangci.yml. Flag exported identifiers that lack a
+        doc comment (revive/exported), potential security issues (gosec), and
+        functions whose cyclomatic complexity exceeds 20 (gocyclo). Prefer
+        concrete, actionable suggestions over pure style nitpicks.
+
+  tools:
+    # Reuse the repo's existing linter config so CodeRabbit and CI stay aligned.
+    golangci-lint:
+      enabled: true
+      config_file: .golangci.yml
+    # Wait for and incorporate existing CI check results (build/test/lint).
+    github-checks:
+      enabled: true
+    # Secret scanning on changed files.
+    gitleaks:
+      enabled: true
+    # Lint the GitHub Actions workflows themselves.
+    actionlint:
+      enabled: true
+
+chat:
+  # Let contributors talk to CodeRabbit without @-mentioning it every time.
+  auto_reply: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,6 @@
 linters-settings:
   gocyclo:
     min-complexity: 20
-  goliddjoijnt:
-    min-confidence: 0
   revive:
     rules:
       - name: package-comments


### PR DESCRIPTION
Cherry-picks two CI/config commits from main (#120, #121) onto v2:

- `ci: add CodeRabbit AI review configuration` — adds `.coderabbit.yaml`
- `chore: drop dead golint setting from .golangci.yml`

For public repositories CodeRabbit only applies the configuration from the **base branch** of a PR, so PRs targeting v2 currently run with defaults. Porting the config to v2 makes those PRs use the same review settings (path filters for generated code, golangci-lint/gitleaks/actionlint integration) as main.

Both files are byte-identical to main after the pick; v2-specific CI changes (codecov ignore for the frozen v0 compat snapshot) are untouched.