### PR TITLE
taskmanager: allow status-event metadata via TaskHandle.UpdateTaskState

### DIFF
--- a/taskmanager/handle.go
+++ b/taskmanager/handle.go
@@ -155,15 +155,39 @@ func (h *TaskHandle) emit(event protocol.StreamEvent) error {
 	}
 }
 
+// UpdateOption configures a status event emitted by UpdateTaskState.
+type UpdateOption func(*updateOptions)
+
+// updateOptions holds the optional fields UpdateTaskState may set on the event.
+type updateOptions struct {
+	metadata map[string]any
+}
+
+// WithStatusMetadata attaches metadata to the emitted TaskStatusUpdateEvent.
+// The A2A TaskStatus itself carries no metadata field (only state/message/
+// timestamp), so status-level metadata belongs on the event; this is the
+// supported way to set it without hand-building the event on the raw channel.
+func WithStatusMetadata(metadata map[string]any) UpdateOption {
+	return func(o *updateOptions) { o.metadata = metadata }
+}
+
 // UpdateTaskState emits a status event for this round's task
 // (former TaskHandler.UpdateTaskState; no taskID argument — one round drives
 // exactly its own task, and the framework stamps the IDs). The state drives
 // the round's lifecycle: completed/failed/canceled/rejected are terminal, and
 // input-required/auth-required suspend the task awaiting a follow-up message
 // (the framework calls ProcessMessage again with ExecContext.Task set).
-func (h *TaskHandle) UpdateTaskState(state protocol.TaskState, message *protocol.Message) error {
+//
+// Options attach event-level fields such as metadata (see WithStatusMetadata);
+// callers that need none pass no options.
+func (h *TaskHandle) UpdateTaskState(state protocol.TaskState, message *protocol.Message, opts ...UpdateOption) error {
+	var o updateOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
 	return h.emit(&protocol.TaskStatusUpdateEvent{
-		Status: protocol.TaskStatus{State: state, Message: message},
+		Status:   protocol.TaskStatus{State: state, Message: message},
+		Metadata: o.metadata,
 	})
 }
 

--- a/taskmanager/handle_test.go
+++ b/taskmanager/handle_test.go
@@ -179,3 +179,40 @@ func TestTaskHandle_EmitSucceedsAfterCancel(t *testing.T) {
 		t.Fatalf("buffered live emit after cancel must succeed, got %v", err)
 	}
 }
+
+// WithStatusMetadata attaches metadata to the emitted status event; omitting it
+// leaves the event's metadata nil (backward compatible).
+func TestTaskHandle_UpdateTaskStateMetadata(t *testing.T) {
+	h := NewTaskHandle(context.Background(), &ExecContext{TaskID: "task-1"})
+	md := map[string]any{"progress": 0.5, "stage": "retrieval"}
+	if err := h.UpdateTaskState(protocol.TaskStateWorking, nil, WithStatusMetadata(md)); err != nil {
+		t.Fatalf("emit failed: %v", err)
+	}
+	if err := h.UpdateTaskState(protocol.TaskStateCompleted, nil); err != nil {
+		t.Fatalf("emit failed: %v", err)
+	}
+	events := h.Events()
+	h.Close()
+
+	var withMD, withoutMD *protocol.TaskStatusUpdateEvent
+	for event := range events {
+		su, ok := event.(*protocol.TaskStatusUpdateEvent)
+		if !ok {
+			continue
+		}
+		if su.Status.State == protocol.TaskStateWorking {
+			withMD = su
+		} else {
+			withoutMD = su
+		}
+	}
+	if withMD == nil || withoutMD == nil {
+		t.Fatalf("expected both status events, got %v / %v", withMD, withoutMD)
+	}
+	if withMD.Metadata["progress"] != 0.5 || withMD.Metadata["stage"] != "retrieval" {
+		t.Errorf("status event metadata = %v, want %v", withMD.Metadata, md)
+	}
+	if withoutMD.Metadata != nil {
+		t.Errorf("expected nil metadata without the option, got %v", withoutMD.Metadata)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #98. `TaskStatusUpdateEvent` carries a `Metadata` field, but `TaskHandle.UpdateTaskState(state, message)` never set it and offered no parameter to, so the only way to attach status-level metadata was to hand-build the event on the raw channel. This adds a variadic option.

```go
handle.UpdateTaskState(protocol.TaskStateWorking, msg,
    taskmanager.WithStatusMetadata(map[string]any{"progress": 0.5}))
```

## Design

- `UpdateTaskState(state, message, opts ...UpdateOption)` — variadic, so every existing two-argument call is unaffected.
- `WithStatusMetadata(md)` sets the emitted `TaskStatusUpdateEvent.Metadata`. The engines already forward the event unchanged (`NewStreamResponseStatusUpdate(event)`), so **no engine change is needed** and it works for both the in-memory and Redis managers.
- Metadata stays on the event, not on `TaskStatus` — matching the A2A spec, where `TaskStatus` carries only `state`/`message`/`timestamp` and status-level metadata belongs on the event.

## Testing

`go test -race ./taskmanager/...` green. New `TestTaskHandle_UpdateTaskStateMetadata` asserts the option lands on the emitted event and that omitting it leaves `Metadata` nil (backward compatible).

## Scope

`taskmanager/handle.go` (+ its test) only. No change to the `TaskManager` interface, the engines, the server, or examples. Independent of #125 and #126.
