### PR TITLE
docs: document runtime architecture and Redis resubscribe flow

### DIFF
--- a/docs/mkdocs/en/overview.md
+++ b/docs/mkdocs/en/overview.md
@@ -29,32 +29,57 @@ the runtime contract see [Server](server.md) and [Client](client.md).
 
 ## Architecture
 
-```mermaid
-flowchart TB
-    subgraph clients["Clients"]
-        C1["A2A client v1.0"]
-        C2["legacy v0.2.x client"]
-    end
-    subgraph server["server"]
-        direction TB
-        AUTH["auth chain"]
-        RPC["JSON-RPC + SSE dispatch"]
-        CARD["agent cards / discovery"]
-        COMPAT["compat/v0 handler"]
-    end
-    TM["TaskManager<br/>memory or redis"]
-    MP["MessageProcessor<br/>your agent"]
+The diagram below shows the production Redis path. The same server,
+`TaskManager`, and `MessageProcessor` boundaries apply to other storage
+implementations; Redis adds shared state and the optional cross-node event
+transport.
 
-    C1 --> AUTH
-    C2 --> AUTH
-    AUTH --> RPC
-    RPC --> TM
-    COMPAT -.-> TM
-    TM --> MP
-    MP -- "event stream" --> TM
+```mermaid
+flowchart LR
+    subgraph CALLERS["Callers"]
+        APP["A2A application / orchestrator"]
+        LEGACY["legacy v0.2.x caller"]
+    end
+
+    subgraph ADAPTERS["Wire adapters"]
+        CLIENT["client<br/>JSON-RPC / SSE"]
+        SERVER["server<br/>agent card · auth · method dispatch"]
+        COMPAT["compat/v0<br/>v0 wire ↔ v1 types"]
+    end
+
+    subgraph RUNTIME["Task runtime"]
+        PORT["taskmanager.TaskManager<br/>framework port"]
+        RT["redis.TaskManager<br/>round engine · lifecycle · persistence · fan-out"]
+        MP["MessageProcessor<br/>your agent"]
+    end
+
+    subgraph STATE["Shared Redis state and distribution"]
+        STORE[("Task · message · conversation · push config")]
+        TRANSPORT["internal task-event transport"]
+        STREAMS[("per-task Redis Streams")]
+    end
+
+    subgraph DELIVERY["Delivery"]
+        UNARY["JSON-RPC result"]
+        SSE["SSE / SubscribeToTask"]
+        PUSH["push.Sender → webhook"]
+    end
+
+    APP --> CLIENT --> SERVER
+    LEGACY --> SERVER
+    SERVER -->|"v1 methods"| PORT
+    SERVER -->|"v0 methods"| COMPAT --> PORT
+    PORT --> RT
+    RT <-->|"ExecContext / ordered StreamEvent"| MP
+    RT <-->|"Task state"| STORE
+    RT <-->|"commit / read"| TRANSPORT
+    TRANSPORT <--> STREAMS
+    RT --> UNARY
+    RT --> SSE
+    RT --> PUSH
 ```
 
-Three layers, three responsibilities:
+Core responsibility boundaries:
 
 - **`server`** terminates the wire. It authenticates the request, serves agent
   cards for discovery, dispatches JSON-RPC methods and SSE streams, and —
@@ -76,16 +101,31 @@ Every request — unary or streaming — flows through the same pipeline:
 sequenceDiagram
     participant Client
     participant Server as server (auth, dispatch)
-    participant TM as TaskManager
+    participant TM as TaskManager / round engine
+    participant Registry as local execution registry
     participant P as MessageProcessor
+    participant Store as task + conversation store
 
     Client->>Server: SendMessage / SendStreamingMessage
     Server->>Server: authenticate, resolve tenant + agent card
     Server->>TM: OnSendMessage / OnSendMessageStream
-    TM->>P: ProcessMessage(ctx, ec)
-    P-->>TM: <-chan events (working, artifact, completed…)
-    Note over TM: persist each event before broadcast,<br/>create the task lazily on the first task event,<br/>apply the round close rules
-    TM-->>Server: final task snapshot (unary) OR live event stream
+    TM->>Registry: acquire this task's local execution slot
+    TM->>Store: load continuation, persist incoming message
+    TM->>P: ProcessMessage(detachedCtx, ExecContext)
+    P-->>TM: <-chan events (message, status, artifact)
+    loop each event
+        TM->>TM: validate and materialize the Task snapshot
+        TM->>Store: persist before exposure
+        Store-->>TM: committed
+        TM-->>Server: committed StreamResponse when streaming
+    end
+    TM->>TM: apply terminal, suspend, violation, or close rules
+    TM->>Registry: release the execution slot
+    alt SendMessage
+        TM-->>Server: derived Task / Message result
+    else SendStreamingMessage
+        TM-->>Server: close the committed event stream
+    end
     Server-->>Client: JSON-RPC result / SSE frames
 ```
 

--- a/docs/mkdocs/en/server.md
+++ b/docs/mkdocs/en/server.md
@@ -244,6 +244,32 @@ It does not route continuation, live-cancel, or execution requests between
 nodes. Each task stream retains approximately the latest 10,000 events; clients
 that lag beyond that bound may miss intermediate events.
 
+```mermaid
+sequenceDiagram
+    participant A as Node A round engine
+    participant Redis as shared Redis
+    participant B as Node B TaskManager
+    participant Client
+
+    A->>Redis: atomically store Task snapshot + append its event
+    Client->>B: SubscribeToTask(taskId)
+    B->>Redis: atomically load Task snapshot + stream tail cursor
+    Redis-->>B: one consistent cut
+    B-->>Client: current Task snapshot (first frame)
+
+    loop events committed after the cursor
+        B->>Redis: read after cursor
+        Redis-->>B: ordered StreamResponse batch
+        B-->>Client: SSE frames
+    end
+```
+
+For task-changing events, the snapshot contains the materialized Task state at
+the cut; no event frame at or before the cursor is replayed. In particular,
+existing artifact chunks are already materialized in `Task.Artifacts`. The
+stream sends only later events, and the atomic write and read boundaries prevent
+an update from falling between the initial snapshot and the subsequent tail.
+
 → [examples/redis](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples/redis).
 Implement the `taskmanager.TaskManager` interface for a custom backend.
 

--- a/docs/mkdocs/zh/overview.md
+++ b/docs/mkdocs/zh/overview.md
@@ -34,33 +34,56 @@ tRPC-A2A-Go 是 A2A（Agent-to-Agent）协议 v1.0 的 Go 实现。它同时提�
 
 ## 架构
 
-```mermaid
-flowchart TB
-    subgraph clients["客户端"]
-        C1["A2A v1.0 client"]
-        C2["legacy v0.2.x client"]
-    end
-    subgraph server["server"]
-        direction TB
-        AUTH["鉴权链"]
-        CARD["agent card / extended card"]
-        RPC["JSON-RPC + SSE 分发"]
-        COMPAT["compat/v0 handler"]
-    end
-    TM["TaskManager<br/>memory / redis / 自定义"]
-    MP["MessageProcessor<br/>你的 agent"]
+下图以生产环境的 Redis 路径为例。其他存储实现仍遵循相同的 server、
+`TaskManager` 与 `MessageProcessor` 边界；Redis 额外提供共享状态和可选的
+跨节点事件传输。
 
-    C1 --> AUTH
-    C2 --> AUTH
-    AUTH --> CARD
-    AUTH --> RPC
-    RPC --> TM
-    COMPAT -.-> TM
-    TM --> MP
-    MP -- "事件流" --> TM
+```mermaid
+flowchart LR
+    subgraph CALLERS["调用方"]
+        APP["A2A 业务应用 / Orchestrator"]
+        LEGACY["legacy v0.2.x 调用方"]
+    end
+
+    subgraph ADAPTERS["Wire 适配层"]
+        CLIENT["client<br/>JSON-RPC / SSE"]
+        SERVER["server<br/>agent card · 鉴权 · 方法分发"]
+        COMPAT["compat/v0<br/>v0 wire ↔ v1 类型"]
+    end
+
+    subgraph RUNTIME["Task Runtime"]
+        PORT["taskmanager.TaskManager<br/>框架端口"]
+        RT["redis.TaskManager<br/>round engine · 生命周期 · 持久化 · fan-out"]
+        MP["MessageProcessor<br/>你的 agent"]
+    end
+
+    subgraph STATE["共享 Redis 状态与分发"]
+        STORE[("Task · Message · Conversation · PushConfig")]
+        TRANSPORT["internal task-event transport"]
+        STREAMS[("每 Task 一个 Redis Stream")]
+    end
+
+    subgraph DELIVERY["响应交付"]
+        UNARY["JSON-RPC 一元结果"]
+        SSE["SSE / SubscribeToTask"]
+        PUSH["push.Sender → webhook"]
+    end
+
+    APP --> CLIENT --> SERVER
+    LEGACY --> SERVER
+    SERVER -->|"v1 方法"| PORT
+    SERVER -->|"v0 方法"| COMPAT --> PORT
+    PORT --> RT
+    RT <-->|"ExecContext / 有序 StreamEvent"| MP
+    RT <-->|"Task 状态"| STORE
+    RT <-->|"commit / read"| TRANSPORT
+    TRANSPORT <--> STREAMS
+    RT --> UNARY
+    RT --> SSE
+    RT --> PUSH
 ```
 
-三层职责是固定的：
+核心职责边界如下：
 
 - **`server`** 终结 wire 层：鉴权、提供 agent card、分发 JSON-RPC 方法和 SSE 流，也可以把 `compat/v0` 挂在同一端点里。
 - **`TaskManager`** 持有状态：懒创建任务、持久化事件、维护会话历史、处理取消、留存策略和订阅者扇出。
@@ -74,16 +97,31 @@ flowchart TB
 sequenceDiagram
     participant Client
     participant Server as server（鉴权、分发）
-    participant TM as TaskManager
+    participant TM as TaskManager / round engine
+    participant Registry as 本地执行注册表
     participant P as MessageProcessor
+    participant Store as Task + Conversation 存储
 
     Client->>Server: SendMessage / SendStreamingMessage
     Server->>Server: 鉴权、解析 tenant、校验 agent 能力
     Server->>TM: OnSendMessage / OnSendMessageStream
-    TM->>P: ProcessMessage(ctx, ec)
+    TM->>Registry: 获取该 Task 的本地执行槽
+    TM->>Store: 加载 continuation、持久化用户消息
+    TM->>P: ProcessMessage(detachedCtx, ExecContext)
     P-->>TM: <-chan events（Message / status / artifact）
-    Note over TM: 事件先持久化再广播；<br/>首个任务事件懒创建任务；<br/>channel 关闭时应用轮次规则
-    TM-->>Server: 最终快照或实时事件流
+    loop 每个事件
+        TM->>TM: 校验事件并物化 Task 快照
+        TM->>Store: 对外暴露前先持久化
+        Store-->>TM: 提交成功
+        TM-->>Server: 流式调用交付已提交的 StreamResponse
+    end
+    TM->>TM: 应用终态、挂起、违规或关闭规则
+    TM->>Registry: 释放执行槽
+    alt SendMessage
+        TM-->>Server: 派生 Task / Message 结果
+    else SendStreamingMessage
+        TM-->>Server: 关闭已提交事件流
+    end
     Server-->>Client: JSON-RPC 结果 / SSE 帧
 ```
 

--- a/docs/mkdocs/zh/server.md
+++ b/docs/mkdocs/zh/server.md
@@ -206,6 +206,31 @@ tm, _ := redistm.NewTaskManager(proc, redisClient,   // 注意参数序:(process
 continuation、live cancel 或执行请求。每个 Task Stream 约保留最新 10,000 个事件；
 落后超过该窗口的客户端可能错过中间事件。
 
+```mermaid
+sequenceDiagram
+    participant A as Node A round engine
+    participant Redis as 共享 Redis
+    participant B as Node B TaskManager
+    participant Client
+
+    A->>Redis: 原子写入 Task 快照及其事件
+    Client->>B: SubscribeToTask(taskId)
+    B->>Redis: 原子读取 Task 快照和 Stream 尾游标
+    Redis-->>B: 同一个一致性切面
+    B-->>Client: 当前 Task 快照（首帧）
+
+    loop 游标之后提交的事件
+        B->>Redis: 从游标之后读取
+        Redis-->>B: 有序 StreamResponse 批次
+        B-->>Client: SSE 帧
+    end
+```
+
+对会改变 Task 的事件，快照包含切面处已物化的 Task 状态；游标及其之前的
+事件帧不会重放。已有 artifact chunk 已物化在 `Task.Artifacts` 中。Stream
+只发送切面之后的新事件，读写两侧的原子边界保证更新不会落在“初始快照”
+和“后续 Stream”之间而丢失。
+
 → [examples/redis](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples/redis)。实现 `taskmanager.TaskManager` 接口即可自带后端。
 
 留存:


### PR DESCRIPTION
## Summary

- expand the framework overview with the production Redis component architecture
- document the unified TaskManager round execution and persistence flow
- add the cross-node `SubscribeToTask` snapshot-and-cursor sequence in both English and Chinese server guides

## Why

The existing documentation described these boundaries in prose but did not show how wire adapters, the TaskManager port, the Redis runtime, event transport, and response delivery fit together. The cross-node resubscribe option also benefits from an explicit consistency-cut diagram so readers can distinguish the initial Task snapshot from subsequent Redis Stream events.

## Impact

Documentation only. No runtime or public API behavior changes.

## Validation

- `mkdocs build --strict --config-file docs/mkdocs.yml --site-dir /tmp/trpc-a2a-go-v2-architecture-docs-site`
- `git diff --check`