### PR TITLE
compat/v0: add request-bound default blocking option

### DIFF
--- a/compat/v0/jsonrpc_server.go
+++ b/compat/v0/jsonrpc_server.go
@@ -54,7 +54,8 @@ const (
 // results are translated back to the legacy wire format. The task manager
 // never sees v0 types.
 type Handler struct {
-	tm taskmanager.TaskManager
+	tm              taskmanager.TaskManager
+	defaultBlocking bool
 	// extendedCardGetter optionally serves agent/getAuthenticatedExtendedCard.
 	extendedCardGetter func(ctx context.Context) (*protocol.AgentCard, error)
 }
@@ -67,6 +68,16 @@ type HandlerOption func(*Handler)
 // automatically so old clients can parse it).
 func WithExtendedAgentCard(getter func(ctx context.Context) (*protocol.AgentCard, error)) HandlerOption {
 	return func(h *Handler) { h.extendedCardGetter = getter }
+}
+
+// WithDefaultBlocking treats message/send requests with an omitted blocking
+// field as blocking. An explicit blocking=false remains non-blocking.
+//
+// This is useful for request-bound TaskManagers that cannot continue reliable
+// execution after the HTTP response ends. It intentionally overrides the
+// legacy v0.2.x default only when the client did not make an explicit choice.
+func WithDefaultBlocking() HandlerOption {
+	return func(h *Handler) { h.defaultBlocking = true }
 }
 
 // NewJSONRPCHandler creates a legacy-protocol handler backed by the given v1
@@ -136,6 +147,14 @@ func (h *Handler) handleMessageSend(ctx context.Context, w http.ResponseWriter, 
 	if err := json.Unmarshal(req.Params, &params); err != nil {
 		writeError(w, req.ID, jsonrpc.ErrInvalidParams(fmt.Sprintf("failed to parse params: %v", err)))
 		return
+	}
+	if h.defaultBlocking &&
+		(params.Configuration == nil || params.Configuration.Blocking == nil) {
+		blocking := true
+		if params.Configuration == nil {
+			params.Configuration = &SendMessageConfiguration{}
+		}
+		params.Configuration.Blocking = &blocking
 	}
 	resp, err := h.tm.OnSendMessage(ctx, ToV1SendMessageParams(params))
 	if err != nil {

--- a/compat/v0/jsonrpc_server_test.go
+++ b/compat/v0/jsonrpc_server_test.go
@@ -162,6 +162,72 @@ func TestHandler_MessageSend_LegacyWire(t *testing.T) {
 	assert.Equal(t, "hi from v1 core", part["text"])
 }
 
+func TestHandler_MessageSend_DefaultBlocking(t *testing.T) {
+	tests := []struct {
+		name              string
+		option            HandlerOption
+		configurationJSON string
+		wantBlocking      bool
+	}{
+		{
+			name:              "legacy default remains non-blocking",
+			configurationJSON: "",
+		},
+		{
+			name:              "option adapts omitted configuration",
+			option:            WithDefaultBlocking(),
+			configurationJSON: "",
+			wantBlocking:      true,
+		},
+		{
+			name:              "option adapts omitted blocking field",
+			option:            WithDefaultBlocking(),
+			configurationJSON: `,"configuration":{}`,
+			wantBlocking:      true,
+		},
+		{
+			name:              "option preserves explicit false",
+			option:            WithDefaultBlocking(),
+			configurationJSON: `,"configuration":{"blocking":false}`,
+		},
+		{
+			name:              "option preserves explicit true",
+			option:            WithDefaultBlocking(),
+			configurationJSON: `,"configuration":{"blocking":true}`,
+			wantBlocking:      true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			agentMsg := protocol.NewMessage(
+				protocol.MessageRoleAgent,
+				[]*protocol.Part{protocol.NewTextPart("done")},
+			)
+			fake := &fakeTaskManager{
+				sendResponse: protocol.NewSendMessageResponseMessage(&agentMsg),
+			}
+			var opts []HandlerOption
+			if test.option != nil {
+				opts = append(opts, test.option)
+			}
+			h := NewJSONRPCHandler(fake, opts...)
+			w := postJSON(t, h, `{
+				"jsonrpc":"2.0","id":"req-default","method":"message/send",
+				"params":{
+					"message":{"kind":"message","messageId":"m1","role":"user",
+						"parts":[{"kind":"text","text":"hello"}]}
+					`+test.configurationJSON+`
+				}
+			}`)
+			require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+			require.NotNil(t, fake.gotSendParams)
+			require.NotNil(t, fake.gotSendParams.Configuration)
+			assert.Equal(t, test.wantBlocking, fake.gotSendParams.Configuration.IsBlocking())
+		})
+	}
+}
+
 func TestHandler_TasksGet_LegacyWire(t *testing.T) {
 	fake := &fakeTaskManager{
 		task: &protocol.Task{


### PR DESCRIPTION
## Summary

- add `compat/v0.WithDefaultBlocking`
- treat an omitted legacy `message/send` blocking field as blocking when the
  option is enabled
- preserve explicit `blocking=false` and `blocking=true`

## Why

Legacy v0.2.x clients default `message/send` to non-blocking execution.
Request-bound TaskManagers cannot continue reliable execution after the HTTP
response ends, so an unchanged legacy client otherwise fails unless every
caller starts setting `blocking=true`.

The behavior is opt-in on the compatibility handler. The standalone conversion
helpers keep the original v0.2.x semantics.

## Checks

- `go test ./...`
- `go vet ./compat/v0`
- `golangci-lint run --timeout=10m ./compat/v0/...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to make `message/send` requests blocking by default when no blocking preference is provided.
  - Explicit `blocking=false` settings continue to be honored.
  - Requests without configuration data are handled automatically when applying the default.

- **Tests**
  - Added coverage for omitted configuration, omitted blocking settings, and explicit `true` or `false` values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->