### PR TITLE
taskmanager/redis: cross-node streaming resubscribe via per-task Redis stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Redis TaskManager
+
+- **Cross-node `SubscribeToTask` is available as an opt-in.** `redis.WithCrossNodeResubscribe(true)` stores Task updates and their Redis Stream events atomically, so a reconnect may land on any replica sharing Redis without a snapshot/event gap. Enable it on every producer and subscriber replica. Execution, continuation, and live-cancel routing remain node-local; this is not a distributed work queue.
+
 ### A2A v1.0 conformance fixes
 
 - **Streaming artifact chunks reassemble by `ArtifactID`.** Artifact events sharing an `ArtifactID` now merge into a single artifact — `TaskHandle.AddArtifact` creates or replaces it, while `TaskHandle.AppendArtifact` appends continuation parts — instead of accumulating as separate fragments. `tasks/get` and the final task snapshot return one merged artifact per streamed deliverable, matching the spec and reference SDKs. Applies to the in-memory and Redis task managers; the per-chunk SSE frames are unchanged.

--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ the native channel style recommended for new code.
 | `TaskHandler.GetTask(taskID)` | `TaskHandle.GetTask()` — this round's continuation snapshot only, `nil` on a fresh round; arbitrary-task reads and `CancellableTask.Cancel` are gone |
 | `TaskHandler.GetMetadata` | removed (it always returned an error in v0.x); message metadata is `ExecContext.Message.Metadata` |
 | `taskmanager.TaskSubscriber` / `CancellableTask` | removed with the callback design |
-| redis `NewTaskSubscriber` / `WithSubscriberSendHook` / `WithSubscriberBlockingSend` | removed — cross-replica streaming is out of scope for the built-in managers |
+| redis `NewTaskSubscriber` / `WithSubscriberSendHook` / `WithSubscriberBlockingSend` | removed — the manager owns fan-out; Redis cross-node `SubscribeToTask` is opt-in with `redis.WithCrossNodeResubscribe(true)` |
 
 ### Behavior changes to check
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -380,7 +380,7 @@ func (p *myProcessor) ProcessMessage(
 | `TaskHandler.GetTask(taskID)` | `TaskHandle.GetTask()` —— 仅本轮的续跑快照，全新一轮时为 `nil`；任意 task 读取与 `CancellableTask.Cancel` 均已移除 |
 | `TaskHandler.GetMetadata` | 已移除（它在 v0.x 中总是返回 error）；message 的 metadata 为 `ExecContext.Message.Metadata` |
 | `taskmanager.TaskSubscriber` / `CancellableTask` | 随回调式设计一并移除 |
-| redis `NewTaskSubscriber` / `WithSubscriberSendHook` / `WithSubscriberBlockingSend` | 已移除——跨副本 streaming 不在内置 manager 的范围内 |
+| redis `NewTaskSubscriber` / `WithSubscriberSendHook` / `WithSubscriberBlockingSend` | 已移除——fan-out 由 manager 管理；Redis 跨节点 `SubscribeToTask` 可通过 `redis.WithCrossNodeResubscribe(true)` 显式开启 |
 
 ### 需要注意的行为变化
 

--- a/docs/mkdocs/en/migration.md
+++ b/docs/mkdocs/en/migration.md
@@ -190,7 +190,7 @@ channel underneath is the actual contract, shown in
 | `taskmanager.CancellableTask` (and `CancellableTask.Cancel`) | removed — cancellation is `CancelTask` cancelling the processor's `ctx` |
 | `memory.NewTaskManager(processor, opts...)` | unchanged shape |
 | `redis.NewTaskManager(...)` | `redis.NewTaskManager(processor, rdb, opts...)` — **note the argument order** `(processor, rdb)` |
-| redis `NewTaskSubscriber` / `WithSubscriberSendHook` / `WithSubscriberBlockingSend` | removed — cross-replica streaming is out of scope for the built-in managers |
+| redis `NewTaskSubscriber` / `WithSubscriberSendHook` / `WithSubscriberBlockingSend` | removed — the manager owns fan-out; Redis cross-node `SubscribeToTask` is opt-in with `redis.WithCrossNodeResubscribe(true)` |
 
 ### Wire method names
 

--- a/docs/mkdocs/en/overview.md
+++ b/docs/mkdocs/en/overview.md
@@ -25,7 +25,7 @@ the runtime contract see [Server](server.md) and [Client](client.md).
 | Multi-tenant hosting with per-tenant agent cards | ✅ | One process, many agents, routed by tenant. |
 | Legacy v0.2.x wire compatibility | ✅ | `compat/v0` on the same endpoint and auth chain. |
 | Telemetry: OpenTelemetry metrics, TTFT tracking | ✅ | Pluggable meter provider and first-token policy. |
-| Cross-replica streaming on the Redis backend | 🚧 Partial | Snapshots are shared; live event fan-out is per-process. |
+| Cross-node `SubscribeToTask` on Redis | ✅ Opt-in | Enable `WithCrossNodeResubscribe(true)` on every replica sharing Redis. |
 
 ## Architecture
 
@@ -120,9 +120,9 @@ retention semantics — lives with the agent-author guide in
 - **gRPC and HTTP+JSON (REST) transport bindings** — the spec defines all
   three; this framework serves the JSON-RPC binding today, and the agent card
   already models multi-transport declaration for when the others land.
-- **Redis cross-replica streaming** — live event fan-out is currently
-  per-process; a shared pub/sub bridge is the planned path to full multi-replica
-  streaming.
+- **Redis execution coordination** — cross-node `SubscribeToTask` is available,
+  but continuation, live cancel, and single-writer execution routing remain
+  node-local concerns rather than a distributed work queue.
 
 ## Where to go next
 

--- a/docs/mkdocs/en/server.md
+++ b/docs/mkdocs/en/server.md
@@ -237,6 +237,13 @@ tm, _ := redistm.NewTaskManager(proc, redisClient,   // note: (processor, client
 )
 ```
 
+For a multi-replica service, add `redistm.WithCrossNodeResubscribe(true)` on
+**every** replica sharing Redis. It lets `SubscribeToTask` reconnect through a
+different node by atomically storing Task updates with a per-task Redis Stream.
+It does not route continuation, live-cancel, or execution requests between
+nodes. Each task stream retains approximately the latest 10,000 events; clients
+that lag beyond that bound may miss intermediate events.
+
 → [examples/redis](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples/redis).
 Implement the `taskmanager.TaskManager` interface for a custom backend.
 
@@ -248,8 +255,9 @@ Retention:
 | Terminal tasks | **kept forever by default** (`TaskTTL` = 0) — set `memory.WithTaskTTL` in production | key TTL (default 1h, `WithExpireTime`) |
 | Suspended tasks | never collected (cleaner is terminal-only) — have clients resume or cancel them | expire with the key TTL |
 
-There is no per-task delete API; A2A defines none. On the Redis backend, live
-event fan-out is per-process (snapshots are shared).
+There is no per-task delete API; A2A defines none. Redis live event fan-out is
+per-process by default; `WithCrossNodeResubscribe(true)` moves resubscribe
+observation to Redis when enabled consistently across replicas.
 
 ## Authentication
 

--- a/docs/mkdocs/zh/migration.md
+++ b/docs/mkdocs/zh/migration.md
@@ -169,7 +169,7 @@ func (p *myProcessor) ProcessMessage(
 | `taskmanager.CancellableTask`（及 `CancellableTask.Cancel`） | 移除——取消即 `CancelTask` 取消 processor 的 `ctx` |
 | `memory.NewTaskManager(processor, opts...)` | 形状不变 |
 | `redis.NewTaskManager(...)` | `redis.NewTaskManager(processor, rdb, opts...)`——**注意参数顺序**为 `(processor, rdb)` |
-| redis `NewTaskSubscriber` / `WithSubscriberSendHook` / `WithSubscriberBlockingSend` | 移除——跨副本流式不在内置 manager 的范围内 |
+| redis `NewTaskSubscriber` / `WithSubscriberSendHook` / `WithSubscriberBlockingSend` | 移除——fan-out 由 manager 管理；Redis 跨节点 `SubscribeToTask` 可通过 `redis.WithCrossNodeResubscribe(true)` 显式开启 |
 
 ### wire 方法名
 

--- a/docs/mkdocs/zh/overview.md
+++ b/docs/mkdocs/zh/overview.md
@@ -30,7 +30,7 @@ tRPC-A2A-Go 是 A2A（Agent-to-Agent）协议 v1.0 的 Go 实现。它同时提�
 | 子路径部署 | 支持 | `WithBasePath` 适配网关或统一前缀。 |
 | legacy v0.2.x wire 兼容 | 支持 | `compat/v0` 挂到同一端点、同一鉴权链，保留 v0 默认行为。 |
 | OpenTelemetry 指标 | 支持 | 请求数、耗时、TTFT；可注入 meter provider 或让 server 创建 OTLP provider。 |
-| Redis 跨副本实时流式 | 部分支持 | 任务快照共享；实时事件扇出仍是进程内。 |
+| Redis 跨节点 `SubscribeToTask` | 可选支持 | 共享 Redis 的所有副本都需开启 `WithCrossNodeResubscribe(true)`。 |
 
 ## 架构
 
@@ -101,7 +101,7 @@ sequenceDiagram
 ## 当前边界
 
 - 当前只实现 JSON-RPC 传输绑定；gRPC 和 HTTP+JSON（REST）还没有落地。
-- Redis 后端共享任务、会话和 artifact 快照，但实时 SSE 事件扇出仍在单进程内。
+- Redis 后端可选择把 Task 事件写入 Redis Stream，使 `SubscribeToTask` 能跨节点接回；continuation、live cancel 和执行 single-writer 仍是节点本地能力，并非分布式工作队列。
 - A2A 没有定义“删除任务”API；生产环境需要通过 TTL 控制终态任务留存。
 
 ## 下一步

--- a/docs/mkdocs/zh/server.md
+++ b/docs/mkdocs/zh/server.md
@@ -200,6 +200,12 @@ tm, _ := redistm.NewTaskManager(proc, redisClient,   // 注意参数序:(process
 )
 ```
 
+多副本部署时，请在共享 Redis 的**每个**副本上增加
+`redistm.WithCrossNodeResubscribe(true)`。它把 Task 更新与每任务 Redis Stream
+事件原子写入，使 `SubscribeToTask` 可经其他节点接回；它不负责跨节点路由
+continuation、live cancel 或执行请求。每个 Task Stream 约保留最新 10,000 个事件；
+落后超过该窗口的客户端可能错过中间事件。
+
 → [examples/redis](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples/redis)。实现 `taskmanager.TaskManager` 接口即可自带后端。
 
 留存:
@@ -210,7 +216,8 @@ tm, _ := redistm.NewTaskManager(proc, redisClient,   // 注意参数序:(process
 | 终态任务 | **默认永久保留**(`TaskTTL`=0)——生产环境请设置 `memory.WithTaskTTL` | key TTL(默认 1h,`WithExpireTime`) |
 | 挂起任务 | 永不回收(清理器只收终态)——请让 client 恢复或取消它们 | 随 key TTL 过期 |
 
-没有按任务的删除 API;A2A 未定义此类接口。Redis 后端上,实时事件扇出是进程内的(快照共享)。
+没有按任务的删除 API；A2A 未定义此类接口。Redis 实时事件扇出默认仍在进程内；所有副本一致开启
+`WithCrossNodeResubscribe(true)` 后，`SubscribeToTask` 的观察面由 Redis 承担。
 
 ## 鉴权
 
@@ -344,7 +351,7 @@ srv, _ := server.NewA2AServer(tm, server.WithAgentCard(card),
 | 需求 | 推荐配置 | 注意事项 |
 | --- | --- | --- |
 | 本地开发、单进程 demo | `taskmanager/memory` | 默认终态任务永久保留；生产请设置 `memory.WithTaskTTL`。 |
-| 重启后保留任务、多个进程共享快照 | `taskmanager/redis` | 实时 SSE 事件扇出仍是进程内；断线后用快照恢复。 |
+| 重启后保留任务、跨节点接回订阅 | `taskmanager/redis` + `WithCrossNodeResubscribe(true)` | 所有共享 Redis 的副本都要开启；只覆盖 `SubscribeToTask`，不路由 continuation/cancel/执行。 |
 | 用户在线等结果 | `SendMessage` 或 `SendStreamingMessage` | v1.0 `SendMessage` 默认阻塞。 |
 | 用户离线等待回调 | push notification + JWKS | 需要 agent card 声明 push 能力，服务端负责发送 webhook。 |
 | 一个 agent 一个进程 | `WithAgentCard` | 最简单，card 直接代表该 agent。 |

--- a/examples/redis/README.md
+++ b/examples/redis/README.md
@@ -152,6 +152,23 @@ Test 2: Streaming conversion with task updates
 - **Command Line Interface**: Modern flag-based parameter handling
 - **Code Standards**: Clean code structure with constants and proper naming conventions
 
+### Multiple Server Replicas
+
+When several server replicas share Redis, enable cross-node resubscribe on
+every replica:
+
+```go
+taskManager, err := redisTaskManager.NewTaskManager(
+    processor,
+    rdb,
+    redisTaskManager.WithCrossNodeResubscribe(true),
+)
+```
+
+This lets a reconnecting `SubscribeToTask` request land on a different replica.
+It does not distribute continuation, cancel, or task execution requests; those
+still require a separate execution-coordination design.
+
 ## Command Line Options
 
 **Server Options:**
@@ -232,4 +249,4 @@ Examples:
 
 **Streaming Effects Not Visible:**
 - Use `--streaming --verbose` for maximum visual effect
-- Ensure you're testing the streaming mode only 
+- Ensure you're testing the streaming mode only

--- a/internal/taskevent/transport.go
+++ b/internal/taskevent/transport.go
@@ -46,8 +46,9 @@ type Transport interface {
 
 	// ReadAfter returns an ordered batch strictly after cursor and the cursor to
 	// use for the next call. It may block until events arrive or ctx ends. An
-	// empty batch is not an error. The returned cursor is never behind the input
-	// cursor and may advance past transport records that yielded no valid event.
+	// empty batch is not an error; callers must wait or back off before retrying
+	// when the cursor also did not advance. The returned cursor is never behind
+	// the input cursor and may advance past records that yielded no valid event.
 	ReadAfter(
 		ctx context.Context,
 		taskID string,

--- a/internal/taskevent/transport.go
+++ b/internal/taskevent/transport.go
@@ -1,0 +1,56 @@
+// Tencent is pleased to support the open source community by making trpc-a2a-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-a2a-go is licensed under the Apache License Version 2.0.
+
+// Package taskevent defines the internal distribution boundary for Task events.
+package taskevent
+
+import (
+	"context"
+
+	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
+)
+
+// Transport distributes Task events between TaskManager instances.
+//
+// A cursor is opaque to callers. Implementations must preserve event order.
+// CommitTaskEvent and LoadTaskAndCursor provide the atomic boundaries needed so
+// a concurrent Task-changing event is either reflected by the loaded snapshot
+// and cursor or returned by a subsequent ReadAfter call, never lost between the
+// two.
+type Transport interface {
+	// CommitTaskEvent atomically stores a Task snapshot and the event that
+	// produced it.
+	CommitTaskEvent(
+		ctx context.Context,
+		task *protocol.Task,
+		event protocol.StreamResponse,
+	) error
+
+	// AppendEvent stores an event that does not modify the Task snapshot.
+	AppendEvent(
+		ctx context.Context,
+		taskID string,
+		event protocol.StreamResponse,
+	) error
+
+	// LoadTaskAndCursor atomically loads the current Task snapshot and the
+	// current event cursor. A subscriber uses the snapshot as its initial frame
+	// and reads only events committed after that cursor.
+	LoadTaskAndCursor(
+		ctx context.Context,
+		taskID string,
+	) (*protocol.Task, string, error)
+
+	// ReadAfter returns an ordered batch strictly after cursor and the cursor to
+	// use for the next call. It may block until events arrive or ctx ends. An
+	// empty batch is not an error. The returned cursor is never behind the input
+	// cursor and may advance past transport records that yielded no valid event.
+	ReadAfter(
+		ctx context.Context,
+		taskID string,
+		cursor string,
+	) ([]protocol.StreamResponse, string, error)
+}

--- a/taskmanager/redis/redis_cross_node_test.go
+++ b/taskmanager/redis/redis_cross_node_test.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -55,6 +56,50 @@ type blockAfterCommandHook struct {
 	entered chan struct{}
 	release chan struct{}
 	once    sync.Once
+}
+
+// nonBlockingEmptyTransport is a valid polling transport that currently has
+// no events. It verifies the manager, rather than every implementation, owns
+// the idle-read backoff contract.
+type nonBlockingEmptyTransport struct {
+	reads atomic.Int64
+}
+
+func (*nonBlockingEmptyTransport) CommitTaskEvent(
+	context.Context,
+	*protocol.Task,
+	protocol.StreamResponse,
+) error {
+	return nil
+}
+
+func (*nonBlockingEmptyTransport) AppendEvent(
+	context.Context,
+	string,
+	protocol.StreamResponse,
+) error {
+	return nil
+}
+
+func (*nonBlockingEmptyTransport) LoadTaskAndCursor(
+	context.Context,
+	string,
+) (*protocol.Task, string, error) {
+	return &protocol.Task{
+		ID: "task-empty-poll",
+		Status: protocol.TaskStatus{
+			State: protocol.TaskStateWorking,
+		},
+	}, "cursor", nil
+}
+
+func (t *nonBlockingEmptyTransport) ReadAfter(
+	context.Context,
+	string,
+	string,
+) ([]protocol.StreamResponse, string, error) {
+	t.reads.Add(1)
+	return nil, "cursor", nil
 }
 
 func (h *blockAfterCommandHook) DialHook(next redis.DialHook) redis.DialHook {
@@ -270,15 +315,14 @@ func TestCrossNode_ClientDisconnectClosesStream(t *testing.T) {
 	}
 }
 
-// Close returns promptly and joins the tailer even with a resubscribe parked in
-// a blocking XREAD.
+// Close returns promptly and joins an active polling resubscribe tailer.
 func TestCrossNode_CloseJoinsActiveTailer(t *testing.T) {
 	nodeA, nodeB := twoNodeManagers(t, scriptedExecutor())
 	task := storedTask(t, nodeA, "task-close", "ctx-close", protocol.TaskStateWorking)
 	if _, err := nodeB.OnResubscribe(context.Background(), protocol.TaskIDParams{ID: task.ID}); err != nil {
 		t.Fatalf("OnResubscribe: %v", err)
 	}
-	// nodeB's tailer is parked in XREAD BLOCK; Close must cancel and join it.
+	// nodeB's tailer is polling/waiting; Close must cancel and join it.
 	done := make(chan error, 1)
 	go func() { done <- nodeB.Close() }()
 	select {
@@ -383,6 +427,51 @@ func TestCrossNode_InputRequiredDoesNotCloseResubscribe(t *testing.T) {
 	}
 }
 
+// A continuation clears the previous Status.Message from the Task snapshot.
+// That mutation must be journaled so a subscriber that already received the
+// old snapshot observes the clear even when the continuation emits only a
+// Message and never produces another task status.
+func TestCrossNode_ContinuationStatusMessageClearIsJournaled(t *testing.T) {
+	nodeA, nodeB := twoNodeManagers(t, scriptedExecutor(agentReply("clarification")))
+	task := storedTask(t, nodeA, "task-clear-status", "ctx-clear-status", protocol.TaskStateInputRequired)
+	task.Status.Message = agentReply("need input")
+	if err := nodeA.storeTask(context.Background(), task); err != nil {
+		t.Fatalf("store task status message: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stream, err := nodeB.OnResubscribe(ctx, protocol.TaskIDParams{ID: task.ID})
+	if err != nil {
+		t.Fatalf("OnResubscribe: %v", err)
+	}
+	initial, ok := recvTimeout(t, stream)
+	if !ok || initial.GetTask() == nil || initial.GetTask().Status.Message == nil {
+		t.Fatalf("expected initial snapshot with status message, got %+v", initial)
+	}
+
+	params := sendParams("more input", task.ContextID)
+	params.Message.TaskID = &task.ID
+	if _, err := nodeA.OnSendMessage(context.Background(), params); err != nil {
+		t.Fatalf("continuation: %v", err)
+	}
+	cleared, ok := recvTimeout(t, stream)
+	if !ok || cleared.GetStatusUpdate() == nil {
+		t.Fatalf("expected journaled status clear, got %+v", cleared)
+	}
+	status := cleared.GetStatusUpdate().Status
+	if status.State != protocol.TaskStateInputRequired || status.Message != nil {
+		t.Fatalf("unexpected status clear event: %+v", status)
+	}
+	stored, err := nodeA.OnGetTask(context.Background(), protocol.TaskQueryParams{ID: task.ID})
+	if err != nil {
+		t.Fatalf("OnGetTask: %v", err)
+	}
+	if stored.Status.Message != nil {
+		t.Fatalf("continuation did not clear stored status message: %+v", stored.Status)
+	}
+}
+
 // The Redis tailer is an independent reader, so it uses cancelable blocking
 // backpressure instead of treating a temporarily full output buffer as EOF.
 func TestCrossNode_SlowConsumerDoesNotLoseStream(t *testing.T) {
@@ -419,6 +508,62 @@ func TestCrossNode_SlowConsumerDoesNotLoseStream(t *testing.T) {
 		// Keep the size-one buffer full between reads. A non-blocking tailer would
 		// evict the subscriber before all queued Redis events are delivered.
 		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// An idle polling transport must back off exponentially instead of producing a
+// fixed-rate Redis read stream when it returns no events or cursor progress.
+func TestCrossNode_EmptyTransportReadBacksOff(t *testing.T) {
+	manager, _ := setupTest(t, scriptedExecutor())
+	transport := &nonBlockingEmptyTransport{}
+	manager.eventTransport = transport
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stream, err := manager.OnResubscribe(ctx, protocol.TaskIDParams{ID: "task-empty-poll"})
+	if err != nil {
+		t.Fatalf("OnResubscribe: %v", err)
+	}
+	if frame, ok := recvTimeout(t, stream); !ok || frame.GetTask() == nil {
+		t.Fatalf("expected initial snapshot, got %+v", frame)
+	}
+	time.Sleep(650 * time.Millisecond)
+	cancel()
+	if _, ok := recvTimeout(t, stream); ok {
+		t.Fatal("resubscribe stream remained open after cancellation")
+	}
+	if reads := transport.reads.Load(); reads > 4 {
+		t.Fatalf("empty ReadAfter did not back off: reads=%d", reads)
+	}
+}
+
+// Idle cross-node subscriptions must not consume the Redis connections used by
+// Task storage. With a size-one pool, one tailer and one GetTask must coexist.
+func TestCrossNode_IdleTailerDoesNotStarveTaskStoragePool(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{
+		Addr:        mr.Addr(),
+		PoolSize:    1,
+		PoolTimeout: 50 * time.Millisecond,
+	})
+	manager, err := NewTaskManager(scriptedExecutor(), client, WithCrossNodeResubscribe(true))
+	if err != nil {
+		t.Fatalf("NewTaskManager: %v", err)
+	}
+	t.Cleanup(func() { _ = manager.Close() })
+	task := storedTask(t, manager, "task-pool", "ctx-pool", protocol.TaskStateWorking)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stream, err := manager.OnResubscribe(ctx, protocol.TaskIDParams{ID: task.ID})
+	if err != nil {
+		t.Fatalf("OnResubscribe: %v", err)
+	}
+	if frame, ok := recvTimeout(t, stream); !ok || frame.GetTask() == nil {
+		t.Fatalf("expected initial snapshot, got %+v", frame)
+	}
+	time.Sleep(20 * time.Millisecond)
+	if _, err := manager.OnGetTask(context.Background(), protocol.TaskQueryParams{ID: task.ID}); err != nil {
+		t.Fatalf("active tailer starved task storage: %v", err)
 	}
 }
 
@@ -467,11 +612,239 @@ func TestCrossNode_MessageAppendFailureIsNotExposedAsSuccess(t *testing.T) {
 
 	params := sendParams("continue", task.ContextID)
 	params.Message.TaskID = &task.ID
-	if response, err := manager.OnSendMessage(context.Background(), params); err == nil {
+	response, err := manager.OnSendMessage(context.Background(), params)
+	if err == nil {
 		t.Fatalf("message append failure was exposed as success: %+v", response)
+	}
+	if !strings.Contains(err.Error(), "task event stream has wrong type") {
+		t.Fatalf("message append returned the wrong error: %v", err)
 	}
 	if buffered := len(subscriber.Channel()); buffered != 0 {
 		t.Fatalf("message append failure reached local subscriber: buffered=%d", buffered)
+	}
+	history, err := manager.getConversationHistory(context.Background(), task.ContextID, 100)
+	if err != nil {
+		t.Fatalf("getConversationHistory: %v", err)
+	}
+	for _, message := range history {
+		if message.Role == protocol.MessageRoleAgent {
+			t.Fatalf("message append failure persisted an agent reply: %+v", message)
+		}
+	}
+}
+
+// A failed Task/event commit is an execution error. Neither a status nor an
+// artifact working copy may be returned as if it committed successfully.
+func TestCrossNode_TaskCommitFailureIsNotExposedAsSuccess(t *testing.T) {
+	tests := []struct {
+		name              string
+		event             protocol.StreamEvent
+		returnImmediately bool
+	}{
+		{name: "status", event: statusEvent(protocol.TaskStateCompleted, agentReply("done"))},
+		{
+			name:              "status-return-immediately",
+			event:             statusEvent(protocol.TaskStateCompleted, agentReply("done")),
+			returnImmediately: true,
+		},
+		{name: "artifact", event: artifactEvent("artifact", "uncommitted")},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			manager, _ := setupTest(
+				t,
+				scriptedExecutor(test.event),
+				WithCrossNodeResubscribe(true),
+			)
+			taskID := "task-" + test.name + "-fail"
+			contextID := "ctx-" + test.name + "-fail"
+			task := storedTask(t, manager, taskID, contextID, protocol.TaskStateWorking)
+			if err := manager.client.Set(context.Background(), streamKey(task.ID), "not-a-stream", 0).Err(); err != nil {
+				t.Fatalf("seed wrong-type stream key: %v", err)
+			}
+
+			params := sendParams("continue", task.ContextID)
+			params.Message.TaskID = &task.ID
+			if test.returnImmediately {
+				returnImmediately := true
+				params.Configuration = &protocol.SendMessageConfiguration{ReturnImmediately: &returnImmediately}
+			}
+			response, err := manager.OnSendMessage(context.Background(), params)
+			if err == nil {
+				t.Fatalf("failed %s commit was exposed as success: %+v", test.name, response)
+			}
+			if !strings.Contains(err.Error(), "task event stream has wrong type") {
+				t.Fatalf("failed %s commit returned the wrong error: %v", test.name, err)
+			}
+			stored, err := manager.OnGetTask(context.Background(), protocol.TaskQueryParams{ID: task.ID})
+			if err != nil {
+				t.Fatalf("OnGetTask after failed %s commit: %v", test.name, err)
+			}
+			if stored.Status.State != protocol.TaskStateWorking || len(stored.Artifacts) != 0 {
+				t.Fatalf("failed %s commit changed stored Task: %+v", test.name, stored)
+			}
+		})
+	}
+}
+
+// A known persistence failure is a result immediately. The unary caller must
+// not wait for a long-running processor to close its channel while the engine
+// drains that channel in the background.
+func TestCrossNode_PersistenceFailureReturnsBeforeProcessorCloses(t *testing.T) {
+	release := make(chan struct{})
+	processorDone := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseProcessor := func() { releaseOnce.Do(func() { close(release) }) }
+	defer releaseProcessor()
+	processor := executorFunc(func(context.Context, *taskmanager.ExecContext) (<-chan protocol.StreamEvent, error) {
+		out := make(chan protocol.StreamEvent)
+		go func() {
+			defer close(processorDone)
+			defer close(out)
+			out <- statusEvent(protocol.TaskStateCompleted, agentReply("uncommitted"))
+			<-release
+		}()
+		return out, nil
+	})
+	manager, _ := setupTest(t, processor, WithCrossNodeResubscribe(true))
+	task := storedTask(t, manager, "task-fast-failure", "ctx-fast-failure", protocol.TaskStateWorking)
+	if err := manager.client.Set(context.Background(), streamKey(task.ID), "not-a-stream", 0).Err(); err != nil {
+		t.Fatalf("seed wrong-type stream key: %v", err)
+	}
+
+	params := sendParams("continue", task.ContextID)
+	params.Message.TaskID = &task.ID
+	result := make(chan error, 1)
+	go func() {
+		_, err := manager.OnSendMessage(context.Background(), params)
+		result <- err
+	}()
+	select {
+	case err := <-result:
+		if err == nil || !strings.Contains(err.Error(), "task event stream has wrong type") {
+			t.Fatalf("unexpected persistence result: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("persistence failure waited for the processor channel to close")
+	}
+	select {
+	case <-processorDone:
+		t.Fatal("processor closed before the failure was returned")
+	default:
+	}
+	releaseProcessor()
+}
+
+// The streaming response has no asynchronous error return, so a persistence
+// failure must at least close it immediately while the processor is drained.
+func TestCrossNode_PersistenceFailureClosesStreamBeforeProcessorCloses(t *testing.T) {
+	release := make(chan struct{})
+	processorDone := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseProcessor := func() { releaseOnce.Do(func() { close(release) }) }
+	defer releaseProcessor()
+	processor := executorFunc(func(context.Context, *taskmanager.ExecContext) (<-chan protocol.StreamEvent, error) {
+		out := make(chan protocol.StreamEvent)
+		go func() {
+			defer close(processorDone)
+			defer close(out)
+			out <- statusEvent(protocol.TaskStateCompleted, agentReply("uncommitted"))
+			<-release
+		}()
+		return out, nil
+	})
+	manager, _ := setupTest(t, processor, WithCrossNodeResubscribe(true))
+	task := storedTask(t, manager, "task-stream-failure", "ctx-stream-failure", protocol.TaskStateWorking)
+	if err := manager.client.Set(context.Background(), streamKey(task.ID), "not-a-stream", 0).Err(); err != nil {
+		t.Fatalf("seed wrong-type stream key: %v", err)
+	}
+
+	params := sendParams("continue", task.ContextID)
+	params.Message.TaskID = &task.ID
+	stream, err := manager.OnSendMessageStream(context.Background(), params)
+	if err != nil {
+		t.Fatalf("OnSendMessageStream: %v", err)
+	}
+	select {
+	case frame, ok := <-stream:
+		if ok {
+			t.Fatalf("uncommitted event reached stream: %+v", frame)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("persistence failure left the response stream open")
+	}
+	select {
+	case <-processorDone:
+		t.Fatal("processor closed before the response stream")
+	default:
+	}
+	releaseProcessor()
+}
+
+// A superseded status message moves to history only after the new status and
+// its event commit. If that commit fails, the message remains solely on the
+// stored Task rather than appearing in both Task.Status and history.
+func TestCrossNode_FailedStatusCommitDoesNotAdvanceHistory(t *testing.T) {
+	taskID := make(chan string, 1)
+	releaseSecond := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseProcessor := func() { releaseOnce.Do(func() { close(releaseSecond) }) }
+	defer releaseProcessor()
+	processor := executorFunc(func(_ context.Context, ec *taskmanager.ExecContext) (<-chan protocol.StreamEvent, error) {
+		taskID <- ec.TaskID
+		out := make(chan protocol.StreamEvent)
+		go func() {
+			defer close(out)
+			out <- statusEvent(protocol.TaskStateWorking, agentReply("first"))
+			<-releaseSecond
+			out <- statusEvent(protocol.TaskStateCompleted, agentReply("second"))
+		}()
+		return out, nil
+	})
+	manager, _ := setupTest(t, processor, WithCrossNodeResubscribe(true))
+	result := make(chan error, 1)
+	go func() {
+		_, err := manager.OnSendMessage(context.Background(), sendParams("start", "ctx-history-failure"))
+		result <- err
+	}()
+	id := <-taskID
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		stored, err := manager.getTaskInternal(context.Background(), id)
+		if err == nil && stored.Status.Message != nil &&
+			stored.Status.Message.Parts[0].TextContent() == "first" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("first status was not persisted: task=%+v err=%v", stored, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if err := manager.client.Set(context.Background(), streamKey(id), "not-a-stream", 0).Err(); err != nil {
+		t.Fatalf("replace stream with wrong type: %v", err)
+	}
+	releaseProcessor()
+	if err := <-result; err == nil || !strings.Contains(err.Error(), "task event stream has wrong type") {
+		t.Fatalf("unexpected failed status result: %v", err)
+	}
+
+	stored, err := manager.getTaskInternal(context.Background(), id)
+	if err != nil {
+		t.Fatalf("get stored task: %v", err)
+	}
+	if stored.Status.State != protocol.TaskStateWorking || stored.Status.Message == nil ||
+		stored.Status.Message.Parts[0].TextContent() != "first" {
+		t.Fatalf("failed commit changed stored status: %+v", stored.Status)
+	}
+	history, err := manager.getConversationHistory(context.Background(), stored.ContextID, 100)
+	if err != nil {
+		t.Fatalf("get conversation history: %v", err)
+	}
+	for _, message := range history {
+		if message.Role == protocol.MessageRoleAgent {
+			t.Fatalf("failed commit advanced status history: %+v", message)
+		}
 	}
 }
 
@@ -499,6 +872,32 @@ func TestCrossNode_SubMillisecondExpirationIsClamped(t *testing.T) {
 	}
 	if got, err := manager.client.XLen(context.Background(), streamKey(task.ID)).Result(); err != nil || got != 1 {
 		t.Fatalf("stream event missing after clamped TTL: xlen=%d err=%v", got, err)
+	}
+}
+
+// The event-transport path preserves storeTask's push-registration TTL refresh
+// without pulling the cross-slot push key into the atomic Task/event script.
+func TestCrossNode_TaskCommitRefreshesPushConfigExpiration(t *testing.T) {
+	manager, _ := setupTest(t, scriptedExecutor(), WithCrossNodeResubscribe(true))
+	task := storedTask(t, manager, "task-push-expire", "ctx-push-expire", protocol.TaskStateWorking)
+	pushKey := pushNotificationPrefix + task.ID
+	if err := manager.client.HSet(context.Background(), pushKey, "config", "value").Err(); err != nil {
+		t.Fatalf("seed push config: %v", err)
+	}
+	if err := manager.client.Persist(context.Background(), pushKey).Err(); err != nil {
+		t.Fatalf("remove push config expiration: %v", err)
+	}
+	update := statusEvent(protocol.TaskStateWorking, nil)
+	update.TaskID = task.ID
+	update.ContextID = task.ContextID
+	task.Status = update.Status
+	if err := manager.commitTaskEvent(
+		context.Background(), task, protocol.NewStreamResponseStatusUpdate(update),
+	); err != nil {
+		t.Fatalf("commitTaskEvent: %v", err)
+	}
+	if ttl, err := manager.client.TTL(context.Background(), pushKey).Result(); err != nil || ttl <= 0 {
+		t.Fatalf("push config TTL was not refreshed: ttl=%s err=%v", ttl, err)
 	}
 }
 

--- a/taskmanager/redis/redis_cross_node_test.go
+++ b/taskmanager/redis/redis_cross_node_test.go
@@ -8,7 +8,10 @@ package redis
 
 import (
 	"context"
+	"errors"
+	"net"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -22,22 +25,59 @@ import (
 // twoNodeManagers builds two RedisTaskManagers sharing one miniredis, both with
 // cross-node resubscribe streaming enabled: nodeA runs procA, nodeB is a
 // bystander instance a resubscribe may land on.
-func twoNodeManagers(t *testing.T, procA taskmanager.MessageProcessor) (*TaskManager, *TaskManager) {
+func twoNodeManagers(
+	t *testing.T,
+	procA taskmanager.MessageProcessor,
+	opts ...TaskManagerOption,
+) (*TaskManager, *TaskManager) {
 	t.Helper()
 	mr := miniredis.RunT(t)
 	ca := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 	cb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 	t.Cleanup(func() { ca.Close(); cb.Close() })
-	a, err := NewTaskManager(procA, ca, WithResubscribeStreaming(true))
+	managerOpts := append([]TaskManagerOption{WithCrossNodeResubscribe(true)}, opts...)
+	a, err := NewTaskManager(procA, ca, managerOpts...)
 	if err != nil {
 		t.Fatalf("nodeA NewTaskManager: %v", err)
 	}
-	b, err := NewTaskManager(scriptedExecutor(), cb, WithResubscribeStreaming(true))
+	b, err := NewTaskManager(scriptedExecutor(), cb, managerOpts...)
 	if err != nil {
 		t.Fatalf("nodeB NewTaskManager: %v", err)
 	}
 	t.Cleanup(func() { _ = a.Close(); _ = b.Close() })
 	return a, b
+}
+
+// blockAfterCommandHook pauses one successful command after Redis has executed
+// it, allowing lifecycle tests to hold an RPC between storage and admission.
+type blockAfterCommandHook struct {
+	name    string
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (h *blockAfterCommandHook) DialHook(next redis.DialHook) redis.DialHook {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return next(ctx, network, addr)
+	}
+}
+
+func (h *blockAfterCommandHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
+	return func(ctx context.Context, cmd redis.Cmder) error {
+		err := next(ctx, cmd)
+		if err == nil && cmd.Name() == h.name {
+			h.once.Do(func() {
+				close(h.entered)
+				<-h.release
+			})
+		}
+		return err
+	}
+}
+
+func (h *blockAfterCommandHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
+	return next
 }
 
 func recvTimeout(t *testing.T, ch <-chan protocol.StreamResponse) (protocol.StreamResponse, bool) {
@@ -74,8 +114,8 @@ func drainForState(t *testing.T, ch <-chan protocol.StreamResponse, wantState pr
 }
 
 // A resubscribe landing on a different instance than the one running the task
-// receives the current snapshot and every subsequent event via the shared Redis
-// stream, and its stream closes on the terminal frame.
+// receives the current snapshot and subsequent events within the bounded Redis
+// stream retention, and its stream closes on the terminal frame.
 func TestCrossNode_ResubscribeReceivesSubsequentEvents(t *testing.T) {
 	started := make(chan struct{})
 	release := make(chan struct{})
@@ -125,24 +165,30 @@ func TestCrossNode_ResubscribeReceivesSubsequentEvents(t *testing.T) {
 	if !drainForState(t, chB, protocol.TaskStateCompleted) {
 		t.Fatal("cross-node resubscriber never received the completed event before the stream closed")
 	}
+	if got, err := nodeA.client.XLen(context.Background(), streamKey(taskA.ID)).Result(); err != nil || got != 2 {
+		t.Fatalf("each status must be appended exactly once: xlen=%d err=%v", got, err)
+	}
 }
 
-// An event published right after resubscribe (in the window between the cursor
-// capture and the tailer's first read) is still delivered. This guards the
-// synchronous pre-snapshot cursor against the gap a "$" cursor would leave.
+// An event published right after the atomic snapshot/cursor read, before the
+// tailer's first XREAD, is still delivered.
 func TestCrossNode_DeliversEventPublishedRightAfterResubscribe(t *testing.T) {
 	nodeA, nodeB := twoNodeManagers(t, scriptedExecutor())
 	task := storedTask(t, nodeA, "task-gap", "ctx-gap", protocol.TaskStateWorking)
-	nodeA.publishStream(task.ID, protocol.NewStreamResponseStatusUpdate(
-		statusEvent(protocol.TaskStateWorking, agentReply("w1"))))
+	if err := nodeA.appendStreamEvent(context.Background(), task.ID, protocol.NewStreamResponseStatusUpdate(
+		statusEvent(protocol.TaskStateWorking, agentReply("w1")))); err != nil {
+		t.Fatalf("append working event: %v", err)
+	}
 
 	chB, err := nodeB.OnResubscribe(context.Background(), protocol.TaskIDParams{ID: task.ID})
 	if err != nil {
 		t.Fatalf("OnResubscribe: %v", err)
 	}
 	// Publish the terminal event immediately after resubscribe.
-	nodeA.publishStream(task.ID, protocol.NewStreamResponseStatusUpdate(
-		statusEvent(protocol.TaskStateCompleted, agentReply("done"))))
+	if err := nodeA.appendStreamEvent(context.Background(), task.ID, protocol.NewStreamResponseStatusUpdate(
+		statusEvent(protocol.TaskStateCompleted, agentReply("done")))); err != nil {
+		t.Fatalf("append completed event: %v", err)
+	}
 
 	first, _ := recvTimeout(t, chB)
 	if first.GetTask() == nil {
@@ -153,9 +199,8 @@ func TestCrossNode_DeliversEventPublishedRightAfterResubscribe(t *testing.T) {
 	}
 }
 
-// A cancel of a task with no live run persists CANCELED and notifies via
-// notifySubscribers, bypassing broadcast. The stream seam sits at
-// notifySubscribers, so a cross-node resubscriber still sees the CANCELED frame.
+// A cancel of a task with no live run atomically persists CANCELED with its
+// event, so a cross-node resubscriber sees the terminal frame.
 func TestCrossNode_CancelWithoutLiveRunReachesResubscriber(t *testing.T) {
 	nodeA, nodeB := twoNodeManagers(t, scriptedExecutor())
 	task := storedTask(t, nodeA, "task-cancel", "ctx-cancel", protocol.TaskStateWorking)
@@ -177,9 +222,9 @@ func TestCrossNode_CancelWithoutLiveRunReachesResubscriber(t *testing.T) {
 	}
 }
 
-// With streaming disabled (default) no per-task stream key is created and the
-// resubscribe path is unchanged.
-func TestResubscribeStreaming_Disabled_NoStreamKey(t *testing.T) {
+// With cross-node resubscribe disabled (default), no per-task stream key is
+// created and the single-node resubscribe path is unchanged.
+func TestCrossNodeResubscribe_Disabled_NoStreamKey(t *testing.T) {
 	mgr, mr := setupTest(t, scriptedExecutor(
 		statusEvent(protocol.TaskStateWorking, agentReply("w")),
 		statusEvent(protocol.TaskStateCompleted, agentReply("done")),
@@ -189,7 +234,7 @@ func TestResubscribeStreaming_Disabled_NoStreamKey(t *testing.T) {
 	}
 	for _, k := range mr.Keys() {
 		if strings.HasPrefix(k, streamPrefix) {
-			t.Fatalf("stream key %q created while ResubscribeStreaming is off", k)
+			t.Fatalf("stream key %q created while cross-node resubscribe is off", k)
 		}
 	}
 }
@@ -240,5 +285,273 @@ func TestCrossNode_CloseJoinsActiveTailer(t *testing.T) {
 	case <-done:
 	case <-time.After(5 * time.Second):
 		t.Fatal("Close hung with an active resubscribe tailer")
+	}
+}
+
+// A task event committed before the atomic snapshot/cursor read is represented
+// by the snapshot only. A later event is represented by the stream only.
+func TestCrossNode_AtomicSnapshotCursorHasNoOverlapOrGap(t *testing.T) {
+	nodeA, nodeB := twoNodeManagers(t, scriptedExecutor())
+	task := storedTask(t, nodeA, "task-atomic", "ctx-atomic", protocol.TaskStateWorking)
+
+	first := artifactEvent("artifact", "part-one")
+	first.TaskID = task.ID
+	first.ContextID = task.ContextID
+	task.Artifacts, _ = protocol.AppendArtifact(task.Artifacts, first.Artifact, false)
+	if err := nodeA.storeTaskEvent(
+		context.Background(), task, protocol.NewStreamResponseArtifactUpdate(first),
+	); err != nil {
+		t.Fatalf("store first task event: %v", err)
+	}
+
+	snapshot, cursor, err := nodeB.loadTaskAndCursor(context.Background(), task.ID)
+	if err != nil {
+		t.Fatalf("loadTaskAndCursor: %v", err)
+	}
+	if len(snapshot.Artifacts) != 1 {
+		t.Fatalf("snapshot must contain the committed artifact exactly once, got %+v", snapshot)
+	}
+	if duplicate, err := nodeB.client.XRead(context.Background(), &redis.XReadArgs{
+		Streams: []string{streamKey(task.ID), cursor},
+		Count:   1,
+		Block:   -1,
+	}).Result(); !errors.Is(err, redis.Nil) {
+		t.Fatalf("event already represented by snapshot was replayed: events=%+v err=%v", duplicate, err)
+	}
+
+	second := artifactEvent("artifact", "part-two")
+	second.TaskID = task.ID
+	second.ContextID = task.ContextID
+	appendChunk := true
+	second.Append = &appendChunk
+	task.Artifacts, _ = protocol.AppendArtifact(task.Artifacts, second.Artifact, true)
+	if err := nodeA.storeTaskEvent(
+		context.Background(), task, protocol.NewStreamResponseArtifactUpdate(second),
+	); err != nil {
+		t.Fatalf("store second task event: %v", err)
+	}
+	streams, err := nodeB.client.XRead(context.Background(), &redis.XReadArgs{
+		Streams: []string{streamKey(task.ID), cursor},
+		Count:   2,
+		Block:   -1,
+	}).Result()
+	if err != nil || len(streams) != 1 || len(streams[0].Messages) != 1 {
+		t.Fatalf("event committed after snapshot was not delivered once: streams=%+v err=%v", streams, err)
+	}
+}
+
+// input-required ends one execution round, not the task subscription. The
+// cross-node stream must remain open for a later continuation's terminal event.
+func TestCrossNode_InputRequiredDoesNotCloseResubscribe(t *testing.T) {
+	nodeA, nodeB := twoNodeManagers(t, scriptedExecutor())
+	task := storedTask(t, nodeA, "task-input", "ctx-input", protocol.TaskStateWorking)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stream, err := nodeB.OnResubscribe(ctx, protocol.TaskIDParams{ID: task.ID})
+	if err != nil {
+		t.Fatalf("OnResubscribe: %v", err)
+	}
+	if frame, ok := recvTimeout(t, stream); !ok || frame.GetTask() == nil {
+		t.Fatalf("expected initial snapshot, got %+v", frame)
+	}
+
+	input := statusEvent(protocol.TaskStateInputRequired, agentReply("need input"))
+	input.TaskID = task.ID
+	input.ContextID = task.ContextID
+	task.Status = input.Status
+	if err := nodeA.storeTaskEvent(
+		context.Background(), task, protocol.NewStreamResponseStatusUpdate(input),
+	); err != nil {
+		t.Fatalf("store input-required: %v", err)
+	}
+	if frame, ok := recvTimeout(t, stream); !ok || frame.GetStatusUpdate() == nil ||
+		frame.GetStatusUpdate().Status.State != protocol.TaskStateInputRequired {
+		t.Fatalf("expected input-required event, got %+v", frame)
+	}
+	completed := statusEvent(protocol.TaskStateCompleted, agentReply("done"))
+	completed.TaskID = task.ID
+	completed.ContextID = task.ContextID
+	task.Status = completed.Status
+	if err := nodeA.storeTaskEvent(
+		context.Background(), task, protocol.NewStreamResponseStatusUpdate(completed),
+	); err != nil {
+		t.Fatalf("store completed: %v", err)
+	}
+	if !drainForState(t, stream, protocol.TaskStateCompleted) {
+		t.Fatal("resubscribe did not receive the terminal event after input-required")
+	}
+}
+
+// The Redis tailer is an independent reader, so it uses cancelable blocking
+// backpressure instead of treating a temporarily full output buffer as EOF.
+func TestCrossNode_SlowConsumerDoesNotLoseStream(t *testing.T) {
+	nodeA, nodeB := twoNodeManagers(
+		t,
+		scriptedExecutor(),
+		WithTaskSubscriberBufferSize(1),
+	)
+	task := storedTask(t, nodeA, "task-slow", "ctx-slow", protocol.TaskStateWorking)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stream, err := nodeB.OnResubscribe(ctx, protocol.TaskIDParams{ID: task.ID})
+	if err != nil {
+		t.Fatalf("OnResubscribe: %v", err)
+	}
+	const updates = 4
+	for i := 0; i < updates; i++ {
+		update := protocol.NewStreamResponseStatusUpdate(
+			statusEvent(protocol.TaskStateWorking, agentReply("still working")),
+		)
+		if err := nodeA.appendStreamEvent(context.Background(), task.ID, update); err != nil {
+			t.Fatalf("append stream event %d: %v", i, err)
+		}
+	}
+
+	if frame, ok := recvTimeout(t, stream); !ok || frame.GetTask() == nil {
+		t.Fatalf("expected initial snapshot, got %+v", frame)
+	}
+	for i := 0; i < updates; i++ {
+		if frame, ok := recvTimeout(t, stream); !ok || frame.GetStatusUpdate() == nil {
+			t.Fatalf("slow consumer lost queued update %d, got %+v", i, frame)
+		}
+		// Keep the size-one buffer full between reads. A non-blocking tailer would
+		// evict the subscriber before all queued Redis events are delivered.
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// Storage/cursor errors are surfaced. A malformed stream key must neither be
+// treated as an empty stream nor allow a Task update to commit by itself.
+func TestCrossNode_WrongTypeStreamFailsAtomically(t *testing.T) {
+	nodeA, nodeB := twoNodeManagers(t, scriptedExecutor())
+	task := storedTask(t, nodeA, "task-wrongtype", "ctx-wrongtype", protocol.TaskStateWorking)
+	if err := nodeA.client.Set(context.Background(), streamKey(task.ID), "not-a-stream", 0).Err(); err != nil {
+		t.Fatalf("seed wrong-type stream key: %v", err)
+	}
+
+	stream, err := nodeB.OnResubscribe(context.Background(), protocol.TaskIDParams{ID: task.ID})
+	if err == nil || stream != nil {
+		t.Fatalf("wrong-type cursor read must fail: stream=%v err=%v", stream, err)
+	}
+	if _, err := nodeA.OnCancelTask(context.Background(), protocol.TaskIDParams{ID: task.ID}); err == nil {
+		t.Fatal("cancel unexpectedly committed Task without its stream event")
+	}
+	stored, err := nodeA.OnGetTask(context.Background(), protocol.TaskQueryParams{ID: task.ID})
+	if err != nil {
+		t.Fatalf("OnGetTask after failed cancel: %v", err)
+	}
+	if stored.Status.State != protocol.TaskStateWorking {
+		t.Fatalf("failed atomic commit changed Task state to %s", stored.Status.State)
+	}
+}
+
+// A Message emitted for an existing Task is not reported to the RPC or local
+// subscribers unless its cross-node stream append succeeds.
+func TestCrossNode_MessageAppendFailureIsNotExposedAsSuccess(t *testing.T) {
+	manager, _ := setupTest(
+		t,
+		scriptedExecutor(agentReply("reply")),
+		WithCrossNodeResubscribe(true),
+	)
+	task := storedTask(t, manager, "task-message-fail", "ctx-message-fail", protocol.TaskStateWorking)
+	if err := manager.client.Set(context.Background(), streamKey(task.ID), "not-a-stream", 0).Err(); err != nil {
+		t.Fatalf("seed wrong-type stream key: %v", err)
+	}
+	subscriber := newTaskSubscriber(task.ID, 1, false)
+	manager.subMu.Lock()
+	manager.subscribers[task.ID] = []*taskSubscriber{subscriber}
+	manager.subMu.Unlock()
+	defer manager.cleanupFailedSubscribers(task.ID, []*taskSubscriber{subscriber})
+
+	params := sendParams("continue", task.ContextID)
+	params.Message.TaskID = &task.ID
+	if response, err := manager.OnSendMessage(context.Background(), params); err == nil {
+		t.Fatalf("message append failure was exposed as success: %+v", response)
+	}
+	if buffered := len(subscriber.Channel()); buffered != 0 {
+		t.Fatalf("message append failure reached local subscriber: buffered=%d", buffered)
+	}
+}
+
+// Lua PX arguments must retain the same one-millisecond lower bound that
+// go-redis applies to ordinary SET expirations.
+func TestCrossNode_SubMillisecondExpirationIsClamped(t *testing.T) {
+	manager, _ := setupTest(
+		t,
+		scriptedExecutor(),
+		WithCrossNodeResubscribe(true),
+		WithExpireTime(time.Nanosecond),
+	)
+	if manager.expiration != time.Millisecond {
+		t.Fatalf("expiration = %s, want %s", manager.expiration, time.Millisecond)
+	}
+	task := storedTask(t, manager, "task-short-ttl", "ctx-short-ttl", protocol.TaskStateWorking)
+	update := statusEvent(protocol.TaskStateWorking, agentReply("working"))
+	update.TaskID = task.ID
+	update.ContextID = task.ContextID
+	task.Status = update.Status
+	if err := manager.storeTaskEvent(
+		context.Background(), task, protocol.NewStreamResponseStatusUpdate(update),
+	); err != nil {
+		t.Fatalf("storeTaskEvent with sub-millisecond configured TTL: %v", err)
+	}
+	if got, err := manager.client.XLen(context.Background(), streamKey(task.ID)).Result(); err != nil || got != 1 {
+		t.Fatalf("stream event missing after clamped TTL: xlen=%d err=%v", got, err)
+	}
+}
+
+// A resubscribe that finishes its storage read after Close must be rejected;
+// it cannot add a tailer after Close has already waited for all admitted ones.
+func TestCrossNode_CloseRejectsTailerAfterSnapshotRead(t *testing.T) {
+	nodeA, nodeB := twoNodeManagers(t, scriptedExecutor())
+	task := storedTask(t, nodeA, "task-close-admission", "ctx-close-admission", protocol.TaskStateWorking)
+	if _, _, err := nodeB.loadTaskAndCursor(context.Background(), task.ID); err != nil {
+		t.Fatalf("warm loadTaskAndCursor script: %v", err)
+	}
+	hook := &blockAfterCommandHook{
+		name:    "evalsha",
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	var releaseOnce sync.Once
+	releaseHook := func() { releaseOnce.Do(func() { close(hook.release) }) }
+	defer releaseHook()
+	nodeB.client.AddHook(hook)
+
+	type result struct {
+		stream <-chan protocol.StreamResponse
+		err    error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		stream, err := nodeB.OnResubscribe(context.Background(), protocol.TaskIDParams{ID: task.ID})
+		resultCh <- result{stream: stream, err: err}
+	}()
+	select {
+	case <-hook.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("resubscribe did not reach the post-read hook")
+	}
+
+	closed := make(chan error, 1)
+	go func() { closed <- nodeB.Close() }()
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close waited for a tailer that was not admitted")
+	}
+	releaseHook()
+	select {
+	case got := <-resultCh:
+		if got.err == nil || got.stream != nil {
+			t.Fatalf("resubscribe admitted after Close: stream=%v err=%v", got.stream, got.err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("resubscribe did not return after storage hook was released")
 	}
 }

--- a/taskmanager/redis/redis_cross_node_test.go
+++ b/taskmanager/redis/redis_cross_node_test.go
@@ -1,0 +1,244 @@
+// Tencent is pleased to support the open source community by making trpc-a2a-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-a2a-go is licensed under the Apache License Version 2.0.
+
+package redis
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+
+	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
+)
+
+// twoNodeManagers builds two RedisTaskManagers sharing one miniredis, both with
+// cross-node resubscribe streaming enabled: nodeA runs procA, nodeB is a
+// bystander instance a resubscribe may land on.
+func twoNodeManagers(t *testing.T, procA taskmanager.MessageProcessor) (*TaskManager, *TaskManager) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	ca := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	cb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { ca.Close(); cb.Close() })
+	a, err := NewTaskManager(procA, ca, WithResubscribeStreaming(true))
+	if err != nil {
+		t.Fatalf("nodeA NewTaskManager: %v", err)
+	}
+	b, err := NewTaskManager(scriptedExecutor(), cb, WithResubscribeStreaming(true))
+	if err != nil {
+		t.Fatalf("nodeB NewTaskManager: %v", err)
+	}
+	t.Cleanup(func() { _ = a.Close(); _ = b.Close() })
+	return a, b
+}
+
+func recvTimeout(t *testing.T, ch <-chan protocol.StreamResponse) (protocol.StreamResponse, bool) {
+	t.Helper()
+	select {
+	case r, ok := <-ch:
+		return r, ok
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for a resubscribe stream frame")
+		return protocol.StreamResponse{}, false
+	}
+}
+
+// drainForState reads until it sees a status frame in wantState (returning true)
+// or the channel closes (returning whether it was seen). It fails on timeout.
+func drainForState(t *testing.T, ch <-chan protocol.StreamResponse, wantState protocol.TaskState) bool {
+	t.Helper()
+	deadline := time.After(5 * time.Second)
+	saw := false
+	for {
+		select {
+		case r, ok := <-ch:
+			if !ok {
+				return saw // channel closed: the tailer self-terminated
+			}
+			if su := r.GetStatusUpdate(); su != nil && su.Status.State == wantState {
+				saw = true
+			}
+		case <-deadline:
+			t.Fatalf("timed out draining the resubscribe stream (saw %s = %v)", wantState, saw)
+			return saw
+		}
+	}
+}
+
+// A resubscribe landing on a different instance than the one running the task
+// receives the current snapshot and every subsequent event via the shared Redis
+// stream, and its stream closes on the terminal frame.
+func TestCrossNode_ResubscribeReceivesSubsequentEvents(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	procA := executorFunc(func(ctx context.Context, ec *taskmanager.ExecContext) (<-chan protocol.StreamEvent, error) {
+		out := make(chan protocol.StreamEvent)
+		go func() {
+			defer close(out)
+			out <- statusEvent(protocol.TaskStateWorking, agentReply("working"))
+			close(started)
+			<-release
+			out <- statusEvent(protocol.TaskStateCompleted, agentReply("done"))
+		}()
+		return out, nil
+	})
+	nodeA, nodeB := twoNodeManagers(t, procA)
+
+	returnImmediately := true
+	params := sendParams("go", "ctx-x")
+	params.Configuration = &protocol.SendMessageConfiguration{ReturnImmediately: &returnImmediately}
+	respA, err := nodeA.OnSendMessage(context.Background(), params)
+	if err != nil {
+		t.Fatalf("nodeA OnSendMessage: %v", err)
+	}
+	taskA := respA.GetTask()
+	if taskA == nil {
+		t.Fatalf("expected a task snapshot from nodeA, got %+v", respA)
+	}
+	<-started // the working event is persisted; the task is live on nodeA
+
+	chB, err := nodeB.OnResubscribe(context.Background(), protocol.TaskIDParams{ID: taskA.ID})
+	if err != nil {
+		t.Fatalf("nodeB OnResubscribe: %v", err)
+	}
+
+	// The first frame must be the current snapshot (non-terminal).
+	first, ok := recvTimeout(t, chB)
+	if !ok {
+		t.Fatal("nodeB did not receive the initial snapshot")
+	}
+	if task := first.GetTask(); task == nil || task.Status.State != protocol.TaskStateWorking {
+		t.Fatalf("first frame must be the working snapshot, got %+v", first)
+	}
+
+	// The terminal event is produced on nodeA AFTER nodeB resubscribed elsewhere.
+	close(release)
+
+	if !drainForState(t, chB, protocol.TaskStateCompleted) {
+		t.Fatal("cross-node resubscriber never received the completed event before the stream closed")
+	}
+}
+
+// An event published right after resubscribe (in the window between the cursor
+// capture and the tailer's first read) is still delivered. This guards the
+// synchronous pre-snapshot cursor against the gap a "$" cursor would leave.
+func TestCrossNode_DeliversEventPublishedRightAfterResubscribe(t *testing.T) {
+	nodeA, nodeB := twoNodeManagers(t, scriptedExecutor())
+	task := storedTask(t, nodeA, "task-gap", "ctx-gap", protocol.TaskStateWorking)
+	nodeA.publishStream(task.ID, protocol.NewStreamResponseStatusUpdate(
+		statusEvent(protocol.TaskStateWorking, agentReply("w1"))))
+
+	chB, err := nodeB.OnResubscribe(context.Background(), protocol.TaskIDParams{ID: task.ID})
+	if err != nil {
+		t.Fatalf("OnResubscribe: %v", err)
+	}
+	// Publish the terminal event immediately after resubscribe.
+	nodeA.publishStream(task.ID, protocol.NewStreamResponseStatusUpdate(
+		statusEvent(protocol.TaskStateCompleted, agentReply("done"))))
+
+	first, _ := recvTimeout(t, chB)
+	if first.GetTask() == nil {
+		t.Fatalf("first frame must be the snapshot, got %+v", first)
+	}
+	if !drainForState(t, chB, protocol.TaskStateCompleted) {
+		t.Fatal("resubscriber lost the event published right after resubscribe (cursor gap)")
+	}
+}
+
+// A cancel of a task with no live run persists CANCELED and notifies via
+// notifySubscribers, bypassing broadcast. The stream seam sits at
+// notifySubscribers, so a cross-node resubscriber still sees the CANCELED frame.
+func TestCrossNode_CancelWithoutLiveRunReachesResubscriber(t *testing.T) {
+	nodeA, nodeB := twoNodeManagers(t, scriptedExecutor())
+	task := storedTask(t, nodeA, "task-cancel", "ctx-cancel", protocol.TaskStateWorking)
+
+	chB, err := nodeB.OnResubscribe(context.Background(), protocol.TaskIDParams{ID: task.ID})
+	if err != nil {
+		t.Fatalf("OnResubscribe: %v", err)
+	}
+	if first, _ := recvTimeout(t, chB); first.GetTask() == nil {
+		t.Fatalf("expected the snapshot first, got %+v", first)
+	}
+
+	if _, err := nodeA.OnCancelTask(context.Background(), protocol.TaskIDParams{ID: task.ID}); err != nil {
+		t.Fatalf("nodeA OnCancelTask: %v", err)
+	}
+
+	if !drainForState(t, chB, protocol.TaskStateCanceled) {
+		t.Fatal("cross-node resubscriber never received the CANCELED event")
+	}
+}
+
+// With streaming disabled (default) no per-task stream key is created and the
+// resubscribe path is unchanged.
+func TestResubscribeStreaming_Disabled_NoStreamKey(t *testing.T) {
+	mgr, mr := setupTest(t, scriptedExecutor(
+		statusEvent(protocol.TaskStateWorking, agentReply("w")),
+		statusEvent(protocol.TaskStateCompleted, agentReply("done")),
+	))
+	if _, err := mgr.OnSendMessage(context.Background(), sendParams("go", "ctx")); err != nil {
+		t.Fatalf("OnSendMessage: %v", err)
+	}
+	for _, k := range mr.Keys() {
+		if strings.HasPrefix(k, streamPrefix) {
+			t.Fatalf("stream key %q created while ResubscribeStreaming is off", k)
+		}
+	}
+}
+
+// When the resubscribing client disconnects (its request context is canceled),
+// the stream closes so the server-side drain ends and nothing leaks.
+func TestCrossNode_ClientDisconnectClosesStream(t *testing.T) {
+	nodeA, nodeB := twoNodeManagers(t, scriptedExecutor())
+	task := storedTask(t, nodeA, "task-disc", "ctx-disc", protocol.TaskStateWorking)
+
+	rctx, rcancel := context.WithCancel(context.Background())
+	chB, err := nodeB.OnResubscribe(rctx, protocol.TaskIDParams{ID: task.ID})
+	if err != nil {
+		t.Fatalf("OnResubscribe: %v", err)
+	}
+	if first, _ := recvTimeout(t, chB); first.GetTask() == nil {
+		t.Fatalf("expected the snapshot first, got %+v", first)
+	}
+
+	rcancel() // the client goes away
+
+	// The stream must close (draining any buffered frames first).
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case _, ok := <-chB:
+			if !ok {
+				return
+			}
+		case <-deadline:
+			t.Fatal("resubscribe stream did not close after client disconnect")
+		}
+	}
+}
+
+// Close returns promptly and joins the tailer even with a resubscribe parked in
+// a blocking XREAD.
+func TestCrossNode_CloseJoinsActiveTailer(t *testing.T) {
+	nodeA, nodeB := twoNodeManagers(t, scriptedExecutor())
+	task := storedTask(t, nodeA, "task-close", "ctx-close", protocol.TaskStateWorking)
+	if _, err := nodeB.OnResubscribe(context.Background(), protocol.TaskIDParams{ID: task.ID}); err != nil {
+		t.Fatalf("OnResubscribe: %v", err)
+	}
+	// nodeB's tailer is parked in XREAD BLOCK; Close must cancel and join it.
+	done := make(chan error, 1)
+	go func() { done <- nodeB.Close() }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close hung with an active resubscribe tailer")
+	}
+}

--- a/taskmanager/redis/redis_cross_node_test.go
+++ b/taskmanager/redis/redis_cross_node_test.go
@@ -175,7 +175,7 @@ func TestCrossNode_ResubscribeReceivesSubsequentEvents(t *testing.T) {
 func TestCrossNode_DeliversEventPublishedRightAfterResubscribe(t *testing.T) {
 	nodeA, nodeB := twoNodeManagers(t, scriptedExecutor())
 	task := storedTask(t, nodeA, "task-gap", "ctx-gap", protocol.TaskStateWorking)
-	if err := nodeA.appendStreamEvent(context.Background(), task.ID, protocol.NewStreamResponseStatusUpdate(
+	if err := nodeA.appendTaskEvent(context.Background(), task.ID, protocol.NewStreamResponseStatusUpdate(
 		statusEvent(protocol.TaskStateWorking, agentReply("w1")))); err != nil {
 		t.Fatalf("append working event: %v", err)
 	}
@@ -185,7 +185,7 @@ func TestCrossNode_DeliversEventPublishedRightAfterResubscribe(t *testing.T) {
 		t.Fatalf("OnResubscribe: %v", err)
 	}
 	// Publish the terminal event immediately after resubscribe.
-	if err := nodeA.appendStreamEvent(context.Background(), task.ID, protocol.NewStreamResponseStatusUpdate(
+	if err := nodeA.appendTaskEvent(context.Background(), task.ID, protocol.NewStreamResponseStatusUpdate(
 		statusEvent(protocol.TaskStateCompleted, agentReply("done")))); err != nil {
 		t.Fatalf("append completed event: %v", err)
 	}
@@ -298,13 +298,13 @@ func TestCrossNode_AtomicSnapshotCursorHasNoOverlapOrGap(t *testing.T) {
 	first.TaskID = task.ID
 	first.ContextID = task.ContextID
 	task.Artifacts, _ = protocol.AppendArtifact(task.Artifacts, first.Artifact, false)
-	if err := nodeA.storeTaskEvent(
+	if err := nodeA.commitTaskEvent(
 		context.Background(), task, protocol.NewStreamResponseArtifactUpdate(first),
 	); err != nil {
 		t.Fatalf("store first task event: %v", err)
 	}
 
-	snapshot, cursor, err := nodeB.loadTaskAndCursor(context.Background(), task.ID)
+	snapshot, cursor, err := nodeB.eventTransport.LoadTaskAndCursor(context.Background(), task.ID)
 	if err != nil {
 		t.Fatalf("loadTaskAndCursor: %v", err)
 	}
@@ -325,7 +325,7 @@ func TestCrossNode_AtomicSnapshotCursorHasNoOverlapOrGap(t *testing.T) {
 	appendChunk := true
 	second.Append = &appendChunk
 	task.Artifacts, _ = protocol.AppendArtifact(task.Artifacts, second.Artifact, true)
-	if err := nodeA.storeTaskEvent(
+	if err := nodeA.commitTaskEvent(
 		context.Background(), task, protocol.NewStreamResponseArtifactUpdate(second),
 	); err != nil {
 		t.Fatalf("store second task event: %v", err)
@@ -360,7 +360,7 @@ func TestCrossNode_InputRequiredDoesNotCloseResubscribe(t *testing.T) {
 	input.TaskID = task.ID
 	input.ContextID = task.ContextID
 	task.Status = input.Status
-	if err := nodeA.storeTaskEvent(
+	if err := nodeA.commitTaskEvent(
 		context.Background(), task, protocol.NewStreamResponseStatusUpdate(input),
 	); err != nil {
 		t.Fatalf("store input-required: %v", err)
@@ -373,7 +373,7 @@ func TestCrossNode_InputRequiredDoesNotCloseResubscribe(t *testing.T) {
 	completed.TaskID = task.ID
 	completed.ContextID = task.ContextID
 	task.Status = completed.Status
-	if err := nodeA.storeTaskEvent(
+	if err := nodeA.commitTaskEvent(
 		context.Background(), task, protocol.NewStreamResponseStatusUpdate(completed),
 	); err != nil {
 		t.Fatalf("store completed: %v", err)
@@ -404,7 +404,7 @@ func TestCrossNode_SlowConsumerDoesNotLoseStream(t *testing.T) {
 		update := protocol.NewStreamResponseStatusUpdate(
 			statusEvent(protocol.TaskStateWorking, agentReply("still working")),
 		)
-		if err := nodeA.appendStreamEvent(context.Background(), task.ID, update); err != nil {
+		if err := nodeA.appendTaskEvent(context.Background(), task.ID, update); err != nil {
 			t.Fatalf("append stream event %d: %v", i, err)
 		}
 	}
@@ -492,10 +492,10 @@ func TestCrossNode_SubMillisecondExpirationIsClamped(t *testing.T) {
 	update.TaskID = task.ID
 	update.ContextID = task.ContextID
 	task.Status = update.Status
-	if err := manager.storeTaskEvent(
+	if err := manager.commitTaskEvent(
 		context.Background(), task, protocol.NewStreamResponseStatusUpdate(update),
 	); err != nil {
-		t.Fatalf("storeTaskEvent with sub-millisecond configured TTL: %v", err)
+		t.Fatalf("commitTaskEvent with sub-millisecond configured TTL: %v", err)
 	}
 	if got, err := manager.client.XLen(context.Background(), streamKey(task.ID)).Result(); err != nil || got != 1 {
 		t.Fatalf("stream event missing after clamped TTL: xlen=%d err=%v", got, err)
@@ -507,7 +507,7 @@ func TestCrossNode_SubMillisecondExpirationIsClamped(t *testing.T) {
 func TestCrossNode_CloseRejectsTailerAfterSnapshotRead(t *testing.T) {
 	nodeA, nodeB := twoNodeManagers(t, scriptedExecutor())
 	task := storedTask(t, nodeA, "task-close-admission", "ctx-close-admission", protocol.TaskStateWorking)
-	if _, _, err := nodeB.loadTaskAndCursor(context.Background(), task.ID); err != nil {
+	if _, _, err := nodeB.eventTransport.LoadTaskAndCursor(context.Background(), task.ID); err != nil {
 		t.Fatalf("warm loadTaskAndCursor script: %v", err)
 	}
 	hook := &blockAfterCommandHook{

--- a/taskmanager/redis/redis_engine.go
+++ b/taskmanager/redis/redis_engine.go
@@ -536,9 +536,16 @@ func (ex *execution) stampTaskEventIDs(taskID, contextID *string) bool {
 func (ex *execution) processMessageEvent(msg *protocol.Message) {
 	contextID := ex.ec.ContextID
 	ex.manager.processReplyMessage(&contextID, msg)
+	response := protocol.NewStreamResponseMessage(msg)
+	if ex.task != nil {
+		if err := ex.manager.appendStreamEvent(context.Background(), ex.ec.TaskID, response); err != nil {
+			log.Errorf("RedisTaskManager: failed to store message event for task %s: %v", ex.ec.TaskID, err)
+			return
+		}
+	}
 	ex.lastMessage = msg
 	ex.offerImmediateResult(sendOutcome{message: msg})
-	ex.broadcast(protocol.NewStreamResponseMessage(msg))
+	ex.broadcast(response)
 }
 
 // storeStatusMessage stores a stamped copy without mutating the processor's
@@ -624,13 +631,14 @@ func (ex *execution) processStatusEvent(ev *protocol.TaskStatusUpdateEvent) {
 	ex.rollStatusMessage(previousStatusMessage)
 	// Persist before broadcast (consistency order).
 	//
-	// KNOWN LIMITATION: on a Redis SET error the in-memory working copy (ex.task)
+	// KNOWN LIMITATION: on a Redis persistence error the in-memory working copy (ex.task)
 	// has already advanced but the store has not, so the unary result derived
 	// from ex.task can disagree with what GetTask returns until the TTL expires.
 	// A full fix (rollback or finish()-time reconciliation) belongs with the
 	// broader Redis storage-error handling; broadcasting is correctly skipped
 	// here so subscribers never get ahead of the store.
-	if err := ex.manager.storeTask(context.Background(), ex.task); err != nil {
+	response := protocol.NewStreamResponseStatusUpdate(ev)
+	if err := ex.manager.storeTaskEvent(context.Background(), ex.task, response); err != nil {
 		if yielding {
 			ex.manager.abortExecutionYield(ex.ec.TaskID, ex.live)
 		}
@@ -645,7 +653,6 @@ func (ex *execution) processStatusEvent(ev *protocol.TaskStatusUpdateEvent) {
 		ex.failTask("failed to persist inline push config")
 		return
 	}
-	response := protocol.NewStreamResponseStatusUpdate(ev)
 	if yielding {
 		ex.yielded = true
 		// Queue automatic push before exposing the suspend state. A full bounded
@@ -697,7 +704,8 @@ func (ex *execution) processArtifactEvent(ev *protocol.TaskArtifactUpdateEvent) 
 	}
 	ex.taskTouched = true
 	// Persist before broadcast (consistency order).
-	if err := ex.manager.storeTask(context.Background(), ex.task); err != nil {
+	response := protocol.NewStreamResponseArtifactUpdate(ev)
+	if err := ex.manager.storeTaskEvent(context.Background(), ex.task, response); err != nil {
 		log.Errorf("RedisTaskManager: failed to store task %s artifact: %v", ev.TaskID, err)
 		return
 	}
@@ -709,7 +717,7 @@ func (ex *execution) processArtifactEvent(ev *protocol.TaskArtifactUpdateEvent) 
 	// Immediate result first: a returnImmediately waiter must never be stalled behind
 	// a slow subscriber in the fan-out below.
 	ex.offerImmediateTask()
-	ex.broadcast(protocol.NewStreamResponseArtifactUpdate(ev))
+	ex.broadcast(response)
 }
 
 func (ex *execution) persistInlinePushConfig() error {

--- a/taskmanager/redis/redis_engine.go
+++ b/taskmanager/redis/redis_engine.go
@@ -538,7 +538,7 @@ func (ex *execution) processMessageEvent(msg *protocol.Message) {
 	ex.manager.processReplyMessage(&contextID, msg)
 	response := protocol.NewStreamResponseMessage(msg)
 	if ex.task != nil {
-		if err := ex.manager.appendStreamEvent(context.Background(), ex.ec.TaskID, response); err != nil {
+		if err := ex.manager.appendTaskEvent(context.Background(), ex.ec.TaskID, response); err != nil {
 			log.Errorf("RedisTaskManager: failed to store message event for task %s: %v", ex.ec.TaskID, err)
 			return
 		}
@@ -638,7 +638,7 @@ func (ex *execution) processStatusEvent(ev *protocol.TaskStatusUpdateEvent) {
 	// broader Redis storage-error handling; broadcasting is correctly skipped
 	// here so subscribers never get ahead of the store.
 	response := protocol.NewStreamResponseStatusUpdate(ev)
-	if err := ex.manager.storeTaskEvent(context.Background(), ex.task, response); err != nil {
+	if err := ex.manager.commitTaskEvent(context.Background(), ex.task, response); err != nil {
 		if yielding {
 			ex.manager.abortExecutionYield(ex.ec.TaskID, ex.live)
 		}
@@ -705,7 +705,7 @@ func (ex *execution) processArtifactEvent(ev *protocol.TaskArtifactUpdateEvent) 
 	ex.taskTouched = true
 	// Persist before broadcast (consistency order).
 	response := protocol.NewStreamResponseArtifactUpdate(ev)
-	if err := ex.manager.storeTaskEvent(context.Background(), ex.task, response); err != nil {
+	if err := ex.manager.commitTaskEvent(context.Background(), ex.task, response); err != nil {
 		log.Errorf("RedisTaskManager: failed to store task %s artifact: %v", ev.TaskID, err)
 		return
 	}

--- a/taskmanager/redis/redis_engine.go
+++ b/taskmanager/redis/redis_engine.go
@@ -106,6 +106,13 @@ type execution struct {
 	// finalTask is the task snapshot taken after the close rules ran; it is
 	// safe to read once done is closed.
 	finalTask *protocol.Task
+	// runErr is the first asynchronous event-persistence failure. The engine
+	// drains the processor channel after it is set; result callers are notified
+	// immediately through runFailed and may also read it after done closes.
+	runErr error
+	// runFailed carries runErr without waiting for the MessageProcessor to close
+	// its channel. It is buffered so the draining engine never waits for a caller.
+	runFailed chan error
 	// taskTouched records whether THIS round wrote to the task (lazy create,
 	// status/artifact persist, violation or close-rule write). §3.1 keys the
 	// unary result on it: a continuation round that only emits Messages
@@ -196,6 +203,7 @@ func (m *TaskManager) prepareExecution(
 		ec:              &taskmanager.ExecContext{},
 		live:            &liveExecution{cancel: cancel},
 		immediateResult: make(chan sendOutcome, 1),
+		runFailed:       make(chan error, 1),
 		done:            make(chan struct{}),
 	}
 	if streaming {
@@ -248,7 +256,15 @@ func (m *TaskManager) prepareExecution(
 		if task.Status.Message != nil {
 			statusMessage := task.Status.Message
 			task.Status.Message = nil
-			if err := m.storeTask(ctx, task); err != nil {
+			// Clearing the current status message changes the Task snapshot. Commit a
+			// same-state status event with it so a cross-node subscriber that loaded
+			// the old snapshot cannot miss this continuation-side transition.
+			event := &protocol.TaskStatusUpdateEvent{
+				TaskID:    task.ID,
+				ContextID: task.ContextID,
+				Status:    task.Status,
+			}
+			if err := m.commitTaskEvent(ctx, task, protocol.NewStreamResponseStatusUpdate(event)); err != nil {
 				m.releaseExecution(taskID, ex.live)
 				cancel()
 				return nil, fmt.Errorf("failed to advance task status history: %w", err)
@@ -350,6 +366,11 @@ func (m *TaskManager) prepareInlinePushConfig(
 func (ex *execution) run(events <-chan protocol.StreamEvent) {
 	mode := engineConsuming
 	for event := range events {
+		if ex.runErr != nil {
+			log.Warnf("RedisTaskManager: discarding %T for task %s after execution persistence failed",
+				event, ex.ec.TaskID)
+			continue
+		}
 		switch mode {
 		case engineDrainTerminal:
 			log.Warnf("RedisTaskManager: discarding %T for task %s emitted after terminal state",
@@ -367,6 +388,22 @@ func (ex *execution) run(events <-chan protocol.StreamEvent) {
 		mode = ex.handleEvent(event)
 	}
 	ex.finish()
+}
+
+// failRun exposes a persistence failure immediately while the engine keeps
+// draining the processor channel in the background. Canceling the processor
+// context asks well-behaved producers to close promptly; closing the request
+// pipe prevents a streaming caller from waiting on a stream that cannot commit
+// any more events.
+func (ex *execution) failRun(err error) {
+	if err == nil || ex.runErr != nil {
+		return
+	}
+	ex.runErr = err
+	ex.runFailed <- err
+	ex.live.cancel()
+	ex.closePipe()
+	log.Errorf("RedisTaskManager: %v", err)
 }
 
 // handleEvent processes one event and returns the next consume mode.
@@ -398,6 +435,9 @@ func (ex *execution) handleEvent(event protocol.StreamEvent) int {
 			return engineDrainViolation
 		}
 		ex.processStatusEvent(ev)
+		if ex.runErr != nil {
+			return engineConsuming
+		}
 		if ex.task != nil && isFinalState(ex.task.Status.State) {
 			return engineDrainTerminal
 		}
@@ -428,7 +468,7 @@ func (ex *execution) handleEvent(event protocol.StreamEvent) int {
 // close rules: ownership of the task moved on at the suspend event — a
 // continuation or a no-live cancel may already be writing it.
 func (ex *execution) finish() {
-	if ex.task != nil && !ex.yielded && !isFinalState(ex.task.Status.State) {
+	if ex.runErr == nil && ex.task != nil && !ex.yielded && !isFinalState(ex.task.Status.State) {
 		switch {
 		case ex.live.cancelRequested.Load():
 			// Cancellation-triggered close: the framework marks the task
@@ -454,7 +494,7 @@ func (ex *execution) finish() {
 	}
 	// §3.1: only rounds that wrote to the task answer with a Task snapshot; a
 	// continuation that merely replied with Messages answers with the Message.
-	if ex.task != nil && ex.taskTouched {
+	if ex.runErr == nil && ex.task != nil && ex.taskTouched {
 		ex.finalTask = copyTask(ex.task)
 	}
 	if ex.pipe != nil {
@@ -535,14 +575,18 @@ func (ex *execution) stampTaskEventIDs(taskID, contextID *string) bool {
 // waiter is never stalled behind a slow subscriber.
 func (ex *execution) processMessageEvent(msg *protocol.Message) {
 	contextID := ex.ec.ContextID
-	ex.manager.processReplyMessage(&contextID, msg)
+	ex.manager.stampReplyMessage(&contextID, msg)
 	response := protocol.NewStreamResponseMessage(msg)
 	if ex.task != nil {
 		if err := ex.manager.appendTaskEvent(context.Background(), ex.ec.TaskID, response); err != nil {
-			log.Errorf("RedisTaskManager: failed to store message event for task %s: %v", ex.ec.TaskID, err)
+			ex.failRun(fmt.Errorf("failed to store message event for task %s: %w", ex.ec.TaskID, err))
 			return
 		}
 	}
+	// The event journal is the success boundary for a reply attached to a Task.
+	// Store conversation history only after the append succeeds, so a failed
+	// request cannot leave behind an agent reply that no stream observed.
+	ex.manager.storeMessage(context.Background(), *msg)
 	ex.lastMessage = msg
 	ex.offerImmediateResult(sendOutcome{message: msg})
 	ex.broadcast(response)
@@ -626,25 +670,21 @@ func (ex *execution) processStatusEvent(ev *protocol.TaskStatusUpdateEvent) {
 		// rather than swallowing the accepted cancellation.
 		yielding = ex.manager.beginExecutionYield(ex.ec.TaskID, ex.live)
 	}
-	// The old status message has now been superseded. Move it to history before
-	// storing/publishing the new status; the new/current message stays on Status.
-	ex.rollStatusMessage(previousStatusMessage)
-	// Persist before broadcast (consistency order).
-	//
-	// KNOWN LIMITATION: on a Redis persistence error the in-memory working copy (ex.task)
-	// has already advanced but the store has not, so the unary result derived
-	// from ex.task can disagree with what GetTask returns until the TTL expires.
-	// A full fix (rollback or finish()-time reconciliation) belongs with the
-	// broader Redis storage-error handling; broadcasting is correctly skipped
-	// here so subscribers never get ahead of the store.
+	// Persist before broadcast (consistency order). A failure terminates the
+	// execution result: the mutated working copy is never returned as if it had
+	// committed successfully.
 	response := protocol.NewStreamResponseStatusUpdate(ev)
 	if err := ex.manager.commitTaskEvent(context.Background(), ex.task, response); err != nil {
 		if yielding {
 			ex.manager.abortExecutionYield(ex.ec.TaskID, ex.live)
 		}
-		log.Errorf("RedisTaskManager: failed to store task %s status %s: %v", ev.TaskID, status.State, err)
+		ex.failRun(fmt.Errorf("failed to store task %s status %s: %w", ev.TaskID, status.State, err))
 		return
 	}
+	// The old status message is durably superseded only after the Task/event
+	// commit succeeds. Moving it earlier would leave failed updates reflected in
+	// conversation history while the stored Task still carried the same message.
+	ex.rollStatusMessage(previousStatusMessage)
 	if err := ex.persistInlinePushConfig(); err != nil {
 		if yielding {
 			ex.manager.abortExecutionYield(ex.ec.TaskID, ex.live)
@@ -706,7 +746,7 @@ func (ex *execution) processArtifactEvent(ev *protocol.TaskArtifactUpdateEvent) 
 	// Persist before broadcast (consistency order).
 	response := protocol.NewStreamResponseArtifactUpdate(ev)
 	if err := ex.manager.commitTaskEvent(context.Background(), ex.task, response); err != nil {
-		log.Errorf("RedisTaskManager: failed to store task %s artifact: %v", ev.TaskID, err)
+		ex.failRun(fmt.Errorf("failed to store task %s artifact: %w", ev.TaskID, err))
 		return
 	}
 	if err := ex.persistInlinePushConfig(); err != nil {

--- a/taskmanager/redis/redis_event_transport.go
+++ b/taskmanager/redis/redis_event_transport.go
@@ -1,0 +1,243 @@
+// Tencent is pleased to support the open source community by making trpc-a2a-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-a2a-go is licensed under the Apache License Version 2.0.
+
+package redis
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	redisclient "github.com/redis/go-redis/v9"
+
+	"trpc.group/trpc-go/trpc-a2a-go/v2/internal/taskevent"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/log"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
+)
+
+const (
+	// streamPrefix keys the per-task event stream used for cross-node resubscribe.
+	// streamKey adds the task key as a Redis Cluster hash tag so the task and
+	// stream can be read or written atomically by one script.
+	streamPrefix = "stream:"
+	// streamField is the single XADD field carrying the JSON-encoded StreamResponse.
+	streamField = "e"
+	// streamMaxLen caps each task's event stream (XADD MAXLEN ~).
+	streamMaxLen = 10000
+	// streamReadCount caps entries returned per XREAD.
+	streamReadCount = 64
+	// streamBlockTimeout bounds one XREAD BLOCK slice so readers re-check context.
+	streamBlockTimeout = 5 * time.Second
+)
+
+// commitTaskEventScript atomically persists a Task snapshot and its event. The
+// stream type is checked before either write because Redis scripts are atomic
+// with respect to other clients but do not roll back commands after a runtime
+// error. The task and stream keys share one Redis Cluster slot (see streamKey).
+var commitTaskEventScript = redisclient.NewScript(`
+local stream_type = redis.call('TYPE', KEYS[2]).ok
+if stream_type ~= 'none' and stream_type ~= 'stream' then
+    return redis.error_reply('task event stream has wrong type')
+end
+local event_id = redis.call(
+    'XADD', KEYS[2], 'MAXLEN', '~', ARGV[3], '*', ARGV[4], ARGV[2]
+)
+redis.call('SET', KEYS[1], ARGV[1], 'PX', ARGV[5])
+redis.call('PEXPIRE', KEYS[2], ARGV[5])
+return event_id
+`)
+
+// appendEventScript persists an event that does not change the Task snapshot.
+// Its TTL is capped to the Task's remaining TTL so an event-only write cannot
+// leave an orphan stream after the Task expires.
+var appendEventScript = redisclient.NewScript(`
+local task_ttl = redis.call('PTTL', KEYS[1])
+if task_ttl == -2 then
+    return redis.error_reply('task does not exist')
+end
+local stream_type = redis.call('TYPE', KEYS[2]).ok
+if stream_type ~= 'none' and stream_type ~= 'stream' then
+    return redis.error_reply('task event stream has wrong type')
+end
+local event_id = redis.call(
+    'XADD', KEYS[2], 'MAXLEN', '~', ARGV[2], '*', ARGV[3], ARGV[1]
+)
+if task_ttl == -1 then
+    redis.call('PERSIST', KEYS[2])
+else
+    redis.call('PEXPIRE', KEYS[2], math.max(1, task_ttl))
+end
+return event_id
+`)
+
+// loadTaskAndCursorScript returns a Task snapshot and the stream tail from one
+// Redis linearization point. A concurrent commitTaskEventScript therefore lands
+// wholly before the snapshot/cursor pair or wholly after it.
+var loadTaskAndCursorScript = redisclient.NewScript(`
+local task = redis.call('GET', KEYS[1])
+if not task then
+    return {0, '', '0-0'}
+end
+local tail = redis.call('XREVRANGE', KEYS[2], '+', '-', 'COUNT', 1)
+local cursor = '0-0'
+if #tail > 0 then
+    cursor = tail[1][1]
+end
+return {1, task, cursor}
+`)
+
+type redisTaskEventTransport struct {
+	client     redisclient.UniversalClient
+	expiration time.Duration
+}
+
+var _ taskevent.Transport = (*redisTaskEventTransport)(nil)
+
+func newRedisTaskEventTransport(
+	client redisclient.UniversalClient,
+	expiration time.Duration,
+) *redisTaskEventTransport {
+	return &redisTaskEventTransport{client: client, expiration: expiration}
+}
+
+// streamKey shares the task key's Redis Cluster slot without changing the
+// existing task key. Redis hashes the full task key and the {...} portion of
+// the stream key, which are the same bytes for manager-generated task IDs.
+func streamKey(taskID string) string {
+	return streamPrefix + "{" + taskPrefix + taskID + "}"
+}
+
+func (t *redisTaskEventTransport) CommitTaskEvent(
+	ctx context.Context,
+	task *protocol.Task,
+	event protocol.StreamResponse,
+) error {
+	taskBytes, err := json.Marshal(task)
+	if err != nil {
+		return fmt.Errorf("failed to serialize task: %w", err)
+	}
+	eventBytes, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("failed to serialize task event: %w", err)
+	}
+	if _, err := commitTaskEventScript.Run(
+		ctx,
+		t.client,
+		[]string{taskPrefix + task.ID, streamKey(task.ID)},
+		taskBytes,
+		eventBytes,
+		streamMaxLen,
+		streamField,
+		t.expiration.Milliseconds(),
+	).Result(); err != nil {
+		return fmt.Errorf("failed to store task and event: %w", err)
+	}
+	return nil
+}
+
+func (t *redisTaskEventTransport) AppendEvent(
+	ctx context.Context,
+	taskID string,
+	event protocol.StreamResponse,
+) error {
+	payload, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("failed to marshal stream event for task %s: %w", taskID, err)
+	}
+	if _, err := appendEventScript.Run(
+		ctx,
+		t.client,
+		[]string{taskPrefix + taskID, streamKey(taskID)},
+		payload,
+		streamMaxLen,
+		streamField,
+	).Result(); err != nil {
+		return fmt.Errorf("failed to append stream event for task %s: %w", taskID, err)
+	}
+	return nil
+}
+
+func (t *redisTaskEventTransport) LoadTaskAndCursor(
+	ctx context.Context,
+	taskID string,
+) (*protocol.Task, string, error) {
+	values, err := loadTaskAndCursorScript.Run(
+		ctx,
+		t.client,
+		[]string{taskPrefix + taskID, streamKey(taskID)},
+	).Slice()
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to load task %s and stream cursor: %w", taskID, err)
+	}
+	if len(values) != 3 {
+		return nil, "", fmt.Errorf("failed to load task %s and stream cursor: unexpected result", taskID)
+	}
+	exists, ok := values[0].(int64)
+	if !ok {
+		return nil, "", fmt.Errorf("failed to load task %s and stream cursor: invalid existence flag", taskID)
+	}
+	if exists == 0 {
+		return nil, "", taskmanager.ErrTaskNotFound(taskID)
+	}
+	taskJSON, ok := values[1].(string)
+	if !ok {
+		return nil, "", fmt.Errorf("failed to load task %s and stream cursor: invalid task payload", taskID)
+	}
+	cursor, ok := values[2].(string)
+	if !ok || cursor == "" {
+		return nil, "", fmt.Errorf("failed to load task %s and stream cursor: invalid cursor", taskID)
+	}
+	var task protocol.Task
+	if err := json.Unmarshal([]byte(taskJSON), &task); err != nil {
+		return nil, "", fmt.Errorf("failed to deserialize task: %w", err)
+	}
+	return &task, cursor, nil
+}
+
+func (t *redisTaskEventTransport) ReadAfter(
+	ctx context.Context,
+	taskID string,
+	cursor string,
+) ([]protocol.StreamResponse, string, error) {
+	res, err := t.client.XRead(ctx, &redisclient.XReadArgs{
+		Streams: []string{streamKey(taskID), cursor},
+		Block:   streamBlockTimeout,
+		Count:   streamReadCount,
+	}).Result()
+	if errors.Is(err, redisclient.Nil) {
+		return nil, cursor, nil
+	}
+	if err != nil {
+		return nil, cursor, err
+	}
+
+	nextCursor := cursor
+	events := make([]protocol.StreamResponse, 0)
+	for _, stream := range res {
+		for _, entry := range stream.Messages {
+			nextCursor = entry.ID
+			var payload []byte
+			switch raw := entry.Values[streamField].(type) {
+			case string:
+				payload = []byte(raw)
+			case []byte:
+				payload = raw
+			default:
+				continue
+			}
+			var event protocol.StreamResponse
+			if err := json.Unmarshal(payload, &event); err != nil {
+				log.Warnf("RedisTaskManager: discarding malformed stream entry for task %s: %v", taskID, err)
+				continue
+			}
+			events = append(events, event)
+		}
+	}
+	return events, nextCursor, nil
+}

--- a/taskmanager/redis/redis_event_transport.go
+++ b/taskmanager/redis/redis_event_transport.go
@@ -32,8 +32,6 @@ const (
 	streamMaxLen = 10000
 	// streamReadCount caps entries returned per XREAD.
 	streamReadCount = 64
-	// streamBlockTimeout bounds one XREAD BLOCK slice so readers re-check context.
-	streamBlockTimeout = 5 * time.Second
 )
 
 // commitTaskEventScript atomically persists a Task snapshot and its event. The
@@ -207,8 +205,11 @@ func (t *redisTaskEventTransport) ReadAfter(
 ) ([]protocol.StreamResponse, string, error) {
 	res, err := t.client.XRead(ctx, &redisclient.XReadArgs{
 		Streams: []string{streamKey(taskID), cursor},
-		Block:   streamBlockTimeout,
-		Count:   streamReadCount,
+		// Do not pin the TaskManager's shared Redis connection pool while a
+		// subscription is idle. The manager applies a context-aware backoff when
+		// this non-blocking read has no event or cursor progress.
+		Block: -1,
+		Count: streamReadCount,
 	}).Result()
 	if errors.Is(err, redisclient.Nil) {
 		return nil, cursor, nil

--- a/taskmanager/redis/redis_manager.go
+++ b/taskmanager/redis/redis_manager.go
@@ -33,6 +33,16 @@ const (
 	conversationPrefix     = "conv:"
 	taskPrefix             = "task:"
 	pushNotificationPrefix = "push:"
+	// streamPrefix keys the per-task event stream used for cross-node resubscribe.
+	streamPrefix = "stream:"
+	// streamField is the single XADD field carrying the JSON-encoded StreamResponse.
+	streamField = "e"
+	// streamMaxLen caps each task's event stream (XADD MAXLEN ~).
+	streamMaxLen = 10000
+	// streamReadCount caps entries returned per XREAD.
+	streamReadCount = 64
+	// streamBlockTimeout bounds one XREAD BLOCK slice so tailers re-check context.
+	streamBlockTimeout = 5 * time.Second
 
 	// Default expiration time for Redis keys (1 hour).
 	defaultExpiration = 1 * time.Hour
@@ -102,6 +112,13 @@ type TaskManager struct {
 	// nil when push is disabled or the agent selected manual delivery.
 	pushDispatcher *pushdispatch.Dispatcher
 
+	// tailerWg counts cross-node resubscribe tailer goroutines so Close joins
+	// them before closing the Redis client. baseCtx is canceled by Close to
+	// unpark a tailer parked in a blocking XREAD.
+	tailerWg   sync.WaitGroup
+	baseCtx    context.Context
+	baseCancel context.CancelFunc
+
 	// options
 	options *TaskManagerOptions
 }
@@ -152,6 +169,7 @@ func NewTaskManager(
 			manager.isCurrentPushRegistration,
 		)
 	}
+	manager.baseCtx, manager.baseCancel = context.WithCancel(context.Background())
 
 	return manager, nil
 }
@@ -693,6 +711,9 @@ func (m *TaskManager) OnResubscribe(
 	ctx context.Context,
 	params protocol.TaskIDParams,
 ) (<-chan protocol.StreamResponse, error) {
+	if m.options.ResubscribeStreaming {
+		return m.onResubscribeStreaming(ctx, params)
+	}
 	// The snapshot read happens OUTSIDE subMu: getTaskInternal is a network
 	// round-trip and subMu sits on every broadcast's fan-out path — holding it
 	// across a slow Redis call would stall every stream in the process.
@@ -759,6 +780,160 @@ func (m *TaskManager) OnResubscribe(
 	}()
 
 	return subscriber.Channel(), nil
+}
+
+// onResubscribeStreaming is the cross-node resubscribe path (opt-in via
+// WithResubscribeStreaming). The first frame is the current snapshot; a tailer
+// then replays the task's Redis event stream from the pre-snapshot cursor, so it
+// works even when the task's live execution runs on another instance.
+func (m *TaskManager) onResubscribeStreaming(
+	ctx context.Context,
+	params protocol.TaskIDParams,
+) (<-chan protocol.StreamResponse, error) {
+	// Capture the stream cursor BEFORE the snapshot so their union is gap-free:
+	// persist-before-publish means any event at or before this cursor is already
+	// in the snapshot, and any later one is replayed by the tailer.
+	startID := m.streamStartID(ctx, params.ID)
+
+	task, err := m.getTaskInternal(ctx, params.ID)
+	if err != nil {
+		return nil, err
+	}
+	// v1.0: subscribing to an already-terminal task is an error.
+	if isFinalState(task.Status.State) {
+		return nil, taskmanager.ErrUnsupportedOperation(
+			fmt.Sprintf("subscribe to task %s in terminal state %s", params.ID, task.Status.State))
+	}
+
+	subscriber := newTaskSubscriber(
+		params.ID,
+		m.options.TaskSubscriberBufSize,
+		m.options.TaskSubscriberBlockingSend,
+	)
+	// v1.0: the first stream event must be the current Task snapshot.
+	if err := subscriber.Send(protocol.NewStreamResponseTask(task)); err != nil {
+		subscriber.Close()
+		return nil, err
+	}
+
+	// The subscriber is NOT registered in the local map: the Redis stream is its
+	// only source, whose producer may be another instance. If the task went
+	// terminal between the cursor and the snapshot, its terminal frame is after
+	// the cursor, so the tailer delivers it and then closes.
+	m.tailerWg.Add(1)
+	go m.tailStream(ctx, params.ID, startID, subscriber)
+
+	return subscriber.Channel(), nil
+}
+
+// streamStartID captures the current tail of a task's event stream. Returns "0"
+// (from the beginning) for an empty/absent stream.
+func (m *TaskManager) streamStartID(ctx context.Context, taskID string) string {
+	msgs, err := m.client.XRevRangeN(ctx, streamPrefix+taskID, "+", "-", 1).Result()
+	if err != nil || len(msgs) == 0 {
+		return "0"
+	}
+	return msgs[0].ID
+}
+
+// tailStream feeds a resubscriber from the task's Redis event stream, reading
+// strictly after startID. It closes the subscriber and returns on the terminal
+// status frame, when the request ends, or when the manager closes.
+func (m *TaskManager) tailStream(ctx context.Context, taskID, startID string, sub *taskSubscriber) {
+	defer m.tailerWg.Done()
+	defer sub.Close()
+
+	// Cancel the blocking XREAD, and unblock a parked blocking-send via Close,
+	// when the request ends or the manager closes.
+	readCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	tailerDone := make(chan struct{})
+	defer close(tailerDone)
+	go func() {
+		select {
+		case <-ctx.Done():
+		case <-m.baseCtx.Done():
+		case <-tailerDone:
+			return
+		}
+		cancel()
+		sub.Close()
+	}()
+
+	key := streamPrefix + taskID
+	for {
+		// A blocking XREAD is not interrupted mid-flight by context cancellation
+		// (only Close, via the client, unblocks it), so re-check between slices:
+		// on client disconnect this bounds teardown to one streamBlockTimeout.
+		select {
+		case <-readCtx.Done():
+			return
+		default:
+		}
+		res, err := m.client.XRead(readCtx, &redis.XReadArgs{
+			Streams: []string{key, startID},
+			Block:   streamBlockTimeout,
+			Count:   streamReadCount,
+		}).Result()
+		if errors.Is(err, redis.Nil) {
+			continue // BLOCK slice timed out with nothing new.
+		}
+		if err != nil {
+			return // readCtx canceled, client closed, or a Redis error.
+		}
+		for _, stream := range res {
+			for _, entry := range stream.Messages {
+				startID = entry.ID
+				raw, ok := entry.Values[streamField].(string)
+				if !ok {
+					continue
+				}
+				var event protocol.StreamResponse
+				if err := json.Unmarshal([]byte(raw), &event); err != nil {
+					log.Warnf("RedisTaskManager: discarding malformed stream entry for task %s: %v", taskID, err)
+					continue
+				}
+				if err := sub.Send(event); err != nil {
+					return // consumer gone.
+				}
+				// Terminate on a terminal STATUS frame only — an artifact's
+				// lastChunk (also IsFinal on the artifact) ends an artifact, not
+				// the task.
+				if su := event.GetStatusUpdate(); su != nil && su.IsFinal() {
+					return
+				}
+			}
+		}
+	}
+}
+
+// publishStream mirrors an already-persisted, already-locally-broadcast event
+// onto the task's Redis stream for cross-instance resubscribers. No-op unless
+// ResubscribeStreaming is enabled. It uses a background context (like storeTask)
+// so a request-scoped cancellation cannot drop the mirror after the event is
+// durable, and bounds the stream with MAXLEN + the same TTL as the task key.
+func (m *TaskManager) publishStream(taskID string, event protocol.StreamResponse) {
+	if !m.options.ResubscribeStreaming {
+		return
+	}
+	payload, err := json.Marshal(event)
+	if err != nil {
+		log.Errorf("RedisTaskManager: failed to marshal stream event for task %s: %v", taskID, err)
+		return
+	}
+	key := streamPrefix + taskID
+	ctx := context.Background()
+	pipe := m.client.Pipeline()
+	pipe.XAdd(ctx, &redis.XAddArgs{
+		Stream: key,
+		MaxLen: streamMaxLen,
+		Approx: true,
+		Values: map[string]interface{}{streamField: payload},
+	})
+	pipe.Expire(ctx, key, m.expiration)
+	if _, err := pipe.Exec(ctx); err != nil {
+		log.Errorf("RedisTaskManager: failed to publish stream event for task %s: %v", taskID, err)
+	}
 }
 
 // taskChanged reports whether two snapshots of the same task differ in what a
@@ -1096,6 +1271,12 @@ func (m *TaskManager) cleanSubscribers(taskID string) {
 
 // notifySubscribers notifies all subscribers of a task.
 func (m *TaskManager) notifySubscribers(taskID string, event protocol.StreamResponse) {
+	// Mirror onto the task's Redis stream first so a resubscriber on another
+	// instance sees the same events. This is the sole fan-out convergence point
+	// (both broadcast and cancelWithoutLiveRun reach here), so no producer path
+	// is missed. No-op unless ResubscribeStreaming is enabled.
+	m.publishStream(taskID, event)
+
 	// Deliver push notifications independently of live SSE subscribers: reaching
 	// clients that are not currently streaming is the whole point of push.
 	m.dispatchPush(taskID, event)
@@ -1234,7 +1415,13 @@ func (m *TaskManager) Close() error {
 		// CANCELED) must land while the Redis client is still usable.
 		m.engineWg.Wait()
 
+		// Stop cross-node resubscribe tailers. A blocking XREAD is not aborted by
+		// context alone, so closing the client is what unparks it; baseCancel
+		// stops any tailer between slices from re-reading. Join after, so no
+		// tailer goroutine outlives Close.
+		m.baseCancel()
 		m.closeErr = m.client.Close()
+		m.tailerWg.Wait()
 	})
 	return m.closeErr
 }

--- a/taskmanager/redis/redis_manager.go
+++ b/taskmanager/redis/redis_manager.go
@@ -34,6 +34,8 @@ const (
 	taskPrefix             = "task:"
 	pushNotificationPrefix = "push:"
 	// streamPrefix keys the per-task event stream used for cross-node resubscribe.
+	// streamKey adds the task key as a Redis Cluster hash tag so the task and
+	// stream can be read or written atomically by one script.
 	streamPrefix = "stream:"
 	// streamField is the single XADD field carrying the JSON-encoded StreamResponse.
 	streamField = "e"
@@ -67,6 +69,63 @@ redis.call('RPUSH', KEYS[1], ARGV[1])
 redis.call('LTRIM', KEYS[1], -tonumber(ARGV[3]), -1)
 redis.call('PEXPIRE', KEYS[1], ARGV[2])
 return 1
+`)
+
+// storeTaskEventScript atomically persists a task snapshot and its event. The
+// stream type is checked before either write because Redis scripts are atomic
+// with respect to other clients but do not roll back commands after a runtime
+// error. The task and stream keys share one Redis Cluster slot (see streamKey).
+var storeTaskEventScript = redis.NewScript(`
+local stream_type = redis.call('TYPE', KEYS[2]).ok
+if stream_type ~= 'none' and stream_type ~= 'stream' then
+    return redis.error_reply('task event stream has wrong type')
+end
+local event_id = redis.call(
+    'XADD', KEYS[2], 'MAXLEN', '~', ARGV[3], '*', ARGV[4], ARGV[2]
+)
+redis.call('SET', KEYS[1], ARGV[1], 'PX', ARGV[5])
+redis.call('PEXPIRE', KEYS[2], ARGV[5])
+return event_id
+`)
+
+// appendStreamEventScript persists an event that does not change the Task
+// snapshot (for example, a Message emitted after the Task exists). Its TTL is
+// capped to the Task's remaining TTL so an event-only write cannot leave an
+// orphan stream after the Task expires.
+var appendStreamEventScript = redis.NewScript(`
+local task_ttl = redis.call('PTTL', KEYS[1])
+if task_ttl == -2 then
+    return redis.error_reply('task does not exist')
+end
+local stream_type = redis.call('TYPE', KEYS[2]).ok
+if stream_type ~= 'none' and stream_type ~= 'stream' then
+    return redis.error_reply('task event stream has wrong type')
+end
+local event_id = redis.call(
+    'XADD', KEYS[2], 'MAXLEN', '~', ARGV[2], '*', ARGV[3], ARGV[1]
+)
+if task_ttl == -1 then
+    redis.call('PERSIST', KEYS[2])
+else
+    redis.call('PEXPIRE', KEYS[2], math.max(1, task_ttl))
+end
+return event_id
+`)
+
+// loadTaskAndCursorScript returns a Task snapshot and the stream tail from one
+// Redis linearization point. A concurrent storeTaskEventScript therefore lands
+// wholly before the snapshot/cursor pair or wholly after it.
+var loadTaskAndCursorScript = redis.NewScript(`
+local task = redis.call('GET', KEYS[1])
+if not task then
+    return {0, '', '0-0'}
+end
+local tail = redis.call('XREVRANGE', KEYS[2], '+', '-', 'COUNT', 1)
+local cursor = '0-0'
+if #tail > 0 then
+    cursor = tail[1][1]
+end
+return {1, task, cursor}
 `)
 
 // TaskManager provides a concrete, Redis-based implementation of the
@@ -151,11 +210,17 @@ func NewTaskManager(
 	if options.Push.MaxConcurrentDeliveries < 0 || options.Push.DeliveryQueueSize < 0 {
 		return nil, errors.New("push delivery concurrency and queue size cannot be negative")
 	}
+	expiration := options.ExpireTime
+	if expiration < time.Millisecond {
+		// go-redis applies the same lower bound for SET expiration. Keep Lua PX
+		// arguments valid and preserve the pre-streaming expiration semantics.
+		expiration = time.Millisecond
+	}
 
 	manager := &TaskManager{
 		processor:   processor,
 		client:      client,
-		expiration:  options.ExpireTime,
+		expiration:  expiration,
 		subscribers: make(map[string][]*taskSubscriber),
 		executions:  make(map[string]*liveExecution),
 		pushEnabled: options.Push.Sender != nil || options.Push.ManualDelivery,
@@ -413,13 +478,14 @@ func (m *TaskManager) cancelWithoutLiveRun(
 		Final: true,
 	}
 	task.Status = event.Status
+	response := protocol.NewStreamResponseStatusUpdate(event)
 	// Persist with a background context (like every engine write): the CANCELED
 	// state must land even if the cancel request's own context is already done.
-	if err := m.storeTask(context.Background(), task); err != nil {
+	if err := m.storeTaskEvent(context.Background(), task, response); err != nil {
 		log.Errorf("Error storing cancelled task %s: %v", params.ID, err)
 		return nil, err
 	}
-	m.notifySubscribers(params.ID, protocol.NewStreamResponseStatusUpdate(event))
+	m.notifySubscribers(params.ID, response)
 	m.cleanSubscribers(params.ID)
 
 	return task, nil
@@ -711,8 +777,8 @@ func (m *TaskManager) OnResubscribe(
 	ctx context.Context,
 	params protocol.TaskIDParams,
 ) (<-chan protocol.StreamResponse, error) {
-	if m.options.ResubscribeStreaming {
-		return m.onResubscribeStreaming(ctx, params)
+	if m.options.CrossNodeResubscribe {
+		return m.onCrossNodeResubscribe(ctx, params)
 	}
 	// The snapshot read happens OUTSIDE subMu: getTaskInternal is a network
 	// round-trip and subMu sits on every broadcast's fan-out path — holding it
@@ -782,20 +848,17 @@ func (m *TaskManager) OnResubscribe(
 	return subscriber.Channel(), nil
 }
 
-// onResubscribeStreaming is the cross-node resubscribe path (opt-in via
-// WithResubscribeStreaming). The first frame is the current snapshot; a tailer
-// then replays the task's Redis event stream from the pre-snapshot cursor, so it
-// works even when the task's live execution runs on another instance.
-func (m *TaskManager) onResubscribeStreaming(
+// onCrossNodeResubscribe is the cross-node resubscribe path (opt-in via
+// WithCrossNodeResubscribe). The first frame is the current snapshot; a tailer
+// then reads events committed after the snapshot's atomic stream cursor.
+func (m *TaskManager) onCrossNodeResubscribe(
 	ctx context.Context,
 	params protocol.TaskIDParams,
 ) (<-chan protocol.StreamResponse, error) {
-	// Capture the stream cursor BEFORE the snapshot so their union is gap-free:
-	// persist-before-publish means any event at or before this cursor is already
-	// in the snapshot, and any later one is replayed by the tailer.
-	startID := m.streamStartID(ctx, params.ID)
-
-	task, err := m.getTaskInternal(ctx, params.ID)
+	// The Task and stream tail are read by one Redis script. A concurrent event
+	// commit is therefore either reflected by both values or by neither: the
+	// snapshot and subsequent XREAD contain no gap and no overlapping task event.
+	task, startID, err := m.loadTaskAndCursor(ctx, params.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -808,7 +871,7 @@ func (m *TaskManager) onResubscribeStreaming(
 	subscriber := newTaskSubscriber(
 		params.ID,
 		m.options.TaskSubscriberBufSize,
-		m.options.TaskSubscriberBlockingSend,
+		true,
 	)
 	// v1.0: the first stream event must be the current Task snapshot.
 	if err := subscriber.Send(protocol.NewStreamResponseTask(task)); err != nil {
@@ -817,23 +880,64 @@ func (m *TaskManager) onResubscribeStreaming(
 	}
 
 	// The subscriber is NOT registered in the local map: the Redis stream is its
-	// only source, whose producer may be another instance. If the task went
-	// terminal between the cursor and the snapshot, its terminal frame is after
-	// the cursor, so the tailer delivers it and then closes.
+	// only source, whose producer may be another instance. Admit the tailer under
+	// cancelMu so Close cannot begin waiting before this goroutine is counted.
+	m.cancelMu.Lock()
+	if m.closed {
+		m.cancelMu.Unlock()
+		subscriber.Close()
+		return nil, jsonrpc.ErrInternalError("task manager is closed")
+	}
 	m.tailerWg.Add(1)
+	m.cancelMu.Unlock()
 	go m.tailStream(ctx, params.ID, startID, subscriber)
 
 	return subscriber.Channel(), nil
 }
 
-// streamStartID captures the current tail of a task's event stream. Returns "0"
-// (from the beginning) for an empty/absent stream.
-func (m *TaskManager) streamStartID(ctx context.Context, taskID string) string {
-	msgs, err := m.client.XRevRangeN(ctx, streamPrefix+taskID, "+", "-", 1).Result()
-	if err != nil || len(msgs) == 0 {
-		return "0"
+// streamKey shares the task key's Redis Cluster slot without changing the
+// existing task key. Redis hashes the full task key and the {...} portion of
+// the stream key, which are the same bytes for manager-generated task IDs.
+func streamKey(taskID string) string {
+	return streamPrefix + "{" + taskPrefix + taskID + "}"
+}
+
+// loadTaskAndCursor atomically loads the current Task and event-stream tail.
+func (m *TaskManager) loadTaskAndCursor(
+	ctx context.Context,
+	taskID string,
+) (*protocol.Task, string, error) {
+	values, err := loadTaskAndCursorScript.Run(
+		ctx,
+		m.client,
+		[]string{taskPrefix + taskID, streamKey(taskID)},
+	).Slice()
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to load task %s and stream cursor: %w", taskID, err)
 	}
-	return msgs[0].ID
+	if len(values) != 3 {
+		return nil, "", fmt.Errorf("failed to load task %s and stream cursor: unexpected result", taskID)
+	}
+	exists, ok := values[0].(int64)
+	if !ok {
+		return nil, "", fmt.Errorf("failed to load task %s and stream cursor: invalid existence flag", taskID)
+	}
+	if exists == 0 {
+		return nil, "", taskmanager.ErrTaskNotFound(taskID)
+	}
+	taskJSON, ok := values[1].(string)
+	if !ok {
+		return nil, "", fmt.Errorf("failed to load task %s and stream cursor: invalid task payload", taskID)
+	}
+	cursor, ok := values[2].(string)
+	if !ok || cursor == "" {
+		return nil, "", fmt.Errorf("failed to load task %s and stream cursor: invalid cursor", taskID)
+	}
+	var task protocol.Task
+	if err := json.Unmarshal([]byte(taskJSON), &task); err != nil {
+		return nil, "", fmt.Errorf("failed to deserialize task: %w", err)
+	}
+	return &task, cursor, nil
 }
 
 // tailStream feeds a resubscriber from the task's Redis event stream, reading
@@ -860,7 +964,7 @@ func (m *TaskManager) tailStream(ctx context.Context, taskID, startID string, su
 		sub.Close()
 	}()
 
-	key := streamPrefix + taskID
+	key := streamKey(taskID)
 	for {
 		// A blocking XREAD is not interrupted mid-flight by context cancellation
 		// (only Close, via the client, unblocks it), so re-check between slices:
@@ -899,7 +1003,7 @@ func (m *TaskManager) tailStream(ctx context.Context, taskID, startID string, su
 				// Terminate on a terminal STATUS frame only — an artifact's
 				// lastChunk (also IsFinal on the artifact) ends an artifact, not
 				// the task.
-				if su := event.GetStatusUpdate(); su != nil && su.IsFinal() {
+				if su := event.GetStatusUpdate(); su != nil && isFinalState(su.Status.State) {
 					return
 				}
 			}
@@ -907,33 +1011,32 @@ func (m *TaskManager) tailStream(ctx context.Context, taskID, startID string, su
 	}
 }
 
-// publishStream mirrors an already-persisted, already-locally-broadcast event
-// onto the task's Redis stream for cross-instance resubscribers. No-op unless
-// ResubscribeStreaming is enabled. It uses a background context (like storeTask)
-// so a request-scoped cancellation cannot drop the mirror after the event is
-// durable, and bounds the stream with MAXLEN + the same TTL as the task key.
-func (m *TaskManager) publishStream(taskID string, event protocol.StreamResponse) {
-	if !m.options.ResubscribeStreaming {
-		return
+// appendStreamEvent stores an event that does not modify the Task snapshot.
+// Task-changing events use storeTaskEvent so their snapshot and event share one
+// atomic commit. No-op when cross-node resubscribe is disabled.
+func (m *TaskManager) appendStreamEvent(
+	ctx context.Context,
+	taskID string,
+	event protocol.StreamResponse,
+) error {
+	if !m.options.CrossNodeResubscribe {
+		return nil
 	}
 	payload, err := json.Marshal(event)
 	if err != nil {
-		log.Errorf("RedisTaskManager: failed to marshal stream event for task %s: %v", taskID, err)
-		return
+		return fmt.Errorf("failed to marshal stream event for task %s: %w", taskID, err)
 	}
-	key := streamPrefix + taskID
-	ctx := context.Background()
-	pipe := m.client.Pipeline()
-	pipe.XAdd(ctx, &redis.XAddArgs{
-		Stream: key,
-		MaxLen: streamMaxLen,
-		Approx: true,
-		Values: map[string]interface{}{streamField: payload},
-	})
-	pipe.Expire(ctx, key, m.expiration)
-	if _, err := pipe.Exec(ctx); err != nil {
-		log.Errorf("RedisTaskManager: failed to publish stream event for task %s: %v", taskID, err)
+	if _, err := appendStreamEventScript.Run(
+		ctx,
+		m.client,
+		[]string{taskPrefix + taskID, streamKey(taskID)},
+		payload,
+		streamMaxLen,
+		streamField,
+	).Result(); err != nil {
+		return fmt.Errorf("failed to append stream event for task %s: %w", taskID, err)
 	}
+	return nil
 }
 
 // taskChanged reports whether two snapshots of the same task differ in what a
@@ -1098,6 +1201,40 @@ func (m *TaskManager) storeTask(ctx context.Context, task *protocol.Task) error 
 		return fmt.Errorf("failed to store task: %w", err)
 	}
 
+	return nil
+}
+
+// storeTaskEvent atomically persists a Task snapshot and the event that produced
+// it when cross-node resubscribe is enabled. With the feature disabled it keeps
+// the original single-key Task persistence path.
+func (m *TaskManager) storeTaskEvent(
+	ctx context.Context,
+	task *protocol.Task,
+	event protocol.StreamResponse,
+) error {
+	if !m.options.CrossNodeResubscribe {
+		return m.storeTask(ctx, task)
+	}
+	taskBytes, err := json.Marshal(task)
+	if err != nil {
+		return fmt.Errorf("failed to serialize task: %w", err)
+	}
+	eventBytes, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("failed to serialize task event: %w", err)
+	}
+	if _, err := storeTaskEventScript.Run(
+		ctx,
+		m.client,
+		[]string{taskPrefix + task.ID, streamKey(task.ID)},
+		taskBytes,
+		eventBytes,
+		streamMaxLen,
+		streamField,
+		m.expiration.Milliseconds(),
+	).Result(); err != nil {
+		return fmt.Errorf("failed to store task and event: %w", err)
+	}
 	return nil
 }
 
@@ -1271,12 +1408,6 @@ func (m *TaskManager) cleanSubscribers(taskID string) {
 
 // notifySubscribers notifies all subscribers of a task.
 func (m *TaskManager) notifySubscribers(taskID string, event protocol.StreamResponse) {
-	// Mirror onto the task's Redis stream first so a resubscriber on another
-	// instance sees the same events. This is the sole fan-out convergence point
-	// (both broadcast and cancelWithoutLiveRun reach here), so no producer path
-	// is missed. No-op unless ResubscribeStreaming is enabled.
-	m.publishStream(taskID, event)
-
 	// Deliver push notifications independently of live SSE subscribers: reaching
 	// clients that are not currently streaming is the whole point of push.
 	m.dispatchPush(taskID, event)

--- a/taskmanager/redis/redis_manager.go
+++ b/taskmanager/redis/redis_manager.go
@@ -41,6 +41,8 @@ const (
 	// Default configuration values.
 	defaultMaxHistoryLength         = 100
 	defaultTaskSubscriberBufferSize = 1024
+	taskEventReadIdleInitialDelay   = 100 * time.Millisecond
+	taskEventReadIdleMaxDelay       = time.Second
 )
 
 // appendConversationMessageScript appends a MessageID exactly once, trims the
@@ -201,9 +203,14 @@ func (m *TaskManager) OnSendMessage(
 		select {
 		case out := <-ex.immediateResult:
 			return m.buildSendResponse(out.task, out.message, historyLength)
+		case err := <-ex.runFailed:
+			return nil, err
 		case <-ex.done:
 			// The stream closed before any immediate result: same derivation as
 			// blocking.
+			if ex.runErr != nil {
+				return nil, ex.runErr
+			}
 			return m.buildSendResponse(ex.finalTask, ex.lastMessage, historyLength)
 		case <-ctx.Done():
 			return nil, ctx.Err()
@@ -211,7 +218,12 @@ func (m *TaskManager) OnSendMessage(
 	}
 
 	select {
+	case err := <-ex.runFailed:
+		return nil, err
 	case <-ex.done:
+		if ex.runErr != nil {
+			return nil, ex.runErr
+		}
 		return m.buildSendResponse(ex.finalTask, ex.lastMessage, historyLength)
 	case <-ctx.Done():
 		// The request died first. The execution is detached: it keeps running
@@ -857,6 +869,11 @@ func (m *TaskManager) tailTaskEvents(ctx context.Context, taskID, startID string
 		sub.Close()
 	}()
 
+	idleDelay := taskEventReadIdleInitialDelay
+	jitterUnit := time.Now().UnixNano() % 1000
+	for i := 0; i < len(taskID); i++ {
+		jitterUnit = (jitterUnit*33 + int64(taskID[i])) % 1000
+	}
 	for {
 		// ReadAfter implementations may use bounded blocking reads, so re-check
 		// cancellation between batches.
@@ -865,11 +882,37 @@ func (m *TaskManager) tailTaskEvents(ctx context.Context, taskID, startID string
 			return
 		default:
 		}
+		previousID := startID
 		events, nextID, err := m.eventTransport.ReadAfter(readCtx, taskID, startID)
 		if err != nil {
 			return // read context canceled, transport closed, or a storage error.
 		}
 		startID = nextID
+		// A transport may implement ReadAfter as a non-blocking poll. Exponential
+		// backoff keeps long-idle subscriptions from producing fixed-rate Redis
+		// traffic; per-tailer jitter avoids synchronized polling across replicas.
+		if len(events) == 0 && nextID == previousID {
+			jitterRange := idleDelay / 4
+			waitDelay := idleDelay
+			if jitterRange > 0 {
+				waitDelay += jitterRange * time.Duration(jitterUnit) / 1000
+			}
+			timer := time.NewTimer(waitDelay)
+			select {
+			case <-readCtx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
+			}
+			if idleDelay < taskEventReadIdleMaxDelay {
+				idleDelay *= 2
+				if idleDelay > taskEventReadIdleMaxDelay {
+					idleDelay = taskEventReadIdleMaxDelay
+				}
+			}
+			continue
+		}
+		idleDelay = taskEventReadIdleInitialDelay
 		for _, event := range events {
 			if err := sub.Send(event); err != nil {
 				return // consumer gone.
@@ -915,8 +958,9 @@ func taskChanged(before, after *protocol.Task) bool {
 // Internal helper methods
 // =============================================================================
 
-// processReplyMessage processes and stores the reply message.
-func (m *TaskManager) processReplyMessage(ctxID *string, message *protocol.Message) {
+// stampReplyMessage fills the framework-owned reply fields before the event is
+// persisted or published.
+func (m *TaskManager) stampReplyMessage(ctxID *string, message *protocol.Message) {
 	message.ContextID = ctxID
 	message.Role = protocol.MessageRoleAgent
 	if message.MessageID == "" {
@@ -926,8 +970,6 @@ func (m *TaskManager) processReplyMessage(ctxID *string, message *protocol.Messa
 		contextID := protocol.GenerateContextID()
 		message.ContextID = &contextID
 	}
-
-	m.storeMessage(context.Background(), *message)
 }
 
 // storeMessage stores a message in Redis and updates conversation history.
@@ -1074,7 +1116,17 @@ func (m *TaskManager) commitTaskEvent(
 	if m.eventTransport == nil {
 		return m.storeTask(ctx, task)
 	}
-	return m.eventTransport.CommitTaskEvent(ctx, task, event)
+	if err := m.eventTransport.CommitTaskEvent(ctx, task, event); err != nil {
+		return err
+	}
+	// Keep the latest v2 storeTask behavior: every Task write refreshes its push
+	// registrations. This key cannot join the atomic script because the existing
+	// push key is in a different Redis Cluster slot; failure here must not turn an
+	// already-committed Task/event pair into a false negative result.
+	if err := m.client.Expire(ctx, pushNotificationPrefix+task.ID, m.expiration).Err(); err != nil {
+		log.Warnf("RedisTaskManager: failed to refresh push config expiration for task %s: %v", task.ID, err)
+	}
+	return nil
 }
 
 // isFinalState checks if a TaskState represents a terminal state.
@@ -1385,10 +1437,9 @@ func (m *TaskManager) Close() error {
 		// CANCELED) must land while the Redis client is still usable.
 		m.engineWg.Wait()
 
-		// Stop cross-node resubscribe tailers. A blocking XREAD is not aborted by
-		// context alone, so closing the client is what unparks it; baseCancel
-		// stops any tailer between slices from re-reading. Join after, so no
-		// tailer goroutine outlives Close.
+		// Stop cross-node resubscribe tailers. baseCancel ends readers between
+		// polls; closing the client below also releases an in-flight Redis command.
+		// Join after that close so no tailer goroutine outlives the manager.
 		m.baseCancel()
 		m.closeErr = m.client.Close()
 		m.tailerWg.Wait()

--- a/taskmanager/redis/redis_manager.go
+++ b/taskmanager/redis/redis_manager.go
@@ -21,6 +21,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/internal/jsonrpc"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/internal/pushdispatch"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/internal/taskevent"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/log"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/push"
@@ -33,18 +34,6 @@ const (
 	conversationPrefix     = "conv:"
 	taskPrefix             = "task:"
 	pushNotificationPrefix = "push:"
-	// streamPrefix keys the per-task event stream used for cross-node resubscribe.
-	// streamKey adds the task key as a Redis Cluster hash tag so the task and
-	// stream can be read or written atomically by one script.
-	streamPrefix = "stream:"
-	// streamField is the single XADD field carrying the JSON-encoded StreamResponse.
-	streamField = "e"
-	// streamMaxLen caps each task's event stream (XADD MAXLEN ~).
-	streamMaxLen = 10000
-	// streamReadCount caps entries returned per XREAD.
-	streamReadCount = 64
-	// streamBlockTimeout bounds one XREAD BLOCK slice so tailers re-check context.
-	streamBlockTimeout = 5 * time.Second
 
 	// Default expiration time for Redis keys (1 hour).
 	defaultExpiration = 1 * time.Hour
@@ -71,63 +60,6 @@ redis.call('PEXPIRE', KEYS[1], ARGV[2])
 return 1
 `)
 
-// storeTaskEventScript atomically persists a task snapshot and its event. The
-// stream type is checked before either write because Redis scripts are atomic
-// with respect to other clients but do not roll back commands after a runtime
-// error. The task and stream keys share one Redis Cluster slot (see streamKey).
-var storeTaskEventScript = redis.NewScript(`
-local stream_type = redis.call('TYPE', KEYS[2]).ok
-if stream_type ~= 'none' and stream_type ~= 'stream' then
-    return redis.error_reply('task event stream has wrong type')
-end
-local event_id = redis.call(
-    'XADD', KEYS[2], 'MAXLEN', '~', ARGV[3], '*', ARGV[4], ARGV[2]
-)
-redis.call('SET', KEYS[1], ARGV[1], 'PX', ARGV[5])
-redis.call('PEXPIRE', KEYS[2], ARGV[5])
-return event_id
-`)
-
-// appendStreamEventScript persists an event that does not change the Task
-// snapshot (for example, a Message emitted after the Task exists). Its TTL is
-// capped to the Task's remaining TTL so an event-only write cannot leave an
-// orphan stream after the Task expires.
-var appendStreamEventScript = redis.NewScript(`
-local task_ttl = redis.call('PTTL', KEYS[1])
-if task_ttl == -2 then
-    return redis.error_reply('task does not exist')
-end
-local stream_type = redis.call('TYPE', KEYS[2]).ok
-if stream_type ~= 'none' and stream_type ~= 'stream' then
-    return redis.error_reply('task event stream has wrong type')
-end
-local event_id = redis.call(
-    'XADD', KEYS[2], 'MAXLEN', '~', ARGV[2], '*', ARGV[3], ARGV[1]
-)
-if task_ttl == -1 then
-    redis.call('PERSIST', KEYS[2])
-else
-    redis.call('PEXPIRE', KEYS[2], math.max(1, task_ttl))
-end
-return event_id
-`)
-
-// loadTaskAndCursorScript returns a Task snapshot and the stream tail from one
-// Redis linearization point. A concurrent storeTaskEventScript therefore lands
-// wholly before the snapshot/cursor pair or wholly after it.
-var loadTaskAndCursorScript = redis.NewScript(`
-local task = redis.call('GET', KEYS[1])
-if not task then
-    return {0, '', '0-0'}
-end
-local tail = redis.call('XREVRANGE', KEYS[2], '+', '-', 'COUNT', 1)
-local cursor = '0-0'
-if #tail > 0 then
-    cursor = tail[1][1]
-end
-return {1, task, cursor}
-`)
-
 // TaskManager provides a concrete, Redis-based implementation of the
 // TaskManager interface. It persists messages, conversations, and tasks in
 // Redis and delegates the agent logic to an injected Processor: the MessageProcessor
@@ -141,6 +73,9 @@ type TaskManager struct {
 	client redis.UniversalClient
 	// expiration is the time after which Redis keys expire.
 	expiration time.Duration
+	// eventTransport distributes task events between manager instances. It is
+	// nil when cross-node resubscribe is disabled.
+	eventTransport taskevent.Transport
 
 	// subMu is a mutex for the subscribers map.
 	subMu sync.RWMutex
@@ -173,7 +108,7 @@ type TaskManager struct {
 
 	// tailerWg counts cross-node resubscribe tailer goroutines so Close joins
 	// them before closing the Redis client. baseCtx is canceled by Close to
-	// unpark a tailer parked in a blocking XREAD.
+	// unpark a tailer parked in a blocking transport read.
 	tailerWg   sync.WaitGroup
 	baseCtx    context.Context
 	baseCancel context.CancelFunc
@@ -225,6 +160,9 @@ func NewTaskManager(
 		executions:  make(map[string]*liveExecution),
 		pushEnabled: options.Push.Sender != nil || options.Push.ManualDelivery,
 		options:     options,
+	}
+	if options.CrossNodeResubscribe {
+		manager.eventTransport = newRedisTaskEventTransport(client, expiration)
 	}
 	manager.pushCtx, manager.pushCancel = context.WithCancel(context.Background())
 	if options.Push.Sender != nil && !options.Push.ManualDelivery {
@@ -481,7 +419,7 @@ func (m *TaskManager) cancelWithoutLiveRun(
 	response := protocol.NewStreamResponseStatusUpdate(event)
 	// Persist with a background context (like every engine write): the CANCELED
 	// state must land even if the cancel request's own context is already done.
-	if err := m.storeTaskEvent(context.Background(), task, response); err != nil {
+	if err := m.commitTaskEvent(context.Background(), task, response); err != nil {
 		log.Errorf("Error storing cancelled task %s: %v", params.ID, err)
 		return nil, err
 	}
@@ -777,7 +715,7 @@ func (m *TaskManager) OnResubscribe(
 	ctx context.Context,
 	params protocol.TaskIDParams,
 ) (<-chan protocol.StreamResponse, error) {
-	if m.options.CrossNodeResubscribe {
+	if m.eventTransport != nil {
 		return m.onCrossNodeResubscribe(ctx, params)
 	}
 	// The snapshot read happens OUTSIDE subMu: getTaskInternal is a network
@@ -850,15 +788,15 @@ func (m *TaskManager) OnResubscribe(
 
 // onCrossNodeResubscribe is the cross-node resubscribe path (opt-in via
 // WithCrossNodeResubscribe). The first frame is the current snapshot; a tailer
-// then reads events committed after the snapshot's atomic stream cursor.
+// then reads events committed after the snapshot's atomic event cursor.
 func (m *TaskManager) onCrossNodeResubscribe(
 	ctx context.Context,
 	params protocol.TaskIDParams,
 ) (<-chan protocol.StreamResponse, error) {
-	// The Task and stream tail are read by one Redis script. A concurrent event
-	// commit is therefore either reflected by both values or by neither: the
-	// snapshot and subsequent XREAD contain no gap and no overlapping task event.
-	task, startID, err := m.loadTaskAndCursor(ctx, params.ID)
+	// The transport loads the Task and event cursor at one atomic boundary. A
+	// concurrent task-event commit is therefore either reflected by both values
+	// or by neither: the snapshot and subsequent read contain no gap or overlap.
+	task, startID, err := m.eventTransport.LoadTaskAndCursor(ctx, params.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -879,9 +817,9 @@ func (m *TaskManager) onCrossNodeResubscribe(
 		return nil, err
 	}
 
-	// The subscriber is NOT registered in the local map: the Redis stream is its
-	// only source, whose producer may be another instance. Admit the tailer under
-	// cancelMu so Close cannot begin waiting before this goroutine is counted.
+	// The subscriber is NOT registered in the local map: the event transport is
+	// its only source, whose producer may be another instance. Admit the tailer
+	// under cancelMu so Close cannot wait before this goroutine is counted.
 	m.cancelMu.Lock()
 	if m.closed {
 		m.cancelMu.Unlock()
@@ -890,65 +828,20 @@ func (m *TaskManager) onCrossNodeResubscribe(
 	}
 	m.tailerWg.Add(1)
 	m.cancelMu.Unlock()
-	go m.tailStream(ctx, params.ID, startID, subscriber)
+	go m.tailTaskEvents(ctx, params.ID, startID, subscriber)
 
 	return subscriber.Channel(), nil
 }
 
-// streamKey shares the task key's Redis Cluster slot without changing the
-// existing task key. Redis hashes the full task key and the {...} portion of
-// the stream key, which are the same bytes for manager-generated task IDs.
-func streamKey(taskID string) string {
-	return streamPrefix + "{" + taskPrefix + taskID + "}"
-}
-
-// loadTaskAndCursor atomically loads the current Task and event-stream tail.
-func (m *TaskManager) loadTaskAndCursor(
-	ctx context.Context,
-	taskID string,
-) (*protocol.Task, string, error) {
-	values, err := loadTaskAndCursorScript.Run(
-		ctx,
-		m.client,
-		[]string{taskPrefix + taskID, streamKey(taskID)},
-	).Slice()
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to load task %s and stream cursor: %w", taskID, err)
-	}
-	if len(values) != 3 {
-		return nil, "", fmt.Errorf("failed to load task %s and stream cursor: unexpected result", taskID)
-	}
-	exists, ok := values[0].(int64)
-	if !ok {
-		return nil, "", fmt.Errorf("failed to load task %s and stream cursor: invalid existence flag", taskID)
-	}
-	if exists == 0 {
-		return nil, "", taskmanager.ErrTaskNotFound(taskID)
-	}
-	taskJSON, ok := values[1].(string)
-	if !ok {
-		return nil, "", fmt.Errorf("failed to load task %s and stream cursor: invalid task payload", taskID)
-	}
-	cursor, ok := values[2].(string)
-	if !ok || cursor == "" {
-		return nil, "", fmt.Errorf("failed to load task %s and stream cursor: invalid cursor", taskID)
-	}
-	var task protocol.Task
-	if err := json.Unmarshal([]byte(taskJSON), &task); err != nil {
-		return nil, "", fmt.Errorf("failed to deserialize task: %w", err)
-	}
-	return &task, cursor, nil
-}
-
-// tailStream feeds a resubscriber from the task's Redis event stream, reading
-// strictly after startID. It closes the subscriber and returns on the terminal
-// status frame, when the request ends, or when the manager closes.
-func (m *TaskManager) tailStream(ctx context.Context, taskID, startID string, sub *taskSubscriber) {
+// tailTaskEvents feeds a resubscriber from the configured event transport,
+// reading strictly after startID. It closes the subscriber and returns on the
+// terminal status frame, when the request ends, or when the manager closes.
+func (m *TaskManager) tailTaskEvents(ctx context.Context, taskID, startID string, sub *taskSubscriber) {
 	defer m.tailerWg.Done()
 	defer sub.Close()
 
-	// Cancel the blocking XREAD, and unblock a parked blocking-send via Close,
-	// when the request ends or the manager closes.
+	// Cancel a blocking transport read, and unblock a parked blocking-send via
+	// Close, when the request ends or the manager closes.
 	readCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	tailerDone := make(chan struct{})
@@ -964,79 +857,45 @@ func (m *TaskManager) tailStream(ctx context.Context, taskID, startID string, su
 		sub.Close()
 	}()
 
-	key := streamKey(taskID)
 	for {
-		// A blocking XREAD is not interrupted mid-flight by context cancellation
-		// (only Close, via the client, unblocks it), so re-check between slices:
-		// on client disconnect this bounds teardown to one streamBlockTimeout.
+		// ReadAfter implementations may use bounded blocking reads, so re-check
+		// cancellation between batches.
 		select {
 		case <-readCtx.Done():
 			return
 		default:
 		}
-		res, err := m.client.XRead(readCtx, &redis.XReadArgs{
-			Streams: []string{key, startID},
-			Block:   streamBlockTimeout,
-			Count:   streamReadCount,
-		}).Result()
-		if errors.Is(err, redis.Nil) {
-			continue // BLOCK slice timed out with nothing new.
-		}
+		events, nextID, err := m.eventTransport.ReadAfter(readCtx, taskID, startID)
 		if err != nil {
-			return // readCtx canceled, client closed, or a Redis error.
+			return // read context canceled, transport closed, or a storage error.
 		}
-		for _, stream := range res {
-			for _, entry := range stream.Messages {
-				startID = entry.ID
-				raw, ok := entry.Values[streamField].(string)
-				if !ok {
-					continue
-				}
-				var event protocol.StreamResponse
-				if err := json.Unmarshal([]byte(raw), &event); err != nil {
-					log.Warnf("RedisTaskManager: discarding malformed stream entry for task %s: %v", taskID, err)
-					continue
-				}
-				if err := sub.Send(event); err != nil {
-					return // consumer gone.
-				}
-				// Terminate on a terminal STATUS frame only — an artifact's
-				// lastChunk (also IsFinal on the artifact) ends an artifact, not
-				// the task.
-				if su := event.GetStatusUpdate(); su != nil && isFinalState(su.Status.State) {
-					return
-				}
+		startID = nextID
+		for _, event := range events {
+			if err := sub.Send(event); err != nil {
+				return // consumer gone.
+			}
+			// Terminate on a terminal STATUS frame only — an artifact's
+			// lastChunk (also IsFinal on the artifact) ends an artifact, not
+			// the task.
+			if su := event.GetStatusUpdate(); su != nil && isFinalState(su.Status.State) {
+				return
 			}
 		}
 	}
 }
 
-// appendStreamEvent stores an event that does not modify the Task snapshot.
-// Task-changing events use storeTaskEvent so their snapshot and event share one
-// atomic commit. No-op when cross-node resubscribe is disabled.
-func (m *TaskManager) appendStreamEvent(
+// appendTaskEvent distributes an event that does not modify the Task snapshot.
+// Task-changing events use commitTaskEvent so their snapshot and event share
+// one atomic commit. It is a no-op when no event transport is configured.
+func (m *TaskManager) appendTaskEvent(
 	ctx context.Context,
 	taskID string,
 	event protocol.StreamResponse,
 ) error {
-	if !m.options.CrossNodeResubscribe {
+	if m.eventTransport == nil {
 		return nil
 	}
-	payload, err := json.Marshal(event)
-	if err != nil {
-		return fmt.Errorf("failed to marshal stream event for task %s: %w", taskID, err)
-	}
-	if _, err := appendStreamEventScript.Run(
-		ctx,
-		m.client,
-		[]string{taskPrefix + taskID, streamKey(taskID)},
-		payload,
-		streamMaxLen,
-		streamField,
-	).Result(); err != nil {
-		return fmt.Errorf("failed to append stream event for task %s: %w", taskID, err)
-	}
-	return nil
+	return m.eventTransport.AppendEvent(ctx, taskID, event)
 }
 
 // taskChanged reports whether two snapshots of the same task differ in what a
@@ -1204,38 +1063,18 @@ func (m *TaskManager) storeTask(ctx context.Context, task *protocol.Task) error 
 	return nil
 }
 
-// storeTaskEvent atomically persists a Task snapshot and the event that produced
-// it when cross-node resubscribe is enabled. With the feature disabled it keeps
+// commitTaskEvent atomically persists a Task snapshot and distributes the event
+// that produced it when an event transport is configured. Without one it keeps
 // the original single-key Task persistence path.
-func (m *TaskManager) storeTaskEvent(
+func (m *TaskManager) commitTaskEvent(
 	ctx context.Context,
 	task *protocol.Task,
 	event protocol.StreamResponse,
 ) error {
-	if !m.options.CrossNodeResubscribe {
+	if m.eventTransport == nil {
 		return m.storeTask(ctx, task)
 	}
-	taskBytes, err := json.Marshal(task)
-	if err != nil {
-		return fmt.Errorf("failed to serialize task: %w", err)
-	}
-	eventBytes, err := json.Marshal(event)
-	if err != nil {
-		return fmt.Errorf("failed to serialize task event: %w", err)
-	}
-	if _, err := storeTaskEventScript.Run(
-		ctx,
-		m.client,
-		[]string{taskPrefix + task.ID, streamKey(task.ID)},
-		taskBytes,
-		eventBytes,
-		streamMaxLen,
-		streamField,
-		m.expiration.Milliseconds(),
-	).Result(); err != nil {
-		return fmt.Errorf("failed to store task and event: %w", err)
-	}
-	return nil
+	return m.eventTransport.CommitTaskEvent(ctx, task, event)
 }
 
 // isFinalState checks if a TaskState represents a terminal state.

--- a/taskmanager/redis/redis_options.go
+++ b/taskmanager/redis/redis_options.go
@@ -24,7 +24,9 @@ type TaskManagerOptions struct {
 	// TaskSubscriberBufSize is the buffer size for task subscriber channels.
 	TaskSubscriberBufSize int
 
-	// TaskSubscriberBlockingSend enables blocking send for task subscribers.
+	// TaskSubscriberBlockingSend enables blocking send for local task subscribers
+	// and request pipes. Cross-node resubscribe tailers always use blocking send:
+	// their Redis reader can wait without blocking a task producer.
 	TaskSubscriberBlockingSend bool
 
 	// Push configures push-notification delivery (see push.Config). Push is
@@ -32,13 +34,14 @@ type TaskManagerOptions struct {
 	// application-owned delivery.
 	Push push.Config
 
-	// ResubscribeStreaming, when true, mirrors each task's events onto a per-task
+	// CrossNodeResubscribe, when true, mirrors each task's events onto a per-task
 	// Redis stream and serves OnResubscribe by tailing that stream. This makes
-	// tasks/resubscribe work across instances (a reconnect landing on a different
+	// SubscribeToTask work across instances (a reconnect landing on a different
 	// node than the one running the task), at the cost of one XADD per event.
+	// Each task stream retains approximately the latest 10,000 events.
 	// When false (default) resubscribe is served from the in-process subscriber
 	// map only — correct for single-instance deployments.
-	ResubscribeStreaming bool
+	CrossNodeResubscribe bool
 }
 
 // DefaultRedisTaskManagerOptions returns the default configuration options.
@@ -81,7 +84,8 @@ func WithTaskSubscriberBufferSize(size int) TaskManagerOption {
 	}
 }
 
-// WithTaskSubscriberBlockingSend sets the blocking send flag for the task subscriber
+// WithTaskSubscriberBlockingSend sets blocking send for local task subscribers
+// and request pipes. Cross-node resubscribe tailers always block independently.
 func WithTaskSubscriberBlockingSend(blockingSend bool) TaskManagerOption {
 	return func(opts *TaskManagerOptions) {
 		opts.TaskSubscriberBlockingSend = blockingSend
@@ -99,12 +103,14 @@ func WithPushNotifications(cfg push.Config) TaskManagerOption {
 	}
 }
 
-// WithResubscribeStreaming enables cross-instance tasks/resubscribe by mirroring
-// each task's events onto a per-task Redis stream. Enable it when multiple server
-// instances share one Redis and a resubscribe may land on a different instance
-// than the one running the task.
-func WithResubscribeStreaming(enabled bool) TaskManagerOption {
+// WithCrossNodeResubscribe enables cross-instance SubscribeToTask by mirroring
+// each task's events onto a per-task Redis stream. Enable it on every replica
+// sharing Redis when a resubscribe may land on a different instance than the one
+// running the task. It does not distribute execution, continuation, or cancel
+// requests between replicas. Each task stream retains approximately the latest
+// 10,000 events.
+func WithCrossNodeResubscribe(enabled bool) TaskManagerOption {
 	return func(opts *TaskManagerOptions) {
-		opts.ResubscribeStreaming = enabled
+		opts.CrossNodeResubscribe = enabled
 	}
 }

--- a/taskmanager/redis/redis_options.go
+++ b/taskmanager/redis/redis_options.go
@@ -31,6 +31,14 @@ type TaskManagerOptions struct {
 	// enabled by either a Sender for automatic delivery or ManualDelivery for
 	// application-owned delivery.
 	Push push.Config
+
+	// ResubscribeStreaming, when true, mirrors each task's events onto a per-task
+	// Redis stream and serves OnResubscribe by tailing that stream. This makes
+	// tasks/resubscribe work across instances (a reconnect landing on a different
+	// node than the one running the task), at the cost of one XADD per event.
+	// When false (default) resubscribe is served from the in-process subscriber
+	// map only — correct for single-instance deployments.
+	ResubscribeStreaming bool
 }
 
 // DefaultRedisTaskManagerOptions returns the default configuration options.
@@ -88,5 +96,15 @@ func WithTaskSubscriberBlockingSend(blockingSend bool) TaskManagerOption {
 func WithPushNotifications(cfg push.Config) TaskManagerOption {
 	return func(opts *TaskManagerOptions) {
 		opts.Push = cfg
+	}
+}
+
+// WithResubscribeStreaming enables cross-instance tasks/resubscribe by mirroring
+// each task's events onto a per-task Redis stream. Enable it when multiple server
+// instances share one Redis and a resubscribe may land on a different instance
+// than the one running the task.
+func WithResubscribeStreaming(enabled bool) TaskManagerOption {
+	return func(opts *TaskManagerOptions) {
+		opts.ResubscribeStreaming = enabled
 	}
 }

--- a/taskmanager/redis/redis_types.go
+++ b/taskmanager/redis/redis_types.go
@@ -18,8 +18,8 @@ import (
 // taskSubscriber is an in-process event channel attached to a task. It is
 // internal machinery: the MessageProcessor contract exposes only event channels, so
 // subscribers are created by the manager for resubscribe and for the
-// message/stream request pipe. Cross-replica streaming is out of scope; the
-// subscriber map lives in this process only.
+// message/stream request pipe. Cross-node resubscribe tailers also feed one of
+// these local channels; the subscriber itself has no distributed semantics.
 type taskSubscriber struct {
 	taskID     string
 	eventQueue chan protocol.StreamResponse


### PR DESCRIPTION
## Summary

Make Redis-backed `SubscribeToTask` work when a reconnect lands on a different server replica from the one executing the task.

The feature is opt-in through `redis.WithCrossNodeResubscribe(true)`. When enabled on every replica sharing Redis, task events are retained in a per-task Redis Stream and a resubscriber receives the current Task snapshot followed by later events from that stream. Single-instance behavior remains unchanged by default.

This PR addresses the observation path only. It does not distribute task execution, continuation, or live-cancel requests, and it does not introduce a work queue or a public event-transport interface.

## Design

### Consistent snapshot and event boundary

Task-changing events (status, artifact, and no-live-run cancel) are committed with the Task snapshot by one private Redis Lua script. Resubscribe loads the Task snapshot and current stream tail with another private Lua script.

The two scripts provide one Redis linearization point:

- if the writer completes first, the snapshot includes the update and the cursor is after its event;
- if the reader completes first, the snapshot excludes the update and the tailer reads its event;
- cursor/storage errors are returned instead of being treated as an empty stream.

The existing Task key remains `task:<taskID>`. The stream key is `stream:{task:<taskID>}`, placing both keys in the same Redis Cluster slot without migrating Task keys.

Message events do not rewrite the Task snapshot. They use a separate private append script and are exposed to the RPC and local subscribers only after the stream append succeeds. The stream TTL follows the Task's remaining TTL; configured expirations below one millisecond are clamped to one millisecond.

### Resubscribe lifecycle

- The current Task snapshot is always the first frame.
- The Redis tailer reads strictly after the atomic snapshot cursor.
- `input-required` and `auth-required` end an execution round but keep the Task subscription open; only completed, failed, canceled, and rejected states close it.
- Cross-node tailers use cancelable blocking backpressure, so a temporarily slow client is not converted into a silent EOF.
- Tailer admission and manager shutdown share the lifecycle lock, preventing a goroutine from being added after `Close` has started waiting.
- Each per-task stream retains approximately the latest 10,000 events. Clients lagging beyond that bounded window may miss intermediate events.

## Usage

```go
tm, err := redis.NewTaskManager(
    processor,
    client,
    redis.WithCrossNodeResubscribe(true),
)
```

Enable the option on every producer and subscriber replica sharing Redis. Leaving it disabled keeps the existing in-process subscriber path and creates no stream keys.

## Testing

Added cross-node and failure-path coverage for:

- node B resubscribing to a Task executing on node A;
- snapshot/cursor boundaries with no duplicate artifact append and no event gap;
- terminal events committed immediately after resubscribe;
- no-live-run cancellation;
- `input-required` followed by a later terminal continuation;
- slow consumers with a size-one output buffer;
- malformed stream keys and atomic Task/event failure behavior;
- Message append failure not being exposed as success;
- sub-millisecond TTL handling;
- client disconnect and `Close`/tailer admission races;
- the disabled path creating no Redis Stream keys.

Validation completed:

- root module: `go test -race ./...`, `go vet ./...`;
- Redis module: `go test -race ./...`, `go vet ./...`;
- new-issue `golangci-lint` for both modules;
- `typos` and `git diff --check`;
- cross-node race tests repeated 20 times.

## Documentation

Updated the English and Chinese README, migration, overview, and server documentation, plus the Redis example and changelog. The docs explicitly distinguish cross-node `SubscribeToTask` from distributed execution coordination.
