### PR TITLE
docs: fix stale taskmanager.ReplyText in example READMEs

### DIFF
--- a/examples/subpath/README.md
+++ b/examples/subpath/README.md
@@ -37,7 +37,7 @@ func (p *simpleProcessor) ProcessMessage(
     defer handle.Close()
 
     // A pure message reply: no task materializes.
-    handle.Reply(taskmanager.ReplyText("Hello from subpath agent!"))
+    handle.Reply(protocol.NewAgentText("Hello from subpath agent!"))
     return handle.Events(), nil
 }
 

--- a/examples/tenant/README.md
+++ b/examples/tenant/README.md
@@ -104,9 +104,9 @@ func (p *multiAgentProcessor) ProcessMessage(
     defer handle.Close()
     switch ec.Tenant {
     case "chatAgent":
-        handle.Reply(taskmanager.ReplyText("Hello from chat agent!"))
+        handle.Reply(protocol.NewAgentText("Hello from chat agent!"))
     case "workerAgent":
-        handle.Reply(taskmanager.ReplyText("Hello from worker agent!"))
+        handle.Reply(protocol.NewAgentText("Hello from worker agent!"))
     default:
         return nil, fmt.Errorf("no such tenant %q", ec.Tenant)
     }


### PR DESCRIPTION
#119 replaced `taskmanager.ReplyText` with `protocol.NewAgentText` in the
example code but missed the code snippets in two example READMEs, which still
reference the now-removed function (they would not compile if copied):

- `examples/subpath/README.md`
- `examples/tenant/README.md`

This updates those snippets to match the actual code. A repo-wide scan
(`*.md`) confirms these were the only stale references.