### PR TITLE
trpc-a2a-go: preserve v0.2.x server compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,10 +154,10 @@ go run main.go --auth jwt --message "Custom message" --session-id "session123"
 ### 4. v0 Compatibility Example ([examples/compat](examples/compat))
 
 One server, both protocol generations: v1.0 clients on the standard wire and
-unmodified v0.2.x clients through [compat/v0](compat/v0) — same endpoint,
-same authentication chain. The client demonstrates the preserved legacy
-defaults (a configuration-less `message/send` answers immediately) plus
-blocking and streaming over the legacy wire.
+unmodified v0.2.x core task calls through [compat/v0](compat/v0) — same
+endpoint, same authentication chain. The client demonstrates the preserved
+legacy defaults (a configuration-less `message/send` answers immediately)
+plus blocking and streaming over the legacy wire.
 
 ```bash
 # Start the v0-compatible server

--- a/compat/v0/conversions.go
+++ b/compat/v0/conversions.go
@@ -479,7 +479,7 @@ func ToV1SendMessageParams(p SendMessageParams) protocol.SendMessageParams {
 	if p.Configuration != nil {
 		cfg := &protocol.SendMessageConfiguration{
 			AcceptedOutputModes: p.Configuration.AcceptedOutputModes,
-			HistoryLength:       p.Configuration.HistoryLength,
+			HistoryLength:       toV1HistoryLength(p.Configuration.HistoryLength),
 		}
 		// blocking=true -> wait for completion -> returnImmediately=false.
 		returnImmediately := !(p.Configuration.Blocking != nil && *p.Configuration.Blocking)
@@ -495,8 +495,10 @@ func ToV1SendMessageParams(p SendMessageParams) protocol.SendMessageParams {
 		// v1.0 returnImmediately means blocking — falling through would
 		// silently invert the most common legacy request shape.
 		returnImmediately := true
+		historyLength := 0
 		res.Configuration = &protocol.SendMessageConfiguration{
 			ReturnImmediately: &returnImmediately,
+			HistoryLength:     &historyLength,
 		}
 	}
 	return res
@@ -530,7 +532,7 @@ func ToV1TaskQueryParams(p TaskQueryParams) protocol.TaskQueryParams {
 	return protocol.TaskQueryParams{
 		RPCID:         p.RPCID,
 		ID:            p.ID,
-		HistoryLength: p.HistoryLength,
+		HistoryLength: toV1HistoryLength(p.HistoryLength),
 		Metadata:      p.Metadata,
 	}
 }
@@ -621,4 +623,14 @@ func optString(s string) *string {
 		return nil
 	}
 	return &s
+}
+
+// toV1HistoryLength preserves the legacy response-shaping default. V0 treated
+// an omitted historyLength as zero messages, while v1 treats it as unlimited.
+func toV1HistoryLength(length *int) *int {
+	if length != nil {
+		return length
+	}
+	zero := 0
+	return &zero
 }

--- a/compat/v0/conversions_test.go
+++ b/compat/v0/conversions_test.go
@@ -162,6 +162,9 @@ func TestSendMessageParamsBlockingMapping(t *testing.T) {
 	v1 := ToV1SendMessageParams(legacy)
 	require.NotNil(t, v1.Configuration)
 	require.NotNil(t, v1.Configuration.ReturnImmediately)
+	require.NotNil(t, v1.Configuration.HistoryLength)
+	assert.Zero(t, *v1.Configuration.HistoryLength,
+		"absent legacy historyLength must not become unlimited v1 history")
 	assert.False(t, *v1.Configuration.ReturnImmediately, "blocking=true -> returnImmediately=false")
 	assert.True(t, v1.Configuration.IsBlocking())
 
@@ -177,6 +180,8 @@ func TestSendMessageParamsBlockingMapping(t *testing.T) {
 	v1 = ToV1SendMessageParams(legacy)
 	require.NotNil(t, v1.Configuration)
 	require.NotNil(t, v1.Configuration.ReturnImmediately)
+	require.NotNil(t, v1.Configuration.HistoryLength)
+	assert.Zero(t, *v1.Configuration.HistoryLength)
 	assert.True(t, *v1.Configuration.ReturnImmediately, "absent legacy configuration -> returnImmediately=true")
 	assert.False(t, v1.Configuration.IsBlocking())
 
@@ -184,6 +189,30 @@ func TestSendMessageParamsBlockingMapping(t *testing.T) {
 	back := FromV1SendMessageParams(v1)
 	require.NotNil(t, back.Configuration.Blocking)
 	assert.False(t, *back.Configuration.Blocking)
+}
+
+func TestHistoryLengthMapping(t *testing.T) {
+	query := ToV1TaskQueryParams(TaskQueryParams{ID: "task-1"})
+	require.NotNil(t, query.HistoryLength)
+	assert.Zero(t, *query.HistoryLength,
+		"absent legacy historyLength must map to explicit v1 zero")
+
+	want := 3
+	query = ToV1TaskQueryParams(TaskQueryParams{ID: "task-1", HistoryLength: &want})
+	require.NotNil(t, query.HistoryLength)
+	assert.Equal(t, want, *query.HistoryLength)
+
+	params := SendMessageParams{
+		Message: Message{
+			Kind: KindMessage, MessageID: "m1", Role: MessageRoleUser,
+			Parts: []Part{TextPart{Kind: KindText, Text: "x"}},
+		},
+		Configuration: &SendMessageConfiguration{HistoryLength: &want},
+	}
+	converted := ToV1SendMessageParams(params)
+	require.NotNil(t, converted.Configuration)
+	require.NotNil(t, converted.Configuration.HistoryLength)
+	assert.Equal(t, want, *converted.Configuration.HistoryLength)
 }
 
 func TestPushConfigRoundTrip(t *testing.T) {

--- a/compat/v0/jsonrpc_server.go
+++ b/compat/v0/jsonrpc_server.go
@@ -37,6 +37,9 @@ const (
 	MethodTasksPushNotificationConfigGet = "tasks/pushNotificationConfig/get"
 	MethodTasksResubscribe               = "tasks/resubscribe"
 	MethodAgentAuthenticatedExtendedCard = "agent/getAuthenticatedExtendedCard"
+	// methodAgentAuthenticatedExtendedCardOld is the method name used by
+	// trpc-a2a-go v0.2.0 through v0.2.4.
+	methodAgentAuthenticatedExtendedCardOld = "agent/authenticatedExtendedCard"
 )
 
 // Legacy SSE event type strings (v1.0 renamed these to statusUpdate /
@@ -77,6 +80,13 @@ func NewJSONRPCHandler(tm taskmanager.TaskManager, opts ...HandlerOption) *Handl
 		opt(h)
 	}
 	return h
+}
+
+// AdaptAgentCard fills the legacy discovery fields on a card copy served by
+// A2AServer. Signed cards are kept immutable by the server and do not reach
+// this hook.
+func (*Handler) AdaptAgentCard(card *protocol.AgentCard) {
+	FillLegacyCardFields(card)
 }
 
 // IsLegacyMethod reports whether the JSON-RPC method name belongs to the
@@ -123,7 +133,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.handlePushSet(ctx, w, &req)
 	case MethodTasksPushNotificationConfigGet:
 		h.handlePushGet(ctx, w, &req)
-	case MethodAgentAuthenticatedExtendedCard:
+	case MethodAgentAuthenticatedExtendedCard, methodAgentAuthenticatedExtendedCardOld:
 		h.handleExtendedCard(ctx, w, &req)
 	default:
 		writeError(w, req.ID,

--- a/compat/v0/jsonrpc_server_test.go
+++ b/compat/v0/jsonrpc_server_test.go
@@ -27,6 +27,7 @@ import (
 // compat translation.
 type fakeTaskManager struct {
 	gotSendParams *protocol.SendMessageParams
+	gotGetParams  *protocol.TaskQueryParams
 	sendResponse  *protocol.SendMessageResponse
 	streamEvents  []protocol.StreamResponse
 	task          *protocol.Task
@@ -57,6 +58,7 @@ func (f *fakeTaskManager) OnSendMessageStream(
 func (f *fakeTaskManager) OnGetTask(
 	ctx context.Context, p protocol.TaskQueryParams,
 ) (*protocol.Task, error) {
+	f.gotGetParams = &p
 	return f.task, nil
 }
 
@@ -148,6 +150,9 @@ func TestHandler_MessageSend_LegacyWire(t *testing.T) {
 	assert.Equal(t, "hello", fake.gotSendParams.Message.Parts[0].TextContent())
 	require.NotNil(t, fake.gotSendParams.Configuration)
 	assert.True(t, fake.gotSendParams.Configuration.IsBlocking())
+	require.NotNil(t, fake.gotSendParams.Configuration.HistoryLength)
+	assert.Zero(t, *fake.gotSendParams.Configuration.HistoryLength,
+		"omitted v0 historyLength must not request full v1 history")
 
 	// Outbound: legacy wire shape (kind + lowercase role, no v1 wrapper).
 	var resp struct {
@@ -174,6 +179,10 @@ func TestHandler_TasksGet_LegacyWire(t *testing.T) {
 
 	w := postJSON(t, h, `{"jsonrpc":"2.0","id":"req-2","method":"tasks/get","params":{"id":"task-1"}}`)
 	require.Equal(t, http.StatusOK, w.Code)
+	require.NotNil(t, fake.gotGetParams)
+	require.NotNil(t, fake.gotGetParams.HistoryLength)
+	assert.Zero(t, *fake.gotGetParams.HistoryLength,
+		"omitted v0 historyLength must not request full v1 history")
 
 	body := w.Body.String()
 	assert.Contains(t, body, `"kind":"task"`)
@@ -333,4 +342,9 @@ func TestHandler_ExtendedCard(t *testing.T) {
 	body := w.Body.String()
 	assert.Contains(t, body, `"url":"https://a.example.com"`)
 	assert.True(t, strings.Contains(body, `"protocolVersion":"0.2.5"`), "body: %s", body)
+
+	// v0.2.0 through v0.2.4 used the earlier method name.
+	w = postJSON(t, h, `{"jsonrpc":"2.0","id":"2","method":"agent/authenticatedExtendedCard"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"url":"https://a.example.com"`)
 }

--- a/docs/mkdocs/en/migration.md
+++ b/docs/mkdocs/en/migration.md
@@ -29,10 +29,11 @@ There is no longer a streaming/non-streaming branch in agent code.
   the `TaskHandler` interface is gone. The familiar names survive as a thin
   compatibility layer (`TaskHandle`), so most v0.x bodies — including the
   common fully synchronous style — port with mechanical edits.
-- **Existing v0.x *clients* keep working, unchanged.** Mount `compat/v0` on the
-  same endpoint and legacy v0.2.x clients are served side by side with v1.0
-  clients, through the same authentication chain, with the legacy defaults
-  preserved. See [Keeping v0.x clients working](#keeping-v0x-clients-working).
+- **Existing v0.x *clients* keep working for core task operations, unchanged.**
+  Mount `compat/v0` on the same endpoint and legacy v0.2.x clients are served
+  side by side with v1.0 clients, through the same authentication chain, with
+  the legacy defaults preserved. See
+  [Keeping v0.x clients working](#keeping-v0x-clients-working).
 
 ## The mental shift
 
@@ -309,7 +310,8 @@ For the full runtime contract behind these rules, see [Server: the round contrac
 Porting the server does not require touching your clients. Mount the
 [compat/v0](https://github.com/trpc-group/trpc-a2a-go/tree/v2/compat/v0) handler
 on the same JSON-RPC endpoint with `server.WithCompatHandler`, and unmodified
-v0.2.x clients keep working:
+v0.2.x clients keep working for task send, streaming, query, cancellation and
+resubscription:
 
 ```go
 import (
@@ -339,6 +341,11 @@ legacy `message/send` still returns immediately, even though the native v1.0
 `message/send` now blocks by default. See
 [examples/compat](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples/compat)
 for a runnable server and legacy-wire client.
+
+The compat handler also publishes unsigned Agent Cards with both v1.0 and
+v0.2.x discovery fields. A signed card cannot be changed without invalidating
+its signature, so populate both representations before signing it. Automatic
+push callback payload translation is not covered by this adapter.
 
 ## Migration checklist
 

--- a/docs/mkdocs/en/overview.md
+++ b/docs/mkdocs/en/overview.md
@@ -109,9 +109,10 @@ A large part of the framework is the protocol work you don't have to do:
 - **Lazy task creation & optional persistence** — a task materializes on the
   first task event. Memory and Redis persist it before broadcast; stateless
   keeps the snapshot only until the originating request ends.
-- **Agent card normalization** — cards carry both the v1.0 fields and their
-  deprecated v0.2.x mirrors, so one card is readable by both client
-  generations.
+- **Agent card normalization** — when `compat/v0` is mounted, unsigned cards
+  carry both the v1.0 fields and their deprecated v0.2.x mirrors, so one card
+  is readable by both client generations. Signed cards must contain both
+  representations before signing.
 - **Legacy translation** — `compat/v0` maps the v0.2.x slash-method wire onto
   the same `TaskManager`, preserving the old defaults.
 

--- a/docs/mkdocs/en/server.md
+++ b/docs/mkdocs/en/server.md
@@ -426,7 +426,10 @@ disjoint from the v1.0 PascalCase names, so one endpoint dispatches both inside
 the same auth chain and against the same `TaskManager`. Memory and Redis
 preserve the old defaults, notably non-blocking `message/send`. Stateless can
 serve that default for direct Message responses, but cannot keep a non-terminal
-Task running in the background.
+Task running in the background. The handler also backfills legacy discovery
+fields on unsigned Agent Cards. Signed cards must contain both v1.0 and v0.2.x
+fields before signing. Automatic push callback payload translation is outside
+the compatibility adapter.
 
 ```go
 import v0 "trpc.group/trpc-go/trpc-a2a-go/v2/compat/v0"

--- a/docs/mkdocs/zh/migration.md
+++ b/docs/mkdocs/zh/migration.md
@@ -24,7 +24,7 @@ v1.0 用**单一事件流契约**取代了**多出口回调**。在 v0.x 中，`
 **迁移策略分两半：**
 
 - **服务端代码必须迁移。** `ProcessMessage` 签名变了，`TaskHandler` 接口没了。熟悉的名字以一层薄兼容层（`TaskHandle`）的形式保留，所以大多数 v0.x 方法体——包括常见的全同步写法——都能靠机械改动完成迁移。
-- **既有的 v0.x *客户端*照常工作，无需改动。** 把 `compat/v0` 挂到同一端点，legacy v0.2.x 客户端就与 v1.0 客户端并肩服务，走同一条认证链，并保留 legacy 默认行为。见下文「保持 v0.x 客户端可用」一节。
+- **既有的 v0.x *客户端*执行核心任务操作时照常工作，无需改动。** 把 `compat/v0` 挂到同一端点，legacy v0.2.x 客户端就与 v1.0 客户端并肩服务，走同一条认证链，并保留 legacy 默认行为。见下文「保持 v0.x 客户端可用」一节。
 
 ## 心智转变
 
@@ -234,7 +234,7 @@ v1.0 的 JSON-RPC 绑定使用 PascalCase 方法名。斜杠分隔的名字是 v
 
 ## 保持 v0.x 客户端可用
 
-迁移服务端无需动你的客户端。用 `server.WithCompatHandler` 把 [compat/v0](https://github.com/trpc-group/trpc-a2a-go/tree/v2/compat/v0) handler 挂到同一个 JSON-RPC 端点上，未经改动的 v0.2.x 客户端就照常工作：
+迁移服务端无需改动客户端的任务发送、流式调用、查询、取消和重新订阅代码。用 `server.WithCompatHandler` 把 [compat/v0](https://github.com/trpc-group/trpc-a2a-go/tree/v2/compat/v0) handler 挂到同一个 JSON-RPC 端点上即可：
 
 ```go
 import (
@@ -258,6 +258,8 @@ srv, err := server.NewA2AServer(tm,
 ```
 
 agent 本身只写一次，基于 v1.0 的 `MessageProcessor` 契约；compat handler 负责在 legacy wire 与它之间来回翻译。关键在于，**legacy 路径上保留了 v0.x 的非阻塞默认**：不带 configuration 的 legacy `message/send` 仍然立即返回，尽管原生 v1.0 的 `message/send` 现在默认阻塞。可运行的服务端与 legacy-wire 客户端见 [examples/compat](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples/compat)。
+
+compat handler 还会为未签名 Agent Card 同时填充 v1.0 与 v0.2.x 的发现字段。签名 card 一经修改就会使签名失效，因此必须在签名前自行填好两套字段。该 adapter 不负责转换自动 push callback 的 payload。
 
 ## 迁移清单
 

--- a/docs/mkdocs/zh/overview.md
+++ b/docs/mkdocs/zh/overview.md
@@ -95,7 +95,7 @@ sequenceDiagram
 - **结果派生**：`SendMessage` 返回最终 `Task` 或直接 `Message`，`SendStreamingMessage` 返回实时事件。
 - **任务生命周期**：首个任务事件会创建 Task。memory 与 Redis 将其持久化；stateless 只构造请求内 Task，并在请求结束后丢弃。
 - **会话历史**：memory 与 Redis 会保存请求消息、processor 发出的 `Message` 事件，以及被后续状态或 follow-up 取代的上一条 status message；stateless 不保存会话历史。
-- **agent card 归一化**：同一张 card 同时包含 v1.0 字段和 v0.x 镜像字段，便于两代客户端读取。
+- **agent card 归一化**：挂载 `compat/v0` 后，未签名 card 会同时包含 v1.0 字段和 v0.x 镜像字段，便于两代客户端读取；签名 card 必须在签名前自行包含两套字段。
 - **兼容层翻译**：`compat/v0` 把 v0.2.x 的斜杠方法名映射到同一个 `TaskManager`。
 - **生产能力封装**：鉴权、CORS、子路径、JWKS、push notification、遥测和多租户都通过 server option 接入。
 

--- a/docs/mkdocs/zh/server.md
+++ b/docs/mkdocs/zh/server.md
@@ -341,7 +341,7 @@ srv, _ := server.NewA2AServer(tm, server.WithAgentCard(card),
 
 ## 服务 legacy v0.2.x 客户端
 
-使用 memory 或 Redis 时，可以在迁移期间让未修改的 v0.2.x 客户端继续工作：把 `compat/v0` 挂到同一端点。legacy 斜杠方法名与 v1.0 的 PascalCase 名不相交，所以一个端点可以在同一鉴权链内、对同一个 `TaskManager` 分发两代请求。memory 与 Redis 会保留老默认，尤其是非阻塞的 `message/send`；stateless 可处理其中的直接 Message 响应，但不能让非终态 Task 脱离请求继续执行。
+使用 memory 或 Redis 时，可以在迁移期间让未修改的 v0.2.x 客户端继续执行核心任务操作：把 `compat/v0` 挂到同一端点。legacy 斜杠方法名与 v1.0 的 PascalCase 名不相交，所以一个端点可以在同一鉴权链内、对同一个 `TaskManager` 分发两代请求。memory 与 Redis 会保留老默认，尤其是非阻塞的 `message/send`；stateless 可处理其中的直接 Message 响应，但不能让非终态 Task 脱离请求继续执行。handler 还会为未签名 Agent Card 补齐 legacy 发现字段；签名 card 必须在签名前自行包含 v1.0 和 v0.2.x 两套字段。兼容层不负责转换自动 push callback 的 payload。
 
 ```go
 import v0 "trpc.group/trpc-go/trpc-a2a-go/v2/compat/v0"

--- a/server/compat_test.go
+++ b/server/compat_test.go
@@ -1,0 +1,189 @@
+// Tencent is pleased to support the open source community by making trpc-a2a-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-a2a-go is licensed under the Apache License Version 2.0.
+
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v0 "trpc.group/trpc-go/trpc-a2a-go/v2/compat/v0"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
+)
+
+func TestCompatHandler_FillsPublicAgentCard(t *testing.T) {
+	card := AgentCard{
+		Name:        "compat agent",
+		Description: "compat agent",
+		Version:     "1.0.0",
+		SupportedInterfaces: []protocol.AgentInterface{{
+			URL:             "https://agent.example.com/",
+			ProtocolBinding: "JSONRPC",
+			ProtocolVersion: protocol.ProtocolVersionV1,
+		}},
+		DefaultInputModes:  []string{"text/plain"},
+		DefaultOutputModes: []string{"text/plain"},
+	}
+	tm := newMockTaskManager()
+	srv, err := NewA2AServer(tm,
+		WithAgentCard(card),
+		WithCompatHandler(v0.NewJSONRPCHandler(tm)),
+	)
+	require.NoError(t, err)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	for _, path := range []string{protocol.AgentCardPath, protocol.OldAgentCardPath} {
+		resp, err := ts.Client().Get(ts.URL + path)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var legacy struct {
+			URL             string  `json:"url"`
+			ProtocolVersion *string `json:"protocolVersion"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&legacy))
+		require.NoError(t, resp.Body.Close())
+		assert.Equal(t, "https://agent.example.com/", legacy.URL)
+		require.NotNil(t, legacy.ProtocolVersion)
+		assert.Equal(t, v0.Version, *legacy.ProtocolVersion)
+	}
+}
+
+func TestCompatHandler_FillsDynamicTenantAgentCard(t *testing.T) {
+	card := AgentCard{
+		Name:        "tenant agent",
+		Description: "tenant agent",
+		Version:     "1.0.0",
+		SupportedInterfaces: []protocol.AgentInterface{{
+			URL:             "https://tenant.example.com/",
+			ProtocolBinding: "JSONRPC",
+			ProtocolVersion: protocol.ProtocolVersionV1,
+		}},
+	}
+	tm := newMockTaskManager()
+	srv, err := NewA2AServer(tm,
+		WithTenantCardProvider(func(_ context.Context, tenant string) (AgentCard, error) {
+			assert.Equal(t, "tenant-a", tenant)
+			return card, nil
+		}),
+		WithCompatHandler(v0.NewJSONRPCHandler(tm)),
+	)
+	require.NoError(t, err)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	resp, err := ts.Client().Get(ts.URL + protocol.AgentCardPath + "?tenant=tenant-a")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	defer resp.Body.Close()
+
+	var legacy struct {
+		URL             string  `json:"url"`
+		ProtocolVersion *string `json:"protocolVersion"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&legacy))
+	assert.Equal(t, "https://tenant.example.com/", legacy.URL)
+	require.NotNil(t, legacy.ProtocolVersion)
+	assert.Equal(t, v0.Version, *legacy.ProtocolVersion)
+}
+
+func TestCompatHandler_DoesNotMutateSignedAgentCard(t *testing.T) {
+	card := AgentCard{
+		Name:        "signed agent",
+		Description: "signed agent",
+		Version:     "1.0.0",
+		SupportedInterfaces: []protocol.AgentInterface{{
+			URL:             "https://agent.example.com/a2a",
+			ProtocolBinding: "JSONRPC",
+			ProtocolVersion: protocol.ProtocolVersionV1,
+		}},
+		Signatures: []protocol.AgentCardSignature{{
+			Protected: "protected",
+			Signature: "signature",
+		}},
+	}
+	tm := newMockTaskManager()
+	srv, err := NewA2AServer(tm,
+		WithAgentCard(card),
+		WithCompatHandler(v0.NewJSONRPCHandler(tm)),
+	)
+	require.NoError(t, err)
+
+	resolved, ok := srv.resolveAgentCard(context.Background(), "")
+	require.True(t, ok)
+	assert.Empty(t, resolved.URL)
+	assert.Nil(t, resolved.ProtocolVersion)
+	assert.Equal(t, card.Signatures, resolved.Signatures)
+}
+
+func TestCompatHandler_DoesNotMutateSignedTenantAgentCard(t *testing.T) {
+	card := AgentCard{
+		Name:        "signed tenant agent",
+		Description: "signed tenant agent",
+		Version:     "1.0.0",
+		SupportedInterfaces: []protocol.AgentInterface{{
+			URL:             "https://tenant.example.com/",
+			ProtocolBinding: "JSONRPC",
+			ProtocolVersion: protocol.ProtocolVersionV1,
+		}},
+		Signatures: []protocol.AgentCardSignature{{
+			Protected: "protected",
+			Signature: "signature",
+		}},
+	}
+	tm := newMockTaskManager()
+	srv, err := NewA2AServer(tm,
+		WithTenantCard("tenant-a", card),
+		WithCompatHandler(v0.NewJSONRPCHandler(tm)),
+	)
+	require.NoError(t, err)
+
+	resolved, ok := srv.resolveAgentCard(context.Background(), "tenant-a")
+	require.True(t, ok)
+	assert.Empty(t, resolved.SupportedInterfaces[0].Tenant)
+	assert.Empty(t, card.SupportedInterfaces[0].Tenant)
+	assert.Equal(t, card.Signatures, resolved.Signatures)
+}
+
+func TestCompatHandler_CORS(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		enabled bool
+		want    string
+	}{
+		{name: "enabled", enabled: true, want: "*"},
+		{name: "disabled", enabled: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			compat := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+			srv, err := NewA2AServer(newMockTaskManager(),
+				WithAgentCard(defaultAgentCard()),
+				WithCORSEnabled(tc.enabled),
+				WithCompatHandler(compat),
+			)
+			require.NoError(t, err)
+			ts := httptest.NewServer(srv.Handler())
+			defer ts.Close()
+
+			resp, err := ts.Client().Post(ts.URL, "application/json", bytes.NewBufferString(
+				`{"jsonrpc":"2.0","id":"1","method":"message/send","params":{}}`,
+			))
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			assert.Equal(t, tc.want, resp.Header.Get("Access-Control-Allow-Origin"))
+		})
+	}
+}

--- a/server/options.go
+++ b/server/options.go
@@ -74,6 +74,11 @@ func WithJSONRPCEndpoint(path string) Option {
 func WithCompatHandler(h http.Handler) Option {
 	return func(s *A2AServer) {
 		s.compatHandler = h
+		if adapter, ok := h.(interface {
+			AdaptAgentCard(*protocol.AgentCard)
+		}); ok {
+			s.compatAgentCardAdapter = adapter.AdaptAgentCard
+		}
 	}
 }
 
@@ -89,7 +94,10 @@ func WithAgentCard(card AgentCard) Option {
 	return func(s *A2AServer) {
 		// Ensure the served card carries a v1.0-conformant supportedInterfaces list,
 		// deriving it from the deprecated URL/PreferredTransport fields when needed.
-		card.NormalizeInterfaces()
+		// Signed cards must already have their final wire shape.
+		if len(card.Signatures) == 0 {
+			card.NormalizeInterfaces()
+		}
 		s.agentCard = card
 		s.agentCardSet = true
 	}
@@ -106,10 +114,13 @@ func WithTenantCard(tenant string, card AgentCard) Option {
 		if s.tenantCards == nil {
 			s.tenantCards = make(map[string]AgentCard)
 		}
-		card.NormalizeInterfaces()
-		// Stamp the tenant onto the card's interfaces so clients see who to address.
-		for i := range card.SupportedInterfaces {
-			card.SupportedInterfaces[i].Tenant = tenant
+		// Signed cards must already have their final wire shape.
+		if len(card.Signatures) == 0 {
+			card.NormalizeInterfaces()
+			// Stamp the tenant onto the card's interfaces so clients see who to address.
+			for i := range card.SupportedInterfaces {
+				card.SupportedInterfaces[i].Tenant = tenant
+			}
 		}
 		s.tenantCards[tenant] = card
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -65,6 +65,9 @@ type A2AServer struct {
 	// on the same endpoint and INSIDE the authentication middleware chain, so
 	// the legacy protocol path is authenticated exactly like the v1 path.
 	compatHandler http.Handler
+	// compatAgentCardAdapter fills legacy discovery fields on unsigned card
+	// copies when the installed compatibility handler supports that capability.
+	compatAgentCardAdapter func(*protocol.AgentCard)
 
 	// Authentication related fields
 	middleWare        []Middleware // Authentication middlewares.
@@ -381,6 +384,9 @@ func (s *A2AServer) dispatchByProtocol(v1Handler, legacyHandler http.Handler) ht
 			Method string `json:"method"`
 		}
 		if json.Unmarshal(body, &probe) == nil && strings.Contains(probe.Method, "/") {
+			if s.corsEnabled {
+				setCORSHeaders(w)
+			}
 			legacyHandler.ServeHTTP(w, r)
 			return
 		}
@@ -427,6 +433,21 @@ func (s *A2AServer) finalizePushCapability(card AgentCard) AgentCard {
 	return card
 }
 
+// finalizeAgentCard applies serving-time derived fields to an AgentCard copy.
+// Signed cards remain immutable because changing either v1 or legacy fields
+// would invalidate their JWS.
+func (s *A2AServer) finalizeAgentCard(card AgentCard) AgentCard {
+	if len(card.Signatures) > 0 {
+		return card
+	}
+	card.NormalizeInterfaces()
+	card = s.finalizePushCapability(card)
+	if s.compatAgentCardAdapter != nil {
+		s.compatAgentCardAdapter(&card)
+	}
+	return card
+}
+
 // resolveAgentCard returns the AgentCard for the given tenant (from "?tenant=").
 // The bool reports whether a card was found: a successful lookup returns
 // (card, true), while a missing default or unknown tenant returns (AgentCard{},
@@ -438,17 +459,17 @@ func (s *A2AServer) resolveAgentCard(ctx context.Context, tenant string) (AgentC
 		if !s.agentCardSet {
 			return AgentCard{}, false
 		}
-		return s.finalizePushCapability(s.agentCard), true
+		return s.finalizeAgentCard(s.agentCard), true
 	}
 	if c, ok := s.tenantCards[tenant]; ok {
-		return s.finalizePushCapability(c), true
+		return s.finalizeAgentCard(c), true
 	}
 	if s.tenantCardProvider != nil {
 		c, err := s.tenantCardProvider(ctx, tenant)
 		if err != nil {
 			return AgentCard{}, false
 		}
-		return s.finalizePushCapability(c), true
+		return s.finalizeAgentCard(c), true
 	}
 	if len(s.tenantCards) > 0 {
 		// Multi-tenant server, but no such tenant.
@@ -458,7 +479,7 @@ func (s *A2AServer) resolveAgentCard(ctx context.Context, tenant string) (AgentC
 	if !s.agentCardSet {
 		return AgentCard{}, false
 	}
-	return s.finalizePushCapability(s.agentCard), true
+	return s.finalizeAgentCard(s.agentCard), true
 }
 
 func (s *A2AServer) pushAvailableForTenant(ctx context.Context, tenant string) bool {


### PR DESCRIPTION
## Summary

- preserve the v0.2.x default of returning no task history when `historyLength` is omitted
- serve unsigned Agent Cards with both v1.0 and legacy discovery fields when `compat/v0` is mounted, while leaving signed cards immutable
- accept both authenticated extended-card method names used across v0.2.0-v0.2.5
- apply configured CORS headers to legacy JSON-RPC responses
- document the supported core-task compatibility boundary and add regression coverage

## Compatibility scope

This keeps unmodified v0.2.x clients working for task send, streaming, query, cancellation, and resubscription against a v2 server using memory or Redis.

Signed Agent Cards must contain both v1.0 and v0.2.x fields before signing. Automatic push callback payload translation remains outside this adapter.

## Validation

- `GOTOOLCHAIN=go1.20.14 GOWORK=off go test ./compat/v0 ./server`
- `GOWORK=off go build ./...`
- `GOWORK=off go test ./...`
- `GOWORK=off go test ./...` in `examples` and `examples/multi`
- Redis module build and tests against the local root module
- `GOWORK=off go mod tidy -diff` for all modules
- `golangci-lint run --skip-files=.*_test.go`
- `typos`
- real-client matrix using v0.2.0 through v0.2.5 for blocking send, task query, and streaming
