### PR TITLE
client: support composable HTTP request middleware

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -36,12 +36,12 @@ const (
 // A2AClient provides methods to interact with an A2A agent server.
 // It handles making HTTP requests and encoding/decoding JSON-RPC messages.
 type A2AClient struct {
-	baseURL            *url.URL            // Parsed base URL of the agent server.
-	httpClient         *http.Client        // Underlying HTTP client.
-	userAgent          string              // User-Agent header string.
-	authProvider       auth.ClientProvider // Authentication provider.
-	httpReqHandler     HTTPReqHandler      // Custom HTTP request handler.
-	httpReqMiddlewares []HTTPReqMiddleware // HTTP request middleware in registration order.
+	baseURL        *url.URL            // Parsed base URL of the agent server.
+	httpClient     *http.Client        // Underlying HTTP client.
+	userAgent      string              // User-Agent header string.
+	authProvider   auth.ClientProvider // Authentication provider.
+	httpReqHandler HTTPReqHandler      // Custom HTTP request handler.
+	middlewares    []Middleware        // HTTP request middleware.
 
 	maxBufSize     int
 	initialBufSize int
@@ -75,24 +75,10 @@ func NewA2AClient(agentURL string, opts ...Option) (*A2AClient, error) {
 	for _, opt := range opts {
 		opt(client)
 	}
-	client.httpReqHandler = wrapHTTPReqHandler(
-		client.httpReqHandler,
-		client.httpReqMiddlewares,
-	)
-	return client, nil
-}
-
-func wrapHTTPReqHandler(
-	handler HTTPReqHandler,
-	middlewares []HTTPReqMiddleware,
-) HTTPReqHandler {
-	for i := len(middlewares) - 1; i >= 0; i-- {
-		if middlewares[i] == nil {
-			continue
-		}
-		handler = middlewares[i].Wrap(handler)
+	if len(client.middlewares) > 0 {
+		client.httpReqHandler = MiddlewareChain(client.middlewares).Wrap(client.httpReqHandler)
 	}
-	return handler
+	return client, nil
 }
 
 // SendMessage sends a message using the message/send method.

--- a/client/client.go
+++ b/client/client.go
@@ -36,11 +36,12 @@ const (
 // A2AClient provides methods to interact with an A2A agent server.
 // It handles making HTTP requests and encoding/decoding JSON-RPC messages.
 type A2AClient struct {
-	baseURL        *url.URL            // Parsed base URL of the agent server.
-	httpClient     *http.Client        // Underlying HTTP client.
-	userAgent      string              // User-Agent header string.
-	authProvider   auth.ClientProvider // Authentication provider.
-	httpReqHandler HTTPReqHandler      // Custom HTTP request handler.
+	baseURL            *url.URL            // Parsed base URL of the agent server.
+	httpClient         *http.Client        // Underlying HTTP client.
+	userAgent          string              // User-Agent header string.
+	authProvider       auth.ClientProvider // Authentication provider.
+	httpReqHandler     HTTPReqHandler      // Custom HTTP request handler.
+	httpReqMiddlewares []HTTPReqMiddleware // HTTP request middleware in registration order.
 
 	maxBufSize     int
 	initialBufSize int
@@ -74,7 +75,24 @@ func NewA2AClient(agentURL string, opts ...Option) (*A2AClient, error) {
 	for _, opt := range opts {
 		opt(client)
 	}
+	client.httpReqHandler = wrapHTTPReqHandler(
+		client.httpReqHandler,
+		client.httpReqMiddlewares,
+	)
 	return client, nil
+}
+
+func wrapHTTPReqHandler(
+	handler HTTPReqHandler,
+	middlewares []HTTPReqMiddleware,
+) HTTPReqHandler {
+	for i := len(middlewares) - 1; i >= 0; i-- {
+		if middlewares[i] == nil {
+			continue
+		}
+		handler = middlewares[i].Wrap(handler)
+	}
+	return handler
 }
 
 // SendMessage sends a message using the message/send method.

--- a/client/options.go
+++ b/client/options.go
@@ -23,6 +23,13 @@ type HTTPReqHandler interface {
 	Handle(ctx context.Context, client *http.Client, req *http.Request) (*http.Response, error)
 }
 
+// HTTPReqMiddleware wraps an HTTPReqHandler with additional request behavior.
+// Wrap is called once when the A2AClient is constructed. The returned handler
+// may be called concurrently and must be safe for concurrent use.
+type HTTPReqMiddleware interface {
+	Wrap(next HTTPReqHandler) HTTPReqHandler
+}
+
 // WithHTTPClient sets a custom http.Client for the A2AClient.
 func WithHTTPClient(client *http.Client) Option {
 	return func(c *A2AClient) {
@@ -119,10 +126,21 @@ func WithAuthProvider(provider auth.ClientProvider) Option {
 	}
 }
 
-// WithHTTPReqHandler sets a custom HTTP request handler for the A2AClient.
+// WithHTTPReqHandler sets the terminal HTTP request handler for the A2AClient.
+// HTTP request middleware is applied around this handler after all client
+// options have been processed.
 func WithHTTPReqHandler(handler HTTPReqHandler) Option {
 	return func(c *A2AClient) {
 		c.httpReqHandler = handler
+	}
+}
+
+// WithHTTPReqMiddleware adds HTTP request middleware to the A2AClient.
+// Multiple middleware are applied in registration order, with the first
+// middleware becoming the outermost wrapper. Nil middleware is ignored.
+func WithHTTPReqMiddleware(middlewares ...HTTPReqMiddleware) Option {
+	return func(c *A2AClient) {
+		c.httpReqMiddlewares = append(c.httpReqMiddlewares, middlewares...)
 	}
 }
 

--- a/client/options.go
+++ b/client/options.go
@@ -23,11 +23,25 @@ type HTTPReqHandler interface {
 	Handle(ctx context.Context, client *http.Client, req *http.Request) (*http.Response, error)
 }
 
-// HTTPReqMiddleware wraps an HTTPReqHandler with additional request behavior.
-// Wrap is called once when the A2AClient is constructed. The returned handler
-// may be called concurrently and must be safe for concurrent use.
-type HTTPReqMiddleware interface {
+// Middleware wraps an HTTPReqHandler with additional request behavior.
+// When configured with WithMiddleware, Wrap is called once when the A2AClient
+// is constructed. The returned handler may be called concurrently and must be
+// safe for concurrent use.
+type Middleware interface {
 	Wrap(next HTTPReqHandler) HTTPReqHandler
+}
+
+// MiddlewareChain represents HTTP request middleware that can be composed.
+// Each middleware in the chain must be non-nil.
+type MiddlewareChain []Middleware
+
+// Wrap applies the chain to handler. Middleware is applied in reverse order,
+// so the first middleware in the chain becomes the outermost wrapper.
+func (chain MiddlewareChain) Wrap(handler HTTPReqHandler) HTTPReqHandler {
+	for i := len(chain) - 1; i >= 0; i-- {
+		handler = chain[i].Wrap(handler)
+	}
+	return handler
 }
 
 // WithHTTPClient sets a custom http.Client for the A2AClient.
@@ -135,12 +149,12 @@ func WithHTTPReqHandler(handler HTTPReqHandler) Option {
 	}
 }
 
-// WithHTTPReqMiddleware adds HTTP request middleware to the A2AClient.
+// WithMiddleware adds HTTP request middleware to the A2AClient.
 // Multiple middleware are applied in registration order, with the first
-// middleware becoming the outermost wrapper. Nil middleware is ignored.
-func WithHTTPReqMiddleware(middlewares ...HTTPReqMiddleware) Option {
+// middleware becoming the outermost wrapper. Each middleware must be non-nil.
+func WithMiddleware(middlewares ...Middleware) Option {
 	return func(c *A2AClient) {
-		c.httpReqMiddlewares = append(c.httpReqMiddlewares, middlewares...)
+		c.middlewares = append(c.middlewares, middlewares...)
 	}
 }
 

--- a/client/options.go
+++ b/client/options.go
@@ -32,13 +32,16 @@ type Middleware interface {
 }
 
 // MiddlewareChain represents HTTP request middleware that can be composed.
-// Each middleware in the chain must be non-nil.
 type MiddlewareChain []Middleware
 
 // Wrap applies the chain to handler. Middleware is applied in reverse order,
-// so the first middleware in the chain becomes the outermost wrapper.
+// so the first middleware in the chain becomes the outermost wrapper. Nil
+// middleware is ignored.
 func (chain MiddlewareChain) Wrap(handler HTTPReqHandler) HTTPReqHandler {
 	for i := len(chain) - 1; i >= 0; i-- {
+		if chain[i] == nil {
+			continue
+		}
 		handler = chain[i].Wrap(handler)
 	}
 	return handler
@@ -151,7 +154,7 @@ func WithHTTPReqHandler(handler HTTPReqHandler) Option {
 
 // WithMiddleware adds HTTP request middleware to the A2AClient.
 // Multiple middleware are applied in registration order, with the first
-// middleware becoming the outermost wrapper. Each middleware must be non-nil.
+// middleware becoming the outermost wrapper. Nil middleware is ignored.
 func WithMiddleware(middlewares ...Middleware) Option {
 	return func(c *A2AClient) {
 		c.middlewares = append(c.middlewares, middlewares...)

--- a/client/options_test.go
+++ b/client/options_test.go
@@ -169,7 +169,7 @@ func TestWithAuthProvider(t *testing.T) {
 	assert.Equal(t, mockProvider, client.authProvider)
 }
 
-func TestWithHTTPReqMiddleware(t *testing.T) {
+func TestWithMiddleware(t *testing.T) {
 	var events []string
 	var wrapCalls int
 	terminal := httpReqHandlerFunc(func(
@@ -180,8 +180,8 @@ func TestWithHTTPReqMiddleware(t *testing.T) {
 		events = append(events, "handler")
 		return httptest.NewRecorder().Result(), nil
 	})
-	middleware := func(name string) HTTPReqMiddleware {
-		return httpReqMiddlewareFunc(func(next HTTPReqHandler) HTTPReqHandler {
+	middleware := func(name string) Middleware {
+		return middlewareFunc(func(next HTTPReqHandler) HTTPReqHandler {
 			wrapCalls++
 			return httpReqHandlerFunc(func(
 				ctx context.Context,
@@ -198,12 +198,13 @@ func TestWithHTTPReqMiddleware(t *testing.T) {
 
 	client, err := NewA2AClient(
 		"http://localhost:8080",
-		WithHTTPReqMiddleware(middleware("first")),
+		WithMiddleware(middleware("first")),
 		WithHTTPReqHandler(terminal),
-		WithHTTPReqMiddleware(nil, middleware("second")),
+		WithMiddleware(middleware("second")),
 	)
 	require.NoError(t, err)
 	assert.Equal(t, 2, wrapCalls)
+	assert.Len(t, client.middlewares, 2)
 
 	req := httptest.NewRequest(http.MethodGet, "http://localhost:8080", nil)
 	resp, err := client.httpReqHandler.Handle(
@@ -238,9 +239,9 @@ func (f httpReqHandlerFunc) Handle(
 	return f(ctx, client, req)
 }
 
-type httpReqMiddlewareFunc func(next HTTPReqHandler) HTTPReqHandler
+type middlewareFunc func(next HTTPReqHandler) HTTPReqHandler
 
-func (f httpReqMiddlewareFunc) Wrap(next HTTPReqHandler) HTTPReqHandler {
+func (f middlewareFunc) Wrap(next HTTPReqHandler) HTTPReqHandler {
 	return f(next)
 }
 

--- a/client/options_test.go
+++ b/client/options_test.go
@@ -169,6 +169,81 @@ func TestWithAuthProvider(t *testing.T) {
 	assert.Equal(t, mockProvider, client.authProvider)
 }
 
+func TestWithHTTPReqMiddleware(t *testing.T) {
+	var events []string
+	var wrapCalls int
+	terminal := httpReqHandlerFunc(func(
+		context.Context,
+		*http.Client,
+		*http.Request,
+	) (*http.Response, error) {
+		events = append(events, "handler")
+		return httptest.NewRecorder().Result(), nil
+	})
+	middleware := func(name string) HTTPReqMiddleware {
+		return httpReqMiddlewareFunc(func(next HTTPReqHandler) HTTPReqHandler {
+			wrapCalls++
+			return httpReqHandlerFunc(func(
+				ctx context.Context,
+				httpClient *http.Client,
+				req *http.Request,
+			) (*http.Response, error) {
+				events = append(events, name+" before")
+				resp, err := next.Handle(ctx, httpClient, req)
+				events = append(events, name+" after")
+				return resp, err
+			})
+		})
+	}
+
+	client, err := NewA2AClient(
+		"http://localhost:8080",
+		WithHTTPReqMiddleware(middleware("first")),
+		WithHTTPReqHandler(terminal),
+		WithHTTPReqMiddleware(nil, middleware("second")),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 2, wrapCalls)
+
+	req := httptest.NewRequest(http.MethodGet, "http://localhost:8080", nil)
+	resp, err := client.httpReqHandler.Handle(
+		context.Background(),
+		client.httpClient,
+		req,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NoError(t, resp.Body.Close())
+	assert.Equal(t, 2, wrapCalls)
+	assert.Equal(t, []string{
+		"first before",
+		"second before",
+		"handler",
+		"second after",
+		"first after",
+	}, events)
+}
+
+type httpReqHandlerFunc func(
+	ctx context.Context,
+	client *http.Client,
+	req *http.Request,
+) (*http.Response, error)
+
+func (f httpReqHandlerFunc) Handle(
+	ctx context.Context,
+	client *http.Client,
+	req *http.Request,
+) (*http.Response, error) {
+	return f(ctx, client, req)
+}
+
+type httpReqMiddlewareFunc func(next HTTPReqHandler) HTTPReqHandler
+
+func (f httpReqMiddlewareFunc) Wrap(next HTTPReqHandler) HTTPReqHandler {
+	return f(next)
+}
+
 // mockClientProvider implements auth.ClientProvider for testing
 type mockClientProvider struct{}
 

--- a/client/options_test.go
+++ b/client/options_test.go
@@ -169,6 +169,8 @@ func TestWithAuthProvider(t *testing.T) {
 	assert.Equal(t, mockProvider, client.authProvider)
 }
 
+// TestWithMiddleware verifies middleware ordering, terminal handler wrapping,
+// and nil middleware handling.
 func TestWithMiddleware(t *testing.T) {
 	var events []string
 	var wrapCalls int
@@ -200,11 +202,11 @@ func TestWithMiddleware(t *testing.T) {
 		"http://localhost:8080",
 		WithMiddleware(middleware("first")),
 		WithHTTPReqHandler(terminal),
-		WithMiddleware(middleware("second")),
+		WithMiddleware(nil, middleware("second")),
 	)
 	require.NoError(t, err)
 	assert.Equal(t, 2, wrapCalls)
-	assert.Len(t, client.middlewares, 2)
+	assert.Len(t, client.middlewares, 3)
 
 	req := httptest.NewRequest(http.MethodGet, "http://localhost:8080", nil)
 	resp, err := client.httpReqHandler.Handle(

--- a/server/options.go
+++ b/server/options.go
@@ -42,9 +42,12 @@ type HTTPRouter interface {
 
 // Wrap applies all middlewares in the chain to the given handler.
 // Middlewares are applied in reverse order so the first middleware in the slice
-// becomes the outermost wrapper.
+// becomes the outermost wrapper. Nil middleware is ignored.
 func (chain MiddlewareChain) Wrap(handler http.Handler) http.Handler {
 	for i := len(chain) - 1; i >= 0; i-- {
+		if chain[i] == nil {
+			continue
+		}
 		handler = chain[i].Wrap(handler)
 	}
 	return handler
@@ -166,6 +169,7 @@ func WithBasePath(basePath string) Option {
 // WithMiddleWare sets the authentication middleware for the server.
 // Multiple middlewares can be provided and will be chained together.
 // The first middleware in the slice will be the outermost wrapper.
+// Nil middleware is ignored.
 // Middlewares only take effect on JSON-RPC endpoint.
 func WithMiddleWare(middlewares ...Middleware) Option {
 	return func(s *A2AServer) {

--- a/server/options_test.go
+++ b/server/options_test.go
@@ -9,6 +9,7 @@ package server
 import (
 	"context"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -20,6 +21,47 @@ import (
 	"trpc.group/trpc-go/trpc-a2a-go/protocol"
 	"trpc.group/trpc-go/trpc-a2a-go/telemetry/metrics"
 )
+
+// TestMiddlewareChain verifies wrapping order and nil middleware handling.
+func TestMiddlewareChain(t *testing.T) {
+	var events []string
+	middleware := func(name string) Middleware {
+		return middlewareFunc(func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				events = append(events, name+" before")
+				next.ServeHTTP(w, r)
+				events = append(events, name+" after")
+			})
+		})
+	}
+	terminal := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		events = append(events, "handler")
+	})
+
+	handler := MiddlewareChain{
+		middleware("first"),
+		nil,
+		middleware("second"),
+	}.Wrap(terminal)
+	handler.ServeHTTP(
+		httptest.NewRecorder(),
+		httptest.NewRequest(http.MethodPost, "/", nil),
+	)
+
+	assert.Equal(t, []string{
+		"first before",
+		"second before",
+		"handler",
+		"second after",
+		"first after",
+	}, events)
+}
+
+type middlewareFunc func(next http.Handler) http.Handler
+
+func (f middlewareFunc) Wrap(next http.Handler) http.Handler {
+	return f(next)
+}
 
 func TestWithCORSEnabled(t *testing.T) {
 	// Test with CORS enabled


### PR DESCRIPTION
## What changed

- Add `client.Middleware`, `client.MiddlewareChain`, and `client.WithMiddleware`, mirroring the server middleware model.
- Store middleware as a slice on `A2AClient`, append across repeated options, and compose the chain after all client options are applied.
- Keep `WithHTTPReqHandler` as the terminal handler regardless of option ordering.
- Apply middleware in registration order, with the first middleware as the outermost wrapper.
- Ignore nil entries in both client and server middleware chains, with coverage for composition order, repeated options, custom terminal handlers, and nil handling.

## Why

The client currently exposes a single replace-only `HTTPReqHandler` slot. Framework integrations that need internal request behavior cannot preserve a caller-provided handler without replacing it or rebuilding clients and replaying opaque options.

The new API deliberately follows the existing server design: an append-only middleware slice is converted to a `MiddlewareChain` and wrapped around the terminal handler. This gives client and server users the same composition model. Both chains now ignore nil entries instead of panicking.

This protocol-independent transport extension is required by the anonymous-cookie integration tracked in trpc-group/trpc-agent-go#2259. The v2 forward-port is #132.

## Compatibility

Existing clients that do not configure middleware keep the same runtime behavior. Existing server middleware chains now ignore nil entries instead of panicking. `WithHTTPReqHandler` remains supported as the terminal handler, and middleware is additive and opt-in.

Adding the middleware slice makes the concrete `A2AClient` value non-comparable. This is intentional and matches the server-side storage model; normal usage through the pointer returned by `NewA2AClient` is unaffected. `go-apidiff` reports only this expected incompatibility plus the three compatible API additions.

## Testing

- `go test ./...`
- `go build ./...`
- `golangci-lint v1.64.8 run --new-from-rev=upstream/main`
- `go-apidiff upstream/main --compare-imports=false --print-compatible=true --repo-path=.` (expected: `A2AClient` becomes non-comparable)

## Release notes

Added composable client request middleware aligned with the server chain, and made middleware chains ignore nil entries.

Updates trpc-group/trpc-agent-go#2259


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added client support for configurable HTTP request middleware via new middleware options.
  * Middleware layers are composed around the outgoing request handler in the order registered.
* **Bug Fixes**
  * Middleware chaining now safely ignores any nil middleware entries.
* **Tests**
  * Added client and server tests to verify middleware ordering and correct behavior with nil middleware.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->