### PR TITLE
trpc-a2a-go: support the HTTP+JSON protocol binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### HTTP+JSON protocol binding
+
+- **The v2 client and server now implement the A2A v1.0 HTTP+JSON/REST binding.** It uses the standard operation routes, `application/a2a+json` request and response bodies, direct protocol objects instead of JSON-RPC envelopes, raw `StreamResponse` SSE data, and `google.rpc.Status` JSON errors. JSON-RPC remains the default for direct client construction and continues to use `application/json`.
+- `client.WithProtocolBinding` selects a direct endpoint binding, while `client.NewA2AClientFromAgentCard` follows the ordered `supportedInterfaces` list without mutating signed cards. `server.WithHTTPJSONEndpoint` explicitly enables and locates the REST binding; a static Agent Card that advertises `HTTP+JSON` also enables it automatically.
+- **TaskManager errors are now binding-neutral.** `taskmanager.Error` and semantic `ErrorCode` values replace the leaked internal JSON-RPC error representation so JSON-RPC and HTTP+JSON adapters can map the same failure independently. This is an intentional prerelease API change.
+
 ## 2.0.0-alpha.3 (2026-07-22)
 
 This prerelease adds request-scoped stateless execution and restores Redis

--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ go run main.go -host localhost:9000
 go run main.go -stream
 ```
 
+The v2 server supports both A2A v1.0 HTTP bindings. JSON-RPC uses `application/json`; HTTP+JSON uses the standard REST routes and `application/a2a+json`. A direct client defaults to JSON-RPC, while Agent Card construction follows the ordered `supportedInterfaces` list:
+
+```go
+restClient, _ := client.NewA2AClient(endpoint,
+	client.WithProtocolBinding(protocol.ProtocolBindingHTTPJSON))
+
+card, _ := discoveryClient.GetAgentCard(ctx, "")
+selectedClient, _ := client.NewA2AClientFromAgentCard(card)
+```
+
 ## Documentation
 
 The [docs/](docs/mkdocs/en/index.md) directory covers the protocol and the

--- a/README_zh.md
+++ b/README_zh.md
@@ -60,6 +60,16 @@ go run main.go -host localhost:9000
 go run main.go -stream
 ```
 
+v2 server 支持 A2A v1.0 的两种 HTTP binding。JSON-RPC 使用 `application/json`；HTTP+JSON 使用标准 REST 路由与 `application/a2a+json`。直接通过 endpoint 创建的 client 默认使用 JSON-RPC；从 Agent Card 创建时，client 会按有序的 `supportedInterfaces` 选择第一个兼容 binding：
+
+```go
+restClient, _ := client.NewA2AClient(endpoint,
+	client.WithProtocolBinding(protocol.ProtocolBindingHTTPJSON))
+
+card, _ := discoveryClient.GetAgentCard(ctx, "")
+selectedClient, _ := client.NewA2AClientFromAgentCard(card)
+```
+
 ## 文档
 
 [docs/](docs/mkdocs/en/index.md) 目录深入讲解了协议与框架（英文，以及 [中文](docs/mkdocs/zh/index.md)）：

--- a/client/binding.go
+++ b/client/binding.go
@@ -1,0 +1,144 @@
+// Tencent is pleased to support the open source community by making trpc-a2a-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-a2a-go is licensed under the Apache License Version 2.0.
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-a2a-go/v2/internal/jsonrpc"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
+)
+
+type clientBinding interface {
+	request(
+		ctx context.Context,
+		client *A2AClient,
+		id string,
+		method string,
+		params any,
+		result any,
+		opts ...RequestOption,
+	) error
+	stream(
+		ctx context.Context,
+		client *A2AClient,
+		id string,
+		method string,
+		params any,
+		opts ...RequestOption,
+	) (*http.Response, error)
+	decodeSSEData(data []byte) ([]byte, error)
+}
+
+type jsonRPCBinding struct{}
+
+type extendedCardParams struct {
+	Tenant string `json:"tenant,omitempty"`
+}
+
+func (jsonRPCBinding) request(
+	ctx context.Context,
+	client *A2AClient,
+	id string,
+	method string,
+	params any,
+	result any,
+	opts ...RequestOption,
+) error {
+	request := jsonrpc.NewRequest(method, id)
+	if extended, ok := params.(extendedCardParams); ok && extended.Tenant == "" {
+		params = nil
+	}
+	if params != nil {
+		paramsBytes, err := json.Marshal(params)
+		if err != nil {
+			return fmt.Errorf("failed to marshal params: %w", err)
+		}
+		request.Params = paramsBytes
+	}
+	response, err := client.doRequest(ctx, request, opts...)
+	if err != nil {
+		return err
+	}
+	if response.Error != nil {
+		return response.Error
+	}
+	if result == nil {
+		return nil
+	}
+	if len(response.Result) == 0 {
+		return fmt.Errorf("rpc response missing required 'result' field for id %v", request.ID)
+	}
+	if err := json.Unmarshal(response.Result, result); err != nil {
+		return fmt.Errorf("failed to unmarshal rpc result: %w. Raw result: %s", err, response.Result)
+	}
+	return nil
+}
+
+func (jsonRPCBinding) stream(
+	ctx context.Context,
+	client *A2AClient,
+	id string,
+	method string,
+	params any,
+	opts ...RequestOption,
+) (*http.Response, error) {
+	paramsBytes, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal params: %w", err)
+	}
+	return client.sendA2AStreamRequest(ctx, id, method, paramsBytes, opts...)
+}
+
+func (jsonRPCBinding) decodeSSEData(data []byte) ([]byte, error) {
+	var response jsonrpc.RawResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to decode JSON-RPC SSE response: %w", err)
+	}
+	// Older servers emitted the StreamResponse directly even on the JSON-RPC
+	// binding. Preserve that existing client tolerance while new HTTP+JSON
+	// requests use the raw form deliberately.
+	if response.JSONRPC == "" {
+		return data, nil
+	}
+	if response.JSONRPC != jsonrpc.Version {
+		return nil, fmt.Errorf("invalid JSON-RPC SSE response version %q", response.JSONRPC)
+	}
+	if response.Error != nil {
+		return nil, response.Error
+	}
+	if len(response.Result) == 0 {
+		return nil, fmt.Errorf("JSON-RPC SSE response is missing result")
+	}
+	return response.Result, nil
+}
+
+func clientBindingForName(name string) (string, clientBinding, error) {
+	switch {
+	case strings.EqualFold(name, protocol.ProtocolBindingJSONRPC):
+		return protocol.ProtocolBindingJSONRPC, jsonRPCBinding{}, nil
+	case strings.EqualFold(name, protocol.ProtocolBindingHTTPJSON):
+		return protocol.ProtocolBindingHTTPJSON, httpJSONBinding{}, nil
+	default:
+		return "", nil, fmt.Errorf("unsupported A2A protocol binding %q", name)
+	}
+}
+
+func (c *A2AClient) applySelectedTenant(tenant *string) error {
+	if c.tenant == "" {
+		return nil
+	}
+	if *tenant != "" && *tenant != c.tenant {
+		return fmt.Errorf("request tenant %q does not match selected AgentInterface tenant %q", *tenant, c.tenant)
+	}
+	*tenant = c.tenant
+	return nil
+}

--- a/client/client.go
+++ b/client/client.go
@@ -33,14 +33,18 @@ const (
 	defaultUserAgent = "trpc-a2a-go-client/0.1"
 )
 
-// A2AClient provides methods to interact with an A2A agent server.
-// It handles making HTTP requests and encoding/decoding JSON-RPC messages.
+// A2AClient provides methods to interact with an A2A agent server over the
+// JSON-RPC or HTTP+JSON protocol binding.
 type A2AClient struct {
-	baseURL        *url.URL            // Parsed base URL of the agent server.
-	httpClient     *http.Client        // Underlying HTTP client.
-	userAgent      string              // User-Agent header string.
-	authProvider   auth.ClientProvider // Authentication provider.
-	httpReqHandler HTTPReqHandler      // Custom HTTP request handler.
+	baseURL         *url.URL            // Parsed base URL of the agent server.
+	httpClient      *http.Client        // Underlying HTTP client.
+	userAgent       string              // User-Agent header string.
+	authProvider    auth.ClientProvider // Authentication provider.
+	httpReqHandler  HTTPReqHandler      // Custom HTTP request handler.
+	protocolBinding string
+	binding         clientBinding
+	bindingExplicit bool
+	tenant          string
 
 	maxBufSize     int
 	initialBufSize int
@@ -52,10 +56,7 @@ type A2AClient struct {
 // Options can be provided to configure the client, such as setting a custom http.Client or timeout.
 // Returns an error if the agentURL is invalid.
 func NewA2AClient(agentURL string, opts ...Option) (*A2AClient, error) {
-	if !strings.HasSuffix(agentURL, "/") {
-		agentURL += "/" // Ensure base URL ends with a slash for correct path joining.
-	}
-	parsedURL, err := url.ParseRequestURI(agentURL)
+	parsedURL, err := parseAgentURL(agentURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid agent URL %q: %w", agentURL, err)
 	}
@@ -64,17 +65,85 @@ func NewA2AClient(agentURL string, opts ...Option) (*A2AClient, error) {
 		httpClient: &http.Client{
 			Timeout: defaultTimeout,
 		},
-		userAgent:      defaultUserAgent,
-		httpReqHandler: &httpRequestHandler{},
-		initialBufSize: 4096,
-		maxBufSize:     bufio.MaxScanTokenSize * 10,
-		channelSize:    1024,
+		userAgent:       defaultUserAgent,
+		httpReqHandler:  &httpRequestHandler{},
+		protocolBinding: protocol.ProtocolBindingJSONRPC,
+		binding:         jsonRPCBinding{},
+		initialBufSize:  4096,
+		maxBufSize:      bufio.MaxScanTokenSize * 10,
+		channelSize:     1024,
 	}
 	// Apply functional options.
 	for _, opt := range opts {
 		opt(client)
 	}
+	canonicalBinding, binding, err := clientBindingForName(client.protocolBinding)
+	if err != nil {
+		return nil, err
+	}
+	client.protocolBinding = canonicalBinding
+	client.binding = binding
 	return client, nil
+}
+
+// NewA2AClientFromAgentCard creates a client from the first compatible entry
+// in AgentCard.SupportedInterfaces. The card is inspected without mutation so
+// signed Agent Cards remain safe to verify after client construction.
+func NewA2AClientFromAgentCard(card *protocol.AgentCard, opts ...Option) (*A2AClient, error) {
+	if card == nil {
+		return nil, fmt.Errorf("agent card is nil")
+	}
+	client, err := NewA2AClient("http://a2a.invalid/", opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	interfaces := card.SupportedInterfaces
+	if len(interfaces) == 0 && card.URL != "" {
+		binding := protocol.ProtocolBindingJSONRPC
+		if card.PreferredTransport != nil && *card.PreferredTransport != "" {
+			binding = *card.PreferredTransport
+		}
+		interfaces = append([]protocol.AgentInterface{{
+			URL:             card.URL,
+			ProtocolBinding: binding,
+			ProtocolVersion: protocol.ProtocolVersionV1,
+		}}, card.AdditionalInterfaces...)
+	}
+
+	for _, iface := range interfaces {
+		if iface.URL == "" || (iface.ProtocolVersion != "" && iface.ProtocolVersion != protocol.ProtocolVersionV1) {
+			continue
+		}
+		canonicalBinding, binding, bindErr := clientBindingForName(iface.ProtocolBinding)
+		if bindErr != nil {
+			continue
+		}
+		if client.bindingExplicit && canonicalBinding != client.protocolBinding {
+			continue
+		}
+		parsedURL, parseErr := parseAgentURL(iface.URL)
+		if parseErr != nil {
+			return nil, fmt.Errorf("invalid URL for AgentInterface %s: %w", iface.ProtocolBinding, parseErr)
+		}
+		client.baseURL = parsedURL
+		client.protocolBinding = canonicalBinding
+		client.binding = binding
+		client.tenant = iface.Tenant
+		return client, nil
+	}
+	return nil, fmt.Errorf("agent card has no compatible A2A v1.0 JSONRPC or HTTP+JSON interface")
+}
+
+func parseAgentURL(agentURL string) (*url.URL, error) {
+	if !strings.HasSuffix(agentURL, "/") {
+		agentURL += "/"
+	}
+	parsedURL, err := url.ParseRequestURI(agentURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid agent URL %q: %w", agentURL, err)
+	}
+	return parsedURL, nil
 }
 
 // SendMessage sends a message using the message/send method.
@@ -83,32 +152,26 @@ func (c *A2AClient) SendMessage(
 	params protocol.SendMessageParams,
 	opts ...RequestOption,
 ) (*protocol.SendMessageResponse, error) {
-	request := jsonrpc.NewRequest(protocol.MethodMessageSend, params.RPCID)
-	paramsBytes, err := json.Marshal(params)
-	if err != nil {
-		return nil, fmt.Errorf("a2aClient.SendMessage: failed to marshal params: %w", err)
-	}
-	request.Params = paramsBytes
-	message, err := c.doRequestAndDecodeMessage(ctx, request, opts...)
-	if err != nil {
+	if err := c.applySelectedTenant(&params.Tenant); err != nil {
 		return nil, fmt.Errorf("a2aClient.SendMessage: %w", err)
 	}
-	return message, nil
+	result := &protocol.SendMessageResponse{}
+	if err := c.binding.request(ctx, c, params.RPCID, protocol.MethodMessageSend, params, result, opts...); err != nil {
+		return nil, fmt.Errorf("a2aClient.SendMessage: %w", err)
+	}
+	return result, nil
 }
 
 // GetTasks retrieves the status of a task using the tasks_get method.
 func (c *A2AClient) GetTasks(ctx context.Context, params protocol.TaskQueryParams, opts ...RequestOption) (*protocol.Task, error) {
-	request := jsonrpc.NewRequest(protocol.MethodTasksGet, params.RPCID)
-	paramsBytes, err := json.Marshal(params)
-	if err != nil {
-		return nil, fmt.Errorf("a2aClient.GetTasks: failed to marshal params: %w", err)
-	}
-	request.Params = paramsBytes
-	task, err := c.doRequestAndDecodeTask(ctx, request, opts...)
-	if err != nil {
+	if err := c.applySelectedTenant(&params.Tenant); err != nil {
 		return nil, fmt.Errorf("a2aClient.GetTasks: %w", err)
 	}
-	return task, nil
+	result := &protocol.Task{}
+	if err := c.binding.request(ctx, c, params.RPCID, protocol.MethodTasksGet, params, result, opts...); err != nil {
+		return nil, fmt.Errorf("a2aClient.GetTasks: %w", err)
+	}
+	return result, nil
 }
 
 // ListTasks lists tasks using the v1.0 ListTasks method, with optional
@@ -118,25 +181,12 @@ func (c *A2AClient) ListTasks(
 	params protocol.ListTasksParams,
 	opts ...RequestOption,
 ) (*protocol.ListTasksResult, error) {
-	request := jsonrpc.NewRequest(protocol.MethodTasksList, params.RPCID)
-	paramsBytes, err := json.Marshal(params)
-	if err != nil {
-		return nil, fmt.Errorf("a2aClient.ListTasks: failed to marshal params: %w", err)
-	}
-	request.Params = paramsBytes
-	fullResponse, err := c.doRequest(ctx, request, opts...)
-	if err != nil {
+	if err := c.applySelectedTenant(&params.Tenant); err != nil {
 		return nil, fmt.Errorf("a2aClient.ListTasks: %w", err)
 	}
-	if fullResponse.Error != nil {
-		return nil, fullResponse.Error
-	}
-	if len(fullResponse.Result) == 0 {
-		return nil, fmt.Errorf("rpc response missing required 'result' field for id %v", request.ID)
-	}
 	result := &protocol.ListTasksResult{}
-	if err := json.Unmarshal(fullResponse.Result, result); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal list tasks result: %w", err)
+	if err := c.binding.request(ctx, c, params.RPCID, protocol.MethodTasksList, params, result, opts...); err != nil {
+		return nil, fmt.Errorf("a2aClient.ListTasks: %w", err)
 	}
 	return result, nil
 }
@@ -148,17 +198,14 @@ func (c *A2AClient) CancelTasks(
 	params protocol.TaskIDParams,
 	opts ...RequestOption,
 ) (*protocol.Task, error) {
-	request := jsonrpc.NewRequest(protocol.MethodTasksCancel, params.RPCID)
-	paramsBytes, err := json.Marshal(params)
-	if err != nil {
-		return nil, fmt.Errorf("a2aClient.CancelTasks: failed to marshal params: %w", err)
-	}
-	request.Params = paramsBytes
-	task, err := c.doRequestAndDecodeTask(ctx, request, opts...)
-	if err != nil {
+	if err := c.applySelectedTenant(&params.Tenant); err != nil {
 		return nil, fmt.Errorf("a2aClient.CancelTasks: %w", err)
 	}
-	return task, nil
+	result := &protocol.Task{}
+	if err := c.binding.request(ctx, c, params.RPCID, protocol.MethodTasksCancel, params, result, opts...); err != nil {
+		return nil, fmt.Errorf("a2aClient.CancelTasks: %w", err)
+	}
+	return result, nil
 }
 
 // ResubscribeTask sends a message using tasks/resubscribe and returns a channel for receiving SSE events.
@@ -169,12 +216,10 @@ func (c *A2AClient) ResubscribeTask(
 	params protocol.TaskIDParams,
 	opts ...RequestOption,
 ) (<-chan protocol.StreamResponse, error) {
-	// Create the JSON-RPC request.
-	paramsBytes, err := json.Marshal(params)
-	if err != nil {
-		return nil, fmt.Errorf("a2aClient.ResubscribeTask: failed to marshal params: %w", err)
+	if err := c.applySelectedTenant(&params.Tenant); err != nil {
+		return nil, fmt.Errorf("a2aClient.ResubscribeTask: %w", err)
 	}
-	resp, err := c.sendA2AStreamRequest(ctx, params.RPCID, protocol.MethodTasksResubscribe, paramsBytes, opts...)
+	resp, err := c.binding.stream(ctx, c, params.RPCID, protocol.MethodTasksResubscribe, params, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("a2aClient.ResubscribeTask: failed to build stream request: %w", err)
 	}
@@ -193,12 +238,10 @@ func (c *A2AClient) StreamMessage(
 	params protocol.SendMessageParams,
 	opts ...RequestOption,
 ) (<-chan protocol.StreamResponse, error) {
-	// Create the JSON-RPC request.
-	paramsBytes, err := json.Marshal(params)
-	if err != nil {
-		return nil, fmt.Errorf("a2aClient.StreamMessage: failed to marshal params: %w", err)
+	if err := c.applySelectedTenant(&params.Tenant); err != nil {
+		return nil, fmt.Errorf("a2aClient.StreamMessage: %w", err)
 	}
-	resp, err := c.sendA2AStreamRequest(ctx, params.RPCID, protocol.MethodMessageStream, paramsBytes, opts...)
+	resp, err := c.binding.stream(ctx, c, params.RPCID, protocol.MethodMessageStream, params, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("a2aClient.StreamMessage: failed to build stream request: %w", err)
 	}
@@ -229,8 +272,8 @@ func (c *A2AClient) sendA2AStreamRequest(ctx context.Context, id, method string,
 		return nil, fmt.Errorf("a2aClient.sendA2AStreamRequest: failed to create http request: %w", err)
 	}
 	// Set headers, including Accept for event stream.
-	req.Header.Set("Content-Type", "application/json; charset=utf-8")
-	req.Header.Set("Accept", "text/event-stream") // Crucial for SSE.
+	req.Header.Set("Content-Type", protocol.MediaTypeJSON+"; charset=utf-8")
+	req.Header.Set("Accept", protocol.MediaTypeEventStream) // Crucial for SSE.
 	req.Header.Set("A2A-Version", protocol.ProtocolVersionV1)
 	if c.userAgent != "" {
 		req.Header.Set("User-Agent", c.userAgent)
@@ -260,7 +303,7 @@ func (c *A2AClient) sendA2AStreamRequest(ctx context.Context, id, method string,
 		)
 	}
 	// Check if the response is actually an event stream.
-	if !strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream") {
+	if !strings.Contains(resp.Header.Get("Content-Type"), protocol.MediaTypeEventStream) {
 		resp.Body.Close()
 		return nil, fmt.Errorf(
 			"a2aClient.sendA2AStreamRequest: server did not respond with Content-Type 'text/event-stream', got %s",
@@ -321,20 +364,10 @@ func (c *A2AClient) processSSEStream(
 				return // Exit immediately, do not process any more events
 			}
 
-			// First, try to unmarshal as a JSON-RPC response
-			var jsonRPCResponse jsonrpc.RawResponse
-			jsonRPCErr := json.Unmarshal(eventBytes, &jsonRPCResponse)
-
-			// If this is a valid JSON-RPC response, extract the result for further processing
-			if jsonRPCErr == nil && jsonRPCResponse.JSONRPC == jsonrpc.Version {
-				log.Debugf("Received JSON-RPC wrapped event for request %s. Type: %s", reqID, eventType)
-				// Check for errors in the JSON-RPC response
-				if jsonRPCResponse.Error != nil {
-					log.Errorf("JSON-RPC error in SSE event for request %s: %v", reqID, jsonRPCResponse.Error)
-					continue // Skip events with JSON-RPC errors
-				}
-				// Use the result field directly for further processing
-				eventBytes = jsonRPCResponse.Result
+			eventBytes, err = c.binding.decodeSSEData(eventBytes)
+			if err != nil {
+				log.Errorf("Error decoding SSE event for request %s: %v", reqID, err)
+				continue
 			}
 
 			// Deserialize the event data based on the event type from SSE.
@@ -455,8 +488,8 @@ func (c *A2AClient) doRequest(ctx context.Context, request *jsonrpc.Request, opt
 		return nil, fmt.Errorf("a2aClient.doRequest: failed to create http request: %w", err)
 	}
 	// Set required headers.
-	req.Header.Set("Content-Type", "application/json; charset=utf-8")
-	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", protocol.MediaTypeJSON+"; charset=utf-8")
+	req.Header.Set("Accept", protocol.MediaTypeJSON)
 	req.Header.Set("A2A-Version", protocol.ProtocolVersionV1)
 	if c.userAgent != "" {
 		req.Header.Set("User-Agent", c.userAgent)
@@ -511,39 +544,16 @@ func (c *A2AClient) SetPushNotification(
 	params protocol.TaskPushNotificationConfig,
 	opts ...RequestOption,
 ) (*protocol.TaskPushNotificationConfig, error) {
-	request := jsonrpc.NewRequest(protocol.MethodTasksPushNotificationConfigSet, params.RPCID)
-	paramsBytes, err := json.Marshal(params)
-	if err != nil {
-		return nil, fmt.Errorf("a2aClient.SetPushNotification: failed to marshal params: %w", err)
-	}
-	request.Params = paramsBytes
-
-	// Perform the HTTP request and basic JSON unmarshaling
-	fullResponse, err := c.doRequest(ctx, request, opts...)
-	if err != nil {
+	if err := c.applySelectedTenant(&params.Tenant); err != nil {
 		return nil, fmt.Errorf("a2aClient.SetPushNotification: %w", err)
 	}
-
-	// Check for JSON-RPC level error included in the response
-	if fullResponse.Error != nil {
-		return nil, fullResponse.Error
+	result := &protocol.TaskPushNotificationConfig{}
+	if err := c.binding.request(
+		ctx, c, params.RPCID, protocol.MethodTasksPushNotificationConfigSet, params, result, opts...,
+	); err != nil {
+		return nil, fmt.Errorf("a2aClient.SetPushNotification: %w", err)
 	}
-
-	// Check if the result field is missing
-	if len(fullResponse.Result) == 0 {
-		return nil, fmt.Errorf("rpc response missing required 'result' field for id %v", request.ID)
-	}
-
-	// Unmarshal the result into a TaskPushNotificationConfig
-	config := &protocol.TaskPushNotificationConfig{}
-	if err := json.Unmarshal(fullResponse.Result, config); err != nil {
-		return nil, fmt.Errorf(
-			"failed to unmarshal push notification config: %w. Raw result: %s",
-			err, string(fullResponse.Result),
-		)
-	}
-
-	return config, nil
+	return result, nil
 }
 
 // GetPushNotification retrieves the push notification configuration for a task.
@@ -552,39 +562,16 @@ func (c *A2AClient) GetPushNotification(
 	params protocol.GetTaskPushNotificationConfigParams,
 	opts ...RequestOption,
 ) (*protocol.TaskPushNotificationConfig, error) {
-	request := jsonrpc.NewRequest(protocol.MethodTasksPushNotificationConfigGet, params.RPCID)
-	paramsBytes, err := json.Marshal(params)
-	if err != nil {
-		return nil, fmt.Errorf("a2aClient.GetPushNotification: failed to marshal params: %w", err)
-	}
-	request.Params = paramsBytes
-
-	// Perform the HTTP request and basic JSON unmarshaling
-	fullResponse, err := c.doRequest(ctx, request, opts...)
-	if err != nil {
+	if err := c.applySelectedTenant(&params.Tenant); err != nil {
 		return nil, fmt.Errorf("a2aClient.GetPushNotification: %w", err)
 	}
-
-	// Check for JSON-RPC level error included in the response
-	if fullResponse.Error != nil {
-		return nil, fullResponse.Error
+	result := &protocol.TaskPushNotificationConfig{}
+	if err := c.binding.request(
+		ctx, c, params.RPCID, protocol.MethodTasksPushNotificationConfigGet, params, result, opts...,
+	); err != nil {
+		return nil, fmt.Errorf("a2aClient.GetPushNotification: %w", err)
 	}
-
-	// Check if the result field is missing
-	if len(fullResponse.Result) == 0 {
-		return nil, fmt.Errorf("rpc response missing required 'result' field for id %v", request.ID)
-	}
-
-	// Unmarshal the result into a TaskPushNotificationConfig
-	config := &protocol.TaskPushNotificationConfig{}
-	if err := json.Unmarshal(fullResponse.Result, config); err != nil {
-		return nil, fmt.Errorf(
-			"failed to unmarshal push notification config: %w. Raw result: %s",
-			err, string(fullResponse.Result),
-		)
-	}
-
-	return config, nil
+	return result, nil
 }
 
 // ListPushNotifications lists the push notification configurations of a task
@@ -594,25 +581,14 @@ func (c *A2AClient) ListPushNotifications(
 	params protocol.ListTaskPushNotificationConfigsParams,
 	opts ...RequestOption,
 ) (*protocol.ListTaskPushNotificationConfigsResult, error) {
-	request := jsonrpc.NewRequest(protocol.MethodTasksPushNotificationConfigList, params.RPCID)
-	paramsBytes, err := json.Marshal(params)
-	if err != nil {
-		return nil, fmt.Errorf("a2aClient.ListPushNotifications: failed to marshal params: %w", err)
-	}
-	request.Params = paramsBytes
-	fullResponse, err := c.doRequest(ctx, request, opts...)
-	if err != nil {
+	if err := c.applySelectedTenant(&params.Tenant); err != nil {
 		return nil, fmt.Errorf("a2aClient.ListPushNotifications: %w", err)
 	}
-	if fullResponse.Error != nil {
-		return nil, fullResponse.Error
-	}
-	if len(fullResponse.Result) == 0 {
-		return nil, fmt.Errorf("rpc response missing required 'result' field for id %v", request.ID)
-	}
 	result := &protocol.ListTaskPushNotificationConfigsResult{}
-	if err := json.Unmarshal(fullResponse.Result, result); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal push notification config list: %w", err)
+	if err := c.binding.request(
+		ctx, c, params.RPCID, protocol.MethodTasksPushNotificationConfigList, params, result, opts...,
+	); err != nil {
+		return nil, fmt.Errorf("a2aClient.ListPushNotifications: %w", err)
 	}
 	return result, nil
 }
@@ -624,18 +600,13 @@ func (c *A2AClient) DeletePushNotification(
 	params protocol.DeleteTaskPushNotificationConfigParams,
 	opts ...RequestOption,
 ) error {
-	request := jsonrpc.NewRequest(protocol.MethodTasksPushNotificationConfigDelete, params.RPCID)
-	paramsBytes, err := json.Marshal(params)
-	if err != nil {
-		return fmt.Errorf("a2aClient.DeletePushNotification: failed to marshal params: %w", err)
-	}
-	request.Params = paramsBytes
-	fullResponse, err := c.doRequest(ctx, request, opts...)
-	if err != nil {
+	if err := c.applySelectedTenant(&params.Tenant); err != nil {
 		return fmt.Errorf("a2aClient.DeletePushNotification: %w", err)
 	}
-	if fullResponse.Error != nil {
-		return fullResponse.Error
+	if err := c.binding.request(
+		ctx, c, params.RPCID, protocol.MethodTasksPushNotificationConfigDelete, params, nil, opts...,
+	); err != nil {
+		return fmt.Errorf("a2aClient.DeletePushNotification: %w", err)
 	}
 	return nil
 }
@@ -718,7 +689,7 @@ func (c *A2AClient) getAgentCardFromURL(
 	}
 
 	// Set standard headers
-	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Accept", protocol.MediaTypeJSON)
 	req.Header.Set("User-Agent", c.userAgent)
 
 	// Apply custom headers from request options
@@ -763,22 +734,13 @@ func (c *A2AClient) getAgentCardFromURL(
 
 // GetAuthenticatedExtendedCard retrieves the extended agent card for authenticated users.
 func (c *A2AClient) GetAuthenticatedExtendedCard(ctx context.Context, opts ...RequestOption) (*server.AgentCard, error) {
-	request := jsonrpc.NewRequest(protocol.MethodAgentAuthenticatedExtendedCard, "")
-	fullResponse, err := c.doRequest(ctx, request, opts...)
-	if err != nil {
+	result := &server.AgentCard{}
+	if err := c.binding.request(
+		ctx, c, "", protocol.MethodAgentAuthenticatedExtendedCard, extendedCardParams{Tenant: c.tenant}, result, opts...,
+	); err != nil {
 		return nil, fmt.Errorf("a2aClient.GetExtendedCard: %w", err)
 	}
-	if fullResponse.Error != nil {
-		return nil, fullResponse.Error
-	}
-	if len(fullResponse.Result) == 0 {
-		return nil, fmt.Errorf("rpc response missing required 'result' field for id %v", request.ID)
-	}
-	extendedCard := &server.AgentCard{}
-	if err := json.Unmarshal(fullResponse.Result, extendedCard); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal extended card: %w. Raw result: %s", err, string(fullResponse.Result))
-	}
-	return extendedCard, nil
+	return result, nil
 }
 
 // httpRequestHandler is the HTTP request handler for a2a client.

--- a/client/http_json.go
+++ b/client/http_json.go
@@ -1,0 +1,390 @@
+// Tencent is pleased to support the open source community by making trpc-a2a-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-a2a-go is licensed under the Apache License Version 2.0.
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
+)
+
+type httpJSONBinding struct{}
+
+type httpJSONRequest struct {
+	method string
+	path   string
+	query  url.Values
+	body   any
+}
+
+func (httpJSONBinding) request(
+	ctx context.Context,
+	client *A2AClient,
+	_ string,
+	operation string,
+	params any,
+	result any,
+	opts ...RequestOption,
+) error {
+	spec, err := buildHTTPJSONRequest(operation, params)
+	if err != nil {
+		return err
+	}
+	req, err := client.newHTTPJSONRequest(ctx, spec, false, opts...)
+	if err != nil {
+		return err
+	}
+	resp, err := client.httpReqHandler.Handle(ctx, client.httpClient, req)
+	if err != nil {
+		return fmt.Errorf("HTTP+JSON request failed: %w", err)
+	}
+	if resp == nil || resp.Body == nil {
+		return fmt.Errorf("HTTP+JSON request returned an unexpected nil response")
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read HTTP+JSON response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return decodeHTTPJSONError(resp.StatusCode, body)
+	}
+	if resp.StatusCode == http.StatusNoContent || result == nil {
+		return nil
+	}
+	if err := validateHTTPJSONResponseType(resp.Header.Get("Content-Type")); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(body, result); err != nil {
+		return fmt.Errorf("failed to decode HTTP+JSON response: %w. Body: %s", err, body)
+	}
+	return nil
+}
+
+func (httpJSONBinding) stream(
+	ctx context.Context,
+	client *A2AClient,
+	_ string,
+	operation string,
+	params any,
+	opts ...RequestOption,
+) (*http.Response, error) {
+	spec, err := buildHTTPJSONRequest(operation, params)
+	if err != nil {
+		return nil, err
+	}
+	req, err := client.newHTTPJSONRequest(ctx, spec, true, opts...)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.httpReqHandler.Handle(ctx, client.httpClient, req)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP+JSON stream request failed: %w", err)
+	}
+	if resp == nil || resp.Body == nil {
+		return nil, fmt.Errorf("HTTP+JSON stream request returned an unexpected nil response")
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return nil, decodeHTTPJSONError(resp.StatusCode, body)
+	}
+	mediaType, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+	if err != nil || mediaType != protocol.MediaTypeEventStream {
+		resp.Body.Close()
+		return nil, fmt.Errorf(
+			"server did not respond with Content-Type %q, got %q",
+			protocol.MediaTypeEventStream,
+			resp.Header.Get("Content-Type"),
+		)
+	}
+	return resp, nil
+}
+
+func (httpJSONBinding) decodeSSEData(data []byte) ([]byte, error) {
+	if len(bytes.TrimSpace(data)) == 0 {
+		return nil, fmt.Errorf("HTTP+JSON SSE event data is empty")
+	}
+	return data, nil
+}
+
+func buildHTTPJSONRequest(operation string, params any) (httpJSONRequest, error) {
+	switch operation {
+	case protocol.MethodMessageSend, protocol.MethodMessageStream:
+		p, ok := params.(protocol.SendMessageParams)
+		if !ok {
+			return httpJSONRequest{}, fmt.Errorf("invalid %s parameters %T", operation, params)
+		}
+		suffix := "/message:send"
+		if operation == protocol.MethodMessageStream {
+			suffix = "/message:stream"
+		}
+		return httpJSONRequest{
+			method: http.MethodPost,
+			path:   httpJSONPath(p.Tenant, suffix),
+			body:   p,
+		}, nil
+	case protocol.MethodTasksGet:
+		p, ok := params.(protocol.TaskQueryParams)
+		if !ok {
+			return httpJSONRequest{}, fmt.Errorf("invalid GetTask parameters %T", params)
+		}
+		if len(p.Metadata) != 0 {
+			return httpJSONRequest{}, taskmanager.ErrInvalidParams("GetTask metadata cannot be represented by the HTTP+JSON binding")
+		}
+		query := make(url.Values)
+		setOptionalIntQuery(query, "historyLength", p.HistoryLength)
+		return httpJSONRequest{
+			method: http.MethodGet,
+			path:   httpJSONPath(p.Tenant, "/tasks/"+url.PathEscape(p.ID)),
+			query:  query,
+		}, nil
+	case protocol.MethodTasksList:
+		p, ok := params.(protocol.ListTasksParams)
+		if !ok {
+			return httpJSONRequest{}, fmt.Errorf("invalid ListTasks parameters %T", params)
+		}
+		if len(p.Metadata) != 0 {
+			return httpJSONRequest{}, taskmanager.ErrInvalidParams("ListTasks metadata cannot be represented by the HTTP+JSON binding")
+		}
+		query := make(url.Values)
+		setQuery(query, "contextId", p.ContextID)
+		if p.Status != "" && p.Status != protocol.TaskStateUnspecified {
+			query.Set("status", string(p.Status))
+		}
+		setOptionalIntQuery(query, "pageSize", p.PageSize)
+		setQuery(query, "pageToken", p.PageToken)
+		setOptionalIntQuery(query, "historyLength", p.HistoryLength)
+		setQuery(query, "statusTimestampAfter", p.StatusTimestampAfter)
+		if p.IncludeArtifacts != nil {
+			query.Set("includeArtifacts", strconv.FormatBool(*p.IncludeArtifacts))
+		}
+		return httpJSONRequest{method: http.MethodGet, path: httpJSONPath(p.Tenant, "/tasks"), query: query}, nil
+	case protocol.MethodTasksCancel:
+		p, ok := params.(protocol.TaskIDParams)
+		if !ok {
+			return httpJSONRequest{}, fmt.Errorf("invalid CancelTask parameters %T", params)
+		}
+		return httpJSONRequest{
+			method: http.MethodPost,
+			path:   httpJSONPath(p.Tenant, "/tasks/"+url.PathEscape(p.ID)+":cancel"),
+			body:   p,
+		}, nil
+	case protocol.MethodTasksResubscribe:
+		p, ok := params.(protocol.TaskIDParams)
+		if !ok {
+			return httpJSONRequest{}, fmt.Errorf("invalid SubscribeToTask parameters %T", params)
+		}
+		if len(p.Metadata) != 0 {
+			return httpJSONRequest{}, taskmanager.ErrInvalidParams("SubscribeToTask metadata cannot be represented by the HTTP+JSON binding")
+		}
+		return httpJSONRequest{
+			method: http.MethodPost,
+			path:   httpJSONPath(p.Tenant, "/tasks/"+url.PathEscape(p.ID)+":subscribe"),
+		}, nil
+	case protocol.MethodTasksPushNotificationConfigSet:
+		p, ok := params.(protocol.TaskPushNotificationConfig)
+		if !ok {
+			return httpJSONRequest{}, fmt.Errorf("invalid CreateTaskPushNotificationConfig parameters %T", params)
+		}
+		return httpJSONRequest{
+			method: http.MethodPost,
+			path: httpJSONPath(
+				p.Tenant,
+				"/tasks/"+url.PathEscape(p.TaskID)+"/pushNotificationConfigs",
+			),
+			body: p,
+		}, nil
+	case protocol.MethodTasksPushNotificationConfigGet:
+		p, ok := params.(protocol.GetTaskPushNotificationConfigParams)
+		if !ok {
+			return httpJSONRequest{}, fmt.Errorf("invalid GetTaskPushNotificationConfig parameters %T", params)
+		}
+		return httpJSONRequest{
+			method: http.MethodGet,
+			path: httpJSONPath(
+				p.Tenant,
+				"/tasks/"+url.PathEscape(p.TaskID)+"/pushNotificationConfigs/"+url.PathEscape(p.ID),
+			),
+		}, nil
+	case protocol.MethodTasksPushNotificationConfigList:
+		p, ok := params.(protocol.ListTaskPushNotificationConfigsParams)
+		if !ok {
+			return httpJSONRequest{}, fmt.Errorf("invalid ListTaskPushNotificationConfigs parameters %T", params)
+		}
+		query := make(url.Values)
+		setOptionalIntQuery(query, "pageSize", p.PageSize)
+		setQuery(query, "pageToken", p.PageToken)
+		return httpJSONRequest{
+			method: http.MethodGet,
+			path: httpJSONPath(
+				p.Tenant,
+				"/tasks/"+url.PathEscape(p.TaskID)+"/pushNotificationConfigs",
+			),
+			query: query,
+		}, nil
+	case protocol.MethodTasksPushNotificationConfigDelete:
+		p, ok := params.(protocol.DeleteTaskPushNotificationConfigParams)
+		if !ok {
+			return httpJSONRequest{}, fmt.Errorf("invalid DeleteTaskPushNotificationConfig parameters %T", params)
+		}
+		return httpJSONRequest{
+			method: http.MethodDelete,
+			path: httpJSONPath(
+				p.Tenant,
+				"/tasks/"+url.PathEscape(p.TaskID)+"/pushNotificationConfigs/"+url.PathEscape(p.ID),
+			),
+		}, nil
+	case protocol.MethodAgentAuthenticatedExtendedCard:
+		p, _ := params.(extendedCardParams)
+		return httpJSONRequest{method: http.MethodGet, path: httpJSONPath(p.Tenant, "/extendedAgentCard")}, nil
+	default:
+		return httpJSONRequest{}, fmt.Errorf("HTTP+JSON operation %q is not supported", operation)
+	}
+}
+
+func httpJSONPath(tenant, suffix string) string {
+	if tenant == "" {
+		return suffix
+	}
+	return "/" + url.PathEscape(tenant) + suffix
+}
+
+func setQuery(query url.Values, name, value string) {
+	if value != "" {
+		query.Set(name, value)
+	}
+}
+
+func setOptionalIntQuery(query url.Values, name string, value *int) {
+	if value != nil {
+		query.Set(name, strconv.Itoa(*value))
+	}
+}
+
+func (c *A2AClient) newHTTPJSONRequest(
+	ctx context.Context,
+	spec httpJSONRequest,
+	stream bool,
+	opts ...RequestOption,
+) (*http.Request, error) {
+	var body io.Reader
+	if spec.body != nil {
+		encoded, err := json.Marshal(spec.body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal HTTP+JSON request: %w", err)
+		}
+		body = bytes.NewReader(encoded)
+	}
+	req, err := http.NewRequestWithContext(ctx, spec.method, c.httpJSONURL(spec.path, spec.query), body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP+JSON request: %w", err)
+	}
+	if spec.body != nil {
+		req.Header.Set("Content-Type", protocol.MediaTypeA2AJSON)
+	}
+	if stream {
+		req.Header.Set("Accept", protocol.MediaTypeEventStream)
+	} else {
+		req.Header.Set("Accept", protocol.MediaTypeA2AJSON+", "+protocol.MediaTypeJSON)
+	}
+	req.Header.Set("A2A-Version", protocol.ProtocolVersionV1)
+	if c.userAgent != "" {
+		req.Header.Set("User-Agent", c.userAgent)
+	}
+	cfg := &requestConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	for key, value := range cfg.headers {
+		req.Header.Set(key, value)
+	}
+	return req, nil
+}
+
+func (c *A2AClient) httpJSONURL(rawPath string, query url.Values) string {
+	target := *c.baseURL
+	basePath := strings.TrimRight(target.EscapedPath(), "/")
+	target.RawPath = basePath + rawPath
+	target.Path, _ = url.PathUnescape(target.RawPath)
+	target.RawQuery = query.Encode()
+	target.Fragment = ""
+	return target.String()
+}
+
+func validateHTTPJSONResponseType(contentType string) error {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil || (mediaType != protocol.MediaTypeA2AJSON && mediaType != protocol.MediaTypeJSON) {
+		return fmt.Errorf(
+			"unexpected HTTP+JSON response Content-Type %q; expected %s or %s",
+			contentType,
+			protocol.MediaTypeA2AJSON,
+			protocol.MediaTypeJSON,
+		)
+	}
+	return nil
+}
+
+func decodeHTTPJSONError(statusCode int, body []byte) error {
+	var response struct {
+		Error struct {
+			Code    int              `json:"code"`
+			Status  string           `json:"status"`
+			Message string           `json:"message"`
+			Details []map[string]any `json:"details"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil || response.Error.Message == "" {
+		return fmt.Errorf("HTTP+JSON request failed with status %d: %s", statusCode, body)
+	}
+	reason := ""
+	taskID := ""
+	for _, detail := range response.Error.Details {
+		if detail["@type"] != "type.googleapis.com/google.rpc.ErrorInfo" {
+			continue
+		}
+		reason, _ = detail["reason"].(string)
+		if metadata, ok := detail["metadata"].(map[string]any); ok {
+			taskID, _ = metadata["taskId"].(string)
+		}
+		break
+	}
+	switch taskmanager.ErrorCode(reason) {
+	case taskmanager.ErrCodeTaskNotFound:
+		return taskmanager.ErrTaskNotFound(taskID)
+	case taskmanager.ErrCodeTaskNotCancelable:
+		return taskmanager.ErrTaskNotCancelable(taskID, protocol.TaskStateUnspecified)
+	case taskmanager.ErrCodePushNotificationNotSupported:
+		return taskmanager.ErrPushNotificationNotSupported()
+	case taskmanager.ErrCodeUnsupportedOperation:
+		return taskmanager.ErrUnsupportedOperation(response.Error.Message)
+	case taskmanager.ErrCodeContentTypeNotSupported:
+		return taskmanager.ErrContentTypeNotSupported(response.Error.Message)
+	case taskmanager.ErrCodeInvalidAgentResponse:
+		return taskmanager.ErrInvalidAgentResponse(response.Error.Message)
+	case taskmanager.ErrCodeAuthenticatedExtendedCardNotConfigured:
+		return taskmanager.ErrAuthenticatedExtendedCardNotConfigured()
+	case taskmanager.ErrCodeExtensionSupportRequired:
+		return taskmanager.ErrExtensionSupportRequired(response.Error.Message)
+	case taskmanager.ErrCodeVersionNotSupported:
+		return taskmanager.ErrVersionNotSupported(response.Error.Message)
+	}
+	if statusCode >= 500 {
+		return taskmanager.ErrInternalError(response.Error.Message)
+	}
+	return taskmanager.ErrInvalidParams(response.Error.Message)
+}

--- a/client/http_json.go
+++ b/client/http_json.go
@@ -122,6 +122,7 @@ func (httpJSONBinding) decodeSSEData(data []byte) ([]byte, error) {
 	return data, nil
 }
 
+//nolint:gocyclo // Keeping the protocol operation-to-route mapping in one switch makes completeness auditable.
 func buildHTTPJSONRequest(operation string, params any) (httpJSONRequest, error) {
 	switch operation {
 	case protocol.MethodMessageSend, protocol.MethodMessageStream:

--- a/client/http_json_test.go
+++ b/client/http_json_test.go
@@ -9,9 +9,12 @@ package client
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
@@ -211,14 +214,317 @@ func TestBuildHTTPJSONRequestRoutes(t *testing.T) {
 	}
 }
 
-func TestDecodeHTTPJSONError(t *testing.T) {
-	body := []byte(`{"error":{"code":404,"status":"NOT_FOUND","message":"missing","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"TASK_NOT_FOUND","domain":"a2a-protocol.org","metadata":{"taskId":"task-1"}}]}}`)
-	err := decodeHTTPJSONError(http.StatusNotFound, body)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, taskmanager.ErrTaskNotFoundSentinel)
+func TestBuildHTTPJSONRequestErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		operation string
+		params    any
+	}{
+		{name: "send type", operation: protocol.MethodMessageSend, params: struct{}{}},
+		{name: "get type", operation: protocol.MethodTasksGet, params: struct{}{}},
+		{name: "get metadata", operation: protocol.MethodTasksGet, params: protocol.TaskQueryParams{Metadata: map[string]any{"key": "value"}}},
+		{name: "list type", operation: protocol.MethodTasksList, params: struct{}{}},
+		{name: "list metadata", operation: protocol.MethodTasksList, params: protocol.ListTasksParams{Metadata: map[string]any{"key": "value"}}},
+		{name: "cancel type", operation: protocol.MethodTasksCancel, params: struct{}{}},
+		{name: "subscribe type", operation: protocol.MethodTasksResubscribe, params: struct{}{}},
+		{name: "subscribe metadata", operation: protocol.MethodTasksResubscribe, params: protocol.TaskIDParams{Metadata: map[string]any{"key": "value"}}},
+		{name: "create push type", operation: protocol.MethodTasksPushNotificationConfigSet, params: struct{}{}},
+		{name: "get push type", operation: protocol.MethodTasksPushNotificationConfigGet, params: struct{}{}},
+		{name: "list push type", operation: protocol.MethodTasksPushNotificationConfigList, params: struct{}{}},
+		{name: "delete push type", operation: protocol.MethodTasksPushNotificationConfigDelete, params: struct{}{}},
+		{name: "unsupported", operation: "unsupported", params: struct{}{}},
+	}
 
-	body = []byte(`{"error":{"code":400,"status":"FAILED_PRECONDITION","message":"not cancelable","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"TASK_NOT_CANCELABLE","domain":"a2a-protocol.org","metadata":{"taskId":"task-1"}}]}}`)
-	err = decodeHTTPJSONError(http.StatusBadRequest, body)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := buildHTTPJSONRequest(tt.operation, tt.params)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestHTTPJSONBindingRequestValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		handle      func(context.Context, *http.Client, *http.Request) (*http.Response, error)
+		result      any
+		expectError string
+	}{
+		{
+			name: "handler error",
+			handle: func(context.Context, *http.Client, *http.Request) (*http.Response, error) {
+				return nil, errors.New("request failed")
+			},
+			expectError: "HTTP+JSON request failed",
+		},
+		{
+			name: "nil response",
+			handle: func(context.Context, *http.Client, *http.Request) (*http.Response, error) {
+				return nil, nil
+			},
+			expectError: "unexpected nil response",
+		},
+		{
+			name: "nil body",
+			handle: func(context.Context, *http.Client, *http.Request) (*http.Response, error) {
+				return &http.Response{StatusCode: http.StatusOK}, nil
+			},
+			expectError: "unexpected nil response",
+		},
+		{
+			name: "error response",
+			handle: func(context.Context, *http.Client, *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusBadRequest,
+					Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"bad request"}}`)),
+				}, nil
+			},
+			expectError: "Invalid params",
+		},
+		{
+			name: "no content",
+			handle: func(context.Context, *http.Client, *http.Request) (*http.Response, error) {
+				return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody}, nil
+			},
+		},
+		{
+			name: "nil result",
+			handle: func(context.Context, *http.Client, *http.Request) (*http.Response, error) {
+				return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+			},
+			result: nil,
+		},
+		{
+			name: "invalid content type",
+			handle: func(context.Context, *http.Client, *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{"text/plain"}},
+					Body:       io.NopCloser(strings.NewReader(`{}`)),
+				}, nil
+			},
+			result:      &map[string]any{},
+			expectError: "unexpected HTTP+JSON response Content-Type",
+		},
+		{
+			name: "invalid JSON",
+			handle: func(context.Context, *http.Client, *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{protocol.MediaTypeJSON}},
+					Body:       io.NopCloser(strings.NewReader(`{`)),
+				}, nil
+			},
+			result:      &map[string]any{},
+			expectError: "failed to decode HTTP+JSON response",
+		},
+		{
+			name: "success",
+			handle: func(context.Context, *http.Client, *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{protocol.MediaTypeA2AJSON + "; charset=utf-8"}},
+					Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+				}, nil
+			},
+			result: &map[string]any{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := NewA2AClient(
+				"https://example.com/a2a",
+				WithProtocolBinding(protocol.ProtocolBindingHTTPJSON),
+				WithHTTPReqHandler(&mockHTTPReqHandler{handleFunc: tt.handle}),
+			)
+			require.NoError(t, err)
+			result := tt.result
+			if result == nil && tt.name != "nil result" {
+				result = &map[string]any{}
+			}
+			err = httpJSONBinding{}.request(
+				context.Background(), client, "request-id", protocol.MethodMessageSend,
+				protocol.SendMessageParams{}, result,
+			)
+			if tt.expectError == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectError)
+		})
+	}
+}
+
+func TestHTTPJSONBindingStreamValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		handle      func(context.Context, *http.Client, *http.Request) (*http.Response, error)
+		expectError string
+	}{
+		{
+			name: "handler error",
+			handle: func(context.Context, *http.Client, *http.Request) (*http.Response, error) {
+				return nil, errors.New("stream failed")
+			},
+			expectError: "HTTP+JSON stream request failed",
+		},
+		{
+			name: "nil response",
+			handle: func(context.Context, *http.Client, *http.Request) (*http.Response, error) {
+				return nil, nil
+			},
+			expectError: "unexpected nil response",
+		},
+		{
+			name: "nil body",
+			handle: func(context.Context, *http.Client, *http.Request) (*http.Response, error) {
+				return &http.Response{StatusCode: http.StatusOK}, nil
+			},
+			expectError: "unexpected nil response",
+		},
+		{
+			name: "error response",
+			handle: func(context.Context, *http.Client, *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusInternalServerError,
+					Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"failed"}}`)),
+				}, nil
+			},
+			expectError: "Internal error",
+		},
+		{
+			name: "invalid content type",
+			handle: func(context.Context, *http.Client, *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{protocol.MediaTypeJSON}},
+					Body:       http.NoBody,
+				}, nil
+			},
+			expectError: "server did not respond with Content-Type",
+		},
+		{
+			name: "success",
+			handle: func(context.Context, *http.Client, *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{protocol.MediaTypeEventStream + "; charset=utf-8"}},
+					Body:       http.NoBody,
+				}, nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := NewA2AClient(
+				"https://example.com/a2a",
+				WithProtocolBinding(protocol.ProtocolBindingHTTPJSON),
+				WithHTTPReqHandler(&mockHTTPReqHandler{handleFunc: tt.handle}),
+			)
+			require.NoError(t, err)
+			resp, err := httpJSONBinding{}.stream(
+				context.Background(), client, "request-id", protocol.MethodMessageStream,
+				protocol.SendMessageParams{},
+			)
+			if tt.expectError == "" {
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				require.NoError(t, resp.Body.Close())
+				return
+			}
+			require.Error(t, err)
+			assert.Nil(t, resp)
+			assert.Contains(t, err.Error(), tt.expectError)
+		})
+	}
+
+	_, err := httpJSONBinding{}.decodeSSEData([]byte(" \n\t"))
 	require.Error(t, err)
-	assert.ErrorIs(t, err, taskmanager.ErrTaskNotCancelableSentinel)
+	data, err := httpJSONBinding{}.decodeSSEData([]byte(`{"message":{}}`))
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"message":{}}`, string(data))
+}
+
+func TestHTTPJSONRequestConstructionErrors(t *testing.T) {
+	client, err := NewA2AClient("https://example.com/base", WithProtocolBinding(protocol.ProtocolBindingHTTPJSON))
+	require.NoError(t, err)
+
+	_, err = client.newHTTPJSONRequest(context.Background(), httpJSONRequest{
+		method: http.MethodPost,
+		path:   "/message:send",
+		body:   func() {},
+	}, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to marshal HTTP+JSON request")
+
+	assert.NoError(t, validateHTTPJSONResponseType(protocol.MediaTypeJSON+"; charset=utf-8"))
+	assert.NoError(t, validateHTTPJSONResponseType(protocol.MediaTypeA2AJSON))
+	require.Error(t, validateHTTPJSONResponseType("not a media type"))
+}
+
+func TestJSONRPCBindingDecodeSSEData(t *testing.T) {
+	binding := jsonRPCBinding{}
+
+	_, err := binding.decodeSSEData([]byte(`{`))
+	require.Error(t, err)
+
+	raw := []byte(`{"message":{"role":"agent","parts":[]}}`)
+	decoded, err := binding.decodeSSEData(raw)
+	require.NoError(t, err)
+	assert.Equal(t, raw, decoded)
+
+	_, err = binding.decodeSSEData([]byte(`{"jsonrpc":"1.0","result":{}}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid JSON-RPC SSE response version")
+
+	_, err = binding.decodeSSEData([]byte(`{"jsonrpc":"2.0","error":{"code":-32603,"message":"failed"}}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "jsonrpc error -32603")
+
+	_, err = binding.decodeSSEData([]byte(`{"jsonrpc":"2.0"}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing result")
+
+	decoded, err = binding.decodeSSEData([]byte(`{"jsonrpc":"2.0","result":{"task":{"id":"task-1"}}}`))
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"task":{"id":"task-1"}}`, string(decoded))
+}
+
+func TestDecodeHTTPJSONError(t *testing.T) {
+	errorBody := func(code taskmanager.ErrorCode) string {
+		return fmt.Sprintf(`{"error":{"message":"failed","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":%q,"metadata":{"taskId":"task-1"}}]}}`, code)
+	}
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		sentinel   error
+	}{
+		{name: "malformed", statusCode: http.StatusBadRequest, body: `{`, sentinel: nil},
+		{name: "missing message", statusCode: http.StatusBadRequest, body: `{}`, sentinel: nil},
+		{name: "invalid params", statusCode: http.StatusBadRequest, body: `{"error":{"message":"invalid"}}`, sentinel: taskmanager.ErrInvalidParamsSentinel},
+		{name: "internal", statusCode: http.StatusInternalServerError, body: `{"error":{"message":"failed"}}`, sentinel: taskmanager.ErrInternalErrorSentinel},
+		{name: "task not found", statusCode: http.StatusNotFound, body: errorBody(taskmanager.ErrCodeTaskNotFound), sentinel: taskmanager.ErrTaskNotFoundSentinel},
+		{name: "task not cancelable", statusCode: http.StatusBadRequest, body: errorBody(taskmanager.ErrCodeTaskNotCancelable), sentinel: taskmanager.ErrTaskNotCancelableSentinel},
+		{name: "push unsupported", statusCode: http.StatusBadRequest, body: errorBody(taskmanager.ErrCodePushNotificationNotSupported), sentinel: taskmanager.ErrPushNotificationNotSupportedSentinel},
+		{name: "operation unsupported", statusCode: http.StatusBadRequest, body: errorBody(taskmanager.ErrCodeUnsupportedOperation), sentinel: taskmanager.ErrUnsupportedOperationSentinel},
+		{name: "content type", statusCode: http.StatusBadRequest, body: errorBody(taskmanager.ErrCodeContentTypeNotSupported), sentinel: taskmanager.ErrContentTypeNotSupportedSentinel},
+		{name: "invalid response", statusCode: http.StatusBadRequest, body: errorBody(taskmanager.ErrCodeInvalidAgentResponse), sentinel: taskmanager.ErrInvalidAgentResponseSentinel},
+		{name: "extended card", statusCode: http.StatusBadRequest, body: errorBody(taskmanager.ErrCodeAuthenticatedExtendedCardNotConfigured), sentinel: taskmanager.ErrAuthenticatedExtendedCardNotConfiguredSentinel},
+		{name: "extension", statusCode: http.StatusBadRequest, body: errorBody(taskmanager.ErrCodeExtensionSupportRequired), sentinel: taskmanager.ErrExtensionSupportRequiredSentinel},
+		{name: "version", statusCode: http.StatusBadRequest, body: errorBody(taskmanager.ErrCodeVersionNotSupported), sentinel: taskmanager.ErrVersionNotSupportedSentinel},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := decodeHTTPJSONError(tt.statusCode, []byte(tt.body))
+			require.Error(t, err)
+			if tt.sentinel != nil {
+				assert.ErrorIs(t, err, tt.sentinel)
+			}
+		})
+	}
 }

--- a/client/http_json_test.go
+++ b/client/http_json_test.go
@@ -1,0 +1,224 @@
+// Tencent is pleased to support the open source community by making trpc-a2a-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-a2a-go is licensed under the Apache License Version 2.0.
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/server"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager/stateless"
+)
+
+type httpJSONEchoProcessor struct{}
+
+func (httpJSONEchoProcessor) ProcessMessage(
+	_ context.Context,
+	execContext *taskmanager.ExecContext,
+) (<-chan protocol.StreamEvent, error) {
+	events := make(chan protocol.StreamEvent, 1)
+	reply := protocol.NewMessage(
+		protocol.MessageRoleAgent,
+		[]*protocol.Part{protocol.NewTextPart("echo: " + execContext.Message.Parts[0].TextContent())},
+	)
+	events <- &reply
+	close(events)
+	return events, nil
+}
+
+func TestHTTPJSONClientServerSendAndStream(t *testing.T) {
+	manager, err := stateless.NewTaskManager(httpJSONEchoProcessor{})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, manager.Close()) })
+
+	streaming := true
+	card := protocol.AgentCard{
+		Name:               "HTTP+JSON Agent",
+		Description:        "test",
+		Version:            "1",
+		Capabilities:       protocol.AgentCapabilities{Streaming: &streaming},
+		DefaultInputModes:  []string{"text/plain"},
+		DefaultOutputModes: []string{"text/plain"},
+		Skills:             []protocol.AgentSkill{},
+		SupportedInterfaces: []protocol.AgentInterface{{
+			URL:             "http://placeholder.invalid",
+			ProtocolBinding: protocol.ProtocolBindingHTTPJSON,
+			ProtocolVersion: protocol.ProtocolVersionV1,
+		}},
+	}
+	a2aServer, err := server.NewA2AServer(manager, server.WithAgentCard(card))
+	require.NoError(t, err)
+	testServer := httptest.NewServer(a2aServer.Handler())
+	t.Cleanup(testServer.Close)
+
+	clientCard := card
+	clientCard.SupportedInterfaces[0].URL = testServer.URL
+	client, err := NewA2AClientFromAgentCard(&clientCard)
+	require.NoError(t, err)
+	assert.Equal(t, protocol.ProtocolBindingHTTPJSON, client.protocolBinding)
+
+	params := protocol.SendMessageParams{Message: protocol.Message{
+		MessageID: "message-1",
+		Role:      protocol.MessageRoleUser,
+		Parts:     []*protocol.Part{protocol.NewTextPart("hello")},
+	}}
+	response, err := client.SendMessage(context.Background(), params)
+	require.NoError(t, err)
+	require.NotNil(t, response.GetMessage())
+	assert.Equal(t, "echo: hello", response.GetMessage().Parts[0].TextContent())
+
+	events, err := client.StreamMessage(context.Background(), params)
+	require.NoError(t, err)
+	var streamed []protocol.StreamResponse
+	for event := range events {
+		streamed = append(streamed, event)
+	}
+	require.Len(t, streamed, 1)
+	require.NotNil(t, streamed[0].GetMessage())
+	assert.Equal(t, "echo: hello", streamed[0].GetMessage().Parts[0].TextContent())
+}
+
+func TestNewA2AClientFromAgentCardSelectionAndTenant(t *testing.T) {
+	card := &protocol.AgentCard{SupportedInterfaces: []protocol.AgentInterface{
+		{URL: "https://unsupported.example", ProtocolBinding: "CUSTOM", ProtocolVersion: protocol.ProtocolVersionV1},
+		{URL: "https://rest.example/api", ProtocolBinding: protocol.ProtocolBindingHTTPJSON, Tenant: "tenant-a", ProtocolVersion: protocol.ProtocolVersionV1},
+		{URL: "https://rpc.example/rpc", ProtocolBinding: protocol.ProtocolBindingJSONRPC, ProtocolVersion: protocol.ProtocolVersionV1},
+	}, Signatures: []protocol.AgentCardSignature{{Protected: "header", Signature: "signature"}}}
+	before, err := json.Marshal(card)
+	require.NoError(t, err)
+
+	client, err := NewA2AClientFromAgentCard(card)
+	require.NoError(t, err)
+	assert.Equal(t, protocol.ProtocolBindingHTTPJSON, client.protocolBinding)
+	assert.Equal(t, "tenant-a", client.tenant)
+	assert.Equal(t, "https://rest.example/api/", client.baseURL.String())
+	after, err := json.Marshal(card)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(before), string(after), "client construction must not mutate a signed Agent Card")
+
+	rpcClient, err := NewA2AClientFromAgentCard(card, WithProtocolBinding(protocol.ProtocolBindingJSONRPC))
+	require.NoError(t, err)
+	assert.Equal(t, protocol.ProtocolBindingJSONRPC, rpcClient.protocolBinding)
+	assert.Equal(t, "https://rpc.example/rpc/", rpcClient.baseURL.String())
+
+	_, err = client.SendMessage(context.Background(), protocol.SendMessageParams{
+		Tenant:  "tenant-b",
+		Message: protocol.Message{Role: protocol.MessageRoleUser, Parts: []*protocol.Part{protocol.NewTextPart("hello")}},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match selected AgentInterface tenant")
+}
+
+func TestHTTPJSONRequestHeadersAndBody(t *testing.T) {
+	var requestErr error
+	var requestErrMu sync.Mutex
+	recordRequestErr := func(err error) {
+		requestErrMu.Lock()
+		defer requestErrMu.Unlock()
+		requestErr = err
+	}
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			recordRequestErr(fmt.Errorf("method = %s", r.Method))
+		}
+		if r.URL.EscapedPath() != "/tenant%2Fa/message:send" {
+			recordRequestErr(fmt.Errorf("path = %s", r.URL.EscapedPath()))
+		}
+		if r.Header.Get("Content-Type") != protocol.MediaTypeA2AJSON {
+			recordRequestErr(fmt.Errorf("Content-Type = %s", r.Header.Get("Content-Type")))
+		}
+		if r.Header.Get("Accept") != protocol.MediaTypeA2AJSON+", "+protocol.MediaTypeJSON {
+			recordRequestErr(fmt.Errorf("Accept = %s", r.Header.Get("Accept")))
+		}
+		if r.Header.Get("A2A-Version") != protocol.ProtocolVersionV1 {
+			recordRequestErr(fmt.Errorf("A2A-Version = %s", r.Header.Get("A2A-Version")))
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			recordRequestErr(err)
+		}
+		if _, ok := body["jsonrpc"]; ok {
+			recordRequestErr(fmt.Errorf("request contains JSON-RPC envelope"))
+		}
+		w.Header().Set("Content-Type", protocol.MediaTypeA2AJSON)
+		_ = json.NewEncoder(w).Encode(map[string]any{"message": body["message"]})
+	}))
+	t.Cleanup(testServer.Close)
+
+	client, err := NewA2AClient(testServer.URL, WithProtocolBinding(protocol.ProtocolBindingHTTPJSON))
+	require.NoError(t, err)
+	_, err = client.SendMessage(context.Background(), protocol.SendMessageParams{
+		Tenant: "tenant/a",
+		Message: protocol.Message{
+			MessageID: "message-1",
+			Role:      protocol.MessageRoleUser,
+			Parts:     []*protocol.Part{protocol.NewTextPart("hello")},
+		},
+	})
+	require.NoError(t, err)
+	requestErrMu.Lock()
+	defer requestErrMu.Unlock()
+	require.NoError(t, requestErr)
+}
+
+func TestBuildHTTPJSONRequestRoutes(t *testing.T) {
+	pageSize := 10
+	tests := []struct {
+		name      string
+		operation string
+		params    any
+		method    string
+		path      string
+		query     string
+		body      bool
+	}{
+		{name: "send", operation: protocol.MethodMessageSend, params: protocol.SendMessageParams{Tenant: "tenant"}, method: http.MethodPost, path: "/tenant/message:send", body: true},
+		{name: "stream", operation: protocol.MethodMessageStream, params: protocol.SendMessageParams{}, method: http.MethodPost, path: "/message:stream", body: true},
+		{name: "get task", operation: protocol.MethodTasksGet, params: protocol.TaskQueryParams{ID: "task/a", HistoryLength: &pageSize}, method: http.MethodGet, path: "/tasks/task%2Fa", query: "historyLength=10"},
+		{name: "list tasks", operation: protocol.MethodTasksList, params: protocol.ListTasksParams{ContextID: "ctx", PageSize: &pageSize}, method: http.MethodGet, path: "/tasks", query: "contextId=ctx&pageSize=10"},
+		{name: "cancel", operation: protocol.MethodTasksCancel, params: protocol.TaskIDParams{ID: "task"}, method: http.MethodPost, path: "/tasks/task:cancel", body: true},
+		{name: "subscribe", operation: protocol.MethodTasksResubscribe, params: protocol.TaskIDParams{ID: "task"}, method: http.MethodPost, path: "/tasks/task:subscribe"},
+		{name: "create push", operation: protocol.MethodTasksPushNotificationConfigSet, params: protocol.TaskPushNotificationConfig{TaskID: "task"}, method: http.MethodPost, path: "/tasks/task/pushNotificationConfigs", body: true},
+		{name: "get push", operation: protocol.MethodTasksPushNotificationConfigGet, params: protocol.GetTaskPushNotificationConfigParams{TaskID: "task", ID: "config"}, method: http.MethodGet, path: "/tasks/task/pushNotificationConfigs/config"},
+		{name: "list push", operation: protocol.MethodTasksPushNotificationConfigList, params: protocol.ListTaskPushNotificationConfigsParams{TaskID: "task", PageSize: &pageSize}, method: http.MethodGet, path: "/tasks/task/pushNotificationConfigs", query: "pageSize=10"},
+		{name: "delete push", operation: protocol.MethodTasksPushNotificationConfigDelete, params: protocol.DeleteTaskPushNotificationConfigParams{TaskID: "task", ID: "config"}, method: http.MethodDelete, path: "/tasks/task/pushNotificationConfigs/config"},
+		{name: "extended card", operation: protocol.MethodAgentAuthenticatedExtendedCard, params: extendedCardParams{Tenant: "tenant"}, method: http.MethodGet, path: "/tenant/extendedAgentCard"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec, err := buildHTTPJSONRequest(tt.operation, tt.params)
+			require.NoError(t, err)
+			assert.Equal(t, tt.method, spec.method)
+			assert.Equal(t, tt.path, spec.path)
+			assert.Equal(t, tt.query, spec.query.Encode())
+			assert.Equal(t, tt.body, spec.body != nil)
+		})
+	}
+}
+
+func TestDecodeHTTPJSONError(t *testing.T) {
+	body := []byte(`{"error":{"code":404,"status":"NOT_FOUND","message":"missing","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"TASK_NOT_FOUND","domain":"a2a-protocol.org","metadata":{"taskId":"task-1"}}]}}`)
+	err := decodeHTTPJSONError(http.StatusNotFound, body)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, taskmanager.ErrTaskNotFoundSentinel)
+
+	body = []byte(`{"error":{"code":400,"status":"FAILED_PRECONDITION","message":"not cancelable","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"TASK_NOT_CANCELABLE","domain":"a2a-protocol.org","metadata":{"taskId":"task-1"}}]}}`)
+	err = decodeHTTPJSONError(http.StatusBadRequest, body)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, taskmanager.ErrTaskNotCancelableSentinel)
+}

--- a/client/options.go
+++ b/client/options.go
@@ -23,6 +23,17 @@ type HTTPReqHandler interface {
 	Handle(ctx context.Context, client *http.Client, req *http.Request) (*http.Response, error)
 }
 
+// WithProtocolBinding selects the protocol binding used with the URL passed to
+// NewA2AClient. Supported values are protocol.ProtocolBindingJSONRPC and
+// protocol.ProtocolBindingHTTPJSON. With NewA2AClientFromAgentCard it filters
+// SupportedInterfaces while preserving their preference order.
+func WithProtocolBinding(binding string) Option {
+	return func(c *A2AClient) {
+		c.protocolBinding = binding
+		c.bindingExplicit = true
+	}
+}
+
 // WithHTTPClient sets a custom http.Client for the A2AClient.
 func WithHTTPClient(client *http.Client) Option {
 	return func(c *A2AClient) {

--- a/compat/v0/jsonrpc_server.go
+++ b/compat/v0/jsonrpc_server.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -352,7 +353,15 @@ func writeError(w http.ResponseWriter, id interface{}, rpcErr *jsonrpc.Error) {
 }
 
 func writeTaskManagerError(w http.ResponseWriter, id interface{}, err error, operation string) {
-	if rpcErr, ok := err.(*jsonrpc.Error); ok {
+	var taskErr *taskmanager.Error
+	if errors.As(err, &taskErr) {
+		rpcErr := jsonrpc.FromTaskManagerError(taskErr)
+		log.Errorf("compat/v0: error calling %s: %v", operation, taskErr)
+		writeError(w, id, rpcErr)
+		return
+	}
+	var rpcErr *jsonrpc.Error
+	if errors.As(err, &rpcErr) {
 		log.Errorf("compat/v0: error calling %s: %v", operation, rpcErr)
 		writeError(w, id, rpcErr)
 		return

--- a/docs/mkdocs/en/client.md
+++ b/docs/mkdocs/en/client.md
@@ -10,8 +10,19 @@ import "trpc.group/trpc-go/trpc-a2a-go/v2/client"
 c, _ := client.NewA2AClient("http://localhost:8080/")
 ```
 
-`NewA2AClient` takes options (timeouts, HTTP client, auth — below). It fetches
-and speaks to the agent over the JSON-RPC binding.
+`NewA2AClient` keeps JSON-RPC as the default for direct endpoint construction. Select HTTP+JSON explicitly with `client.WithProtocolBinding(protocol.ProtocolBindingHTTPJSON)`, or construct from an Agent Card so the client follows the ordered `supportedInterfaces` list:
+
+```go
+restClient, _ := client.NewA2AClient(
+    "https://agent.example.com/a2a",
+    client.WithProtocolBinding(protocol.ProtocolBindingHTTPJSON),
+)
+
+card, _ := c.GetAgentCard(ctx, "")
+discoveredClient, _ := client.NewA2AClientFromAgentCard(card)
+```
+
+JSON-RPC requests continue to use `application/json`. HTTP+JSON requests use REST paths and send `application/a2a+json`; unary responses accept both `application/a2a+json` and the 1.0.0-era `application/json` for compatibility.
 
 ## The four consumption modes
 

--- a/docs/mkdocs/en/overview.md
+++ b/docs/mkdocs/en/overview.md
@@ -15,8 +15,9 @@ the runtime contract see [Server](server.md) and [Client](client.md).
 | Capability | Status | Notes |
 | --- | --- | --- |
 | A2A v1.0 protocol objects, task lifecycle, `Task \| Message` result union | ✅ | The full object and state model of the spec. |
-| JSON-RPC transport binding (HTTP POST + SSE) | ✅ | The wire this framework serves. |
-| gRPC / HTTP+JSON (REST) transport bindings | 🗺️ Planned | Defined by the spec; not yet implemented — JSON-RPC only today. |
+| JSON-RPC transport binding (HTTP POST + SSE) | ✅ | Uses `application/json` and JSON-RPC envelopes. |
+| HTTP+JSON (REST) transport binding | ✅ | Uses REST routes, `application/a2a+json`, direct JSON responses, and raw SSE data. |
+| gRPC transport binding | 🗺️ Planned | Defined by the spec; not yet implemented. |
 | `SendMessage` / `SendStreamingMessage` from one processor | ✅ | One code path serves unary and streaming. |
 | Blocking send, `returnImmediately`, live streaming, `SubscribeToTask` | ✅ | Four client consumption modes over the same agent. |
 | Stateless request-scoped execution | ✅ | Direct Messages and ephemeral Tasks with no retained state or conversation history. |
@@ -39,7 +40,7 @@ flowchart TB
     subgraph server["server"]
         direction TB
         AUTH["auth chain"]
-        RPC["JSON-RPC + SSE dispatch"]
+        RPC["JSON-RPC / HTTP+JSON + SSE dispatch"]
         CARD["agent cards / discovery"]
         COMPAT["compat/v0 handler"]
     end
@@ -57,10 +58,7 @@ flowchart TB
 
 Three layers, three responsibilities:
 
-- **`server`** terminates the wire. It authenticates the request, serves agent
-  cards for discovery, dispatches JSON-RPC methods and SSE streams, and —
-  optionally — mounts the legacy v0.2.x endpoint on the same port inside the
-  same auth chain.
+- **`server`** terminates the wire. It authenticates requests, serves agent cards for discovery, dispatches JSON-RPC and HTTP+JSON operations and SSE streams, and — optionally — mounts the legacy v0.2.x endpoint on the same port inside the same auth chain.
 - **`TaskManager`** owns execution policy and, when enabled, task state: lazy
   task creation, round close rules, cancellation, conversation history,
   retention, and subscriber fan-out. `taskmanager/stateless` derives direct
@@ -89,7 +87,7 @@ sequenceDiagram
     P-->>TM: <-chan events (Message / status / artifact)
     Note over TM: memory/Redis persist task events;<br/>stateless applies them to a request-local Task only
     TM-->>Server: Task or Message (unary) OR live event stream
-    Server-->>Client: JSON-RPC result / SSE frames
+    Server-->>Client: binding-specific result / SSE frames
 ```
 
 The load-bearing idea: **your agent is one method that emits an event stream,
@@ -121,9 +119,7 @@ retention semantics — lives with the agent-author guide in
 
 ## Roadmap
 
-- **gRPC and HTTP+JSON (REST) transport bindings** — the spec defines all
-  three; this framework serves the JSON-RPC binding today, and the agent card
-  already models multi-transport declaration for when the others land.
+- **gRPC transport binding** — the spec defines it alongside JSON-RPC and HTTP+JSON; this framework does not serve gRPC yet.
 - **Redis execution coordination** — cross-node `SubscribeToTask` is available,
   but continuation, live cancel, and single-writer execution routing remain
   node-local concerns rather than a distributed work queue.

--- a/docs/mkdocs/en/protocol.md
+++ b/docs/mkdocs/en/protocol.md
@@ -20,11 +20,7 @@ how it is built:
 - an **orchestrator agent** fanning work out to specialist agents,
 - **cross-organization** calls that need authentication and webhooks.
 
-The transport is deliberately boring: the client fetches the agent's **agent
-card** to learn its identity, skills and capabilities, then speaks JSON-RPC —
-unary calls over HTTP POST, streaming over SSE. trpc-a2a-go implements A2A
-**v1.0** (the legacy v0.2.x wire is kept alive by
-[compat/v0](https://github.com/trpc-group/trpc-a2a-go/tree/v2/compat/v0)).
+The transport is deliberately boring: the client fetches the agent's **agent card** to learn its identity, skills, capabilities, and ordered `supportedInterfaces`, then selects JSON-RPC or HTTP+JSON; both use SSE for streaming. trpc-a2a-go implements A2A **v1.0** (the legacy v0.2.x wire is kept alive by [compat/v0](https://github.com/trpc-group/trpc-a2a-go/tree/v2/compat/v0)).
 
 ## The mental model
 
@@ -313,10 +309,7 @@ slash-delimited names, shown for reference):
 | `CreateTaskPushNotificationConfig` / `Get…` / `List…` / `Delete…` | unary | Webhook config CRUD, for disconnected operation. | `tasks/pushNotificationConfig/*` |
 | `GetExtendedAgentCard` | unary | Authenticated agent card with extended metadata. | `agent/getAuthenticatedExtendedCard` |
 
-The v1.0 specification defines three functionally equivalent transport
-bindings — JSON-RPC, gRPC, and HTTP+JSON/REST — with binding-specific method
-naming. This framework implements the JSON-RPC binding (the names above); the
-agent card's `supportedInterfaces` declares which bindings an agent offers.
+The v1.0 specification defines three functionally equivalent transport bindings — JSON-RPC, gRPC, and HTTP+JSON/REST — with binding-specific method naming. This framework implements JSON-RPC and HTTP+JSON; the agent card's ordered `supportedInterfaces` declares which bindings and endpoint URLs an agent offers. gRPC remains planned.
 
 ### Blocking vs `returnImmediately`
 
@@ -331,23 +324,21 @@ agent card's `supportedInterfaces` declares which bindings an agent offers.
 > layer preserves the old default for legacy clients; migrating clients must
 > opt in explicitly (see [Migrating from v0.x](migration.md)).
 
-### Error codes
+### Error mapping
 
-Standard JSON-RPC codes apply (`-32700` parse error, `-32600` invalid request,
-`-32601` method not found, `-32602` invalid params, `-32603` internal error),
-plus the A2A-specific range:
+Standard JSON-RPC codes apply (`-32700` parse error, `-32600` invalid request, `-32601` method not found, `-32602` invalid params, `-32603` internal error). A2A-specific failures map by binding; HTTP+JSON uses a `google.rpc.Status` JSON body and includes `google.rpc.ErrorInfo` to distinguish failures that share an HTTP status:
 
-| Code | Meaning |
-| --- | --- |
-| `-32001` | Task not found |
-| `-32002` | Task cannot be canceled (already terminal) |
-| `-32003` | Push notifications not supported |
-| `-32004` | Operation not supported |
-| `-32005` | Incompatible content types |
-| `-32006` | Invalid agent response |
-| `-32007` | Extended agent card not configured |
-| `-32008` | A required extension was not opted into by the client |
-| `-32009` | The requested A2A protocol version is not supported |
+| Meaning | JSON-RPC code | HTTP status |
+| --- | --- | --- |
+| Task not found | `-32001` | `404` |
+| Task cannot be canceled (already terminal) | `-32002` | `400` |
+| Push notifications not supported | `-32003` | `400` |
+| Operation not supported | `-32004` | `400` |
+| Incompatible content types | `-32005` | `400` |
+| Invalid agent response | `-32006` | `500` |
+| Extended agent card not configured | `-32007` | `400` |
+| A required extension was not opted into by the client | `-32008` | `400` |
+| The requested A2A protocol version is not supported | `-32009` | `400` |
 
 ### The canonical event paradigm
 

--- a/docs/mkdocs/en/server.md
+++ b/docs/mkdocs/en/server.md
@@ -22,7 +22,7 @@ import (
 
 tm, _ := memory.NewTaskManager(&myProcessor{})
 srv, _ := server.NewA2AServer(tm, server.WithAgentCard(agentCard))
-srv.Start(":8080")   // serves JSON-RPC at "/" and the card at /.well-known/agent-card.json
+srv.Start(":8080")   // serves JSON-RPC plus the well-known card
 ```
 
 `NewA2AServer` takes functional options:
@@ -35,6 +35,7 @@ srv.Start(":8080")   // serves JSON-RPC at "/" and the card at /.well-known/agen
 | `WithPushNotificationJWKSHandler(handler)` | Publish a push sender's verification keys. Pass `sender.JWKSHandler()` for `SignedSender`, or any custom `http.Handler`. |
 | `WithJWKSEndpoint(false, "")` | Disable the built-in JWKS route when verification keys are published elsewhere; a non-empty path changes the route. |
 | `WithBasePath(prefix)` | Mount under a subpath. |
+| `WithHTTPJSONEndpoint(prefix)` | Enable HTTP+JSON and set its base path independently of JSON-RPC. A static card advertising `HTTP+JSON` also enables it. |
 | `WithCompatHandler(h)` | Also serve the legacy v0.2.x wire. |
 | `WithMiddleware(mw...)` | Wrap the HTTP handler chain. → [middleware context example](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples/middleware) |
 | `WithCORSEnabled(true)` | Emit CORS headers. |
@@ -403,12 +404,11 @@ srv, _ := server.NewA2AServer(tm,
 ## Serving on a subpath
 
 Mount the whole server under a path prefix, for example behind a gateway.
-Prefer an explicit `WithBasePath`; it adjusts the agent card, JSON-RPC, and JWKS
-endpoints together:
+Prefer an explicit `WithBasePath`; it adjusts the Agent Card, JSON-RPC, enabled HTTP+JSON, and JWKS endpoints together:
 
 ```go
 srv, _ := server.NewA2AServer(tm, server.WithAgentCard(card),
-    server.WithBasePath("/api/v1/agent"))   // card + JSON-RPC under /api/v1/agent/…
+    server.WithBasePath("/api/v1/agent"))   // card + enabled bindings under /api/v1/agent/…
 ```
 
 If `WithBasePath` is not set, the server attempts to derive the base path from
@@ -452,6 +452,4 @@ srv, _ := server.NewA2AServer(tm, server.WithAgentCard(card),
 
 ## Capability status
 
-The framework serves the **JSON-RPC** transport binding today. The spec also
-defines **gRPC** and **HTTP+JSON (REST)** bindings — planned, not yet
-implemented. See the [Overview](overview.md#what-you-get) capability matrix.
+The framework implements both **JSON-RPC** and **HTTP+JSON (REST)**. JSON-RPC remains enabled by default and uses `application/json`. HTTP+JSON is enabled by `WithHTTPJSONEndpoint` or a static Agent Card interface declaring `HTTP+JSON`; it accepts `application/a2a+json` and compatibility `application/json`, responds with `application/a2a+json`, and emits raw `StreamResponse` objects in SSE `data:` fields. **gRPC** remains planned. The Agent Card must accurately declare every enabled endpoint in `supportedInterfaces`; the server does not add bindings to or otherwise rewrite signed cards.

--- a/docs/mkdocs/zh/client.md
+++ b/docs/mkdocs/zh/client.md
@@ -11,7 +11,19 @@ if err != nil {
 }
 ```
 
-`NewA2AClient` 接收 agent 的 JSON-RPC endpoint。默认没有超时；生产代码通常会传 `client.WithTimeout(...)` 或自定义 `http.Client`。
+`NewA2AClient` 接收 agent endpoint，默认继续使用 JSON-RPC。直接指定 HTTP+JSON 时传 `client.WithProtocolBinding(protocol.ProtocolBindingHTTPJSON)`；更推荐先获取 Agent Card，再让 client 按有序的 `supportedInterfaces` 选择第一个自己支持的 binding：
+
+```go
+restClient, _ := client.NewA2AClient(
+    "https://agent.example.com/a2a",
+    client.WithProtocolBinding(protocol.ProtocolBindingHTTPJSON),
+)
+
+card, _ := c.GetAgentCard(ctx, "")
+discoveredClient, _ := client.NewA2AClientFromAgentCard(card)
+```
+
+JSON-RPC 请求继续使用 `application/json`。HTTP+JSON 使用 REST 路由并发送 `application/a2a+json`；一元响应同时接受 `application/a2a+json` 与兼容 1.0.0 实现的 `application/json`。默认没有超时；生产代码通常会传 `client.WithTimeout(...)` 或自定义 `http.Client`。
 
 ## 先发现 Agent
 

--- a/docs/mkdocs/zh/overview.md
+++ b/docs/mkdocs/zh/overview.md
@@ -6,7 +6,7 @@ tRPC-A2A-Go 是 A2A（Agent-to-Agent）协议 v1.0 的 Go 实现。它同时提�
 
 ## 适合什么场景
 
-- **把已有 Go agent 接入 A2A 生态**：定义 agent card，实现一个 `MessageProcessor`，框架负责 JSON-RPC 与 SSE。
+- **把已有 Go agent 接入 A2A 生态**：定义 agent card，实现一个 `MessageProcessor`，框架负责 JSON-RPC、HTTP+JSON 与 SSE。
 - **调用远端 agent**：发现 agent card 后，用同一个 client 支持阻塞调用、立即返回、实时流式和断线后订阅。
 - **长任务与多轮任务**：任务可查询、可取消、可恢复；`input-required` / `auth-required` 用于等待用户补充。
 - **生产化托管**：内置 memory / Redis 存储、JWT / API key / OAuth2、webhook 推送、多租户、子路径部署和 OpenTelemetry 指标。
@@ -17,8 +17,9 @@ tRPC-A2A-Go 是 A2A（Agent-to-Agent）协议 v1.0 的 Go 实现。它同时提�
 | 能力 | 状态 | 说明 |
 | --- | --- | --- |
 | A2A v1.0 协议对象与任务生命周期 | 支持 | `Message`、`Task`、状态事件、artifact 事件和 `Task \| Message` 结果 union。 |
-| JSON-RPC 传输绑定 | 支持 | HTTP POST 处理一元方法，SSE 处理流式方法。 |
-| gRPC / HTTP+JSON（REST）传输绑定 | 规划中 | A2A v1.0 spec 已定义；当前实现只服务 JSON-RPC。 |
+| JSON-RPC 传输绑定 | 支持 | 使用 `application/json` 与 JSON-RPC envelope；流式响应使用 SSE。 |
+| HTTP+JSON（REST）传输绑定 | 支持 | 使用 REST 路由、`application/a2a+json`、直接 JSON 响应与 raw SSE data。 |
+| gRPC 传输绑定 | 规划中 | A2A v1.0 spec 已定义，当前尚未实现。 |
 | 一份 processor 服务一元与流式 | 支持 | 同一个 `ProcessMessage` 同时服务 `SendMessage` 与 `SendStreamingMessage`。 |
 | 四种消费模式 | 支持 | 阻塞 send、`returnImmediately`、实时流式、`SubscribeToTask` / Go `ResubscribeTask`。 |
 | Stateless 请求内执行 | 支持 | 可返回直接 Message 或临时 Task，不保存任何状态或会话历史。 |
@@ -45,7 +46,7 @@ flowchart TB
         direction TB
         AUTH["鉴权链"]
         CARD["agent card / extended card"]
-        RPC["JSON-RPC + SSE 分发"]
+        RPC["JSON-RPC / HTTP+JSON + SSE 分发"]
         COMPAT["compat/v0 handler"]
     end
     TM["TaskManager<br/>stateless / memory / redis / 自定义"]
@@ -63,7 +64,7 @@ flowchart TB
 
 三层职责是固定的：
 
-- **`server`** 终结 wire 层：鉴权、提供 agent card、分发 JSON-RPC 方法和 SSE 流，也可以把 `compat/v0` 挂在同一端点里。
+- **`server`** 终结 wire 层：鉴权、提供 agent card、分发 JSON-RPC 与 HTTP+JSON 操作和 SSE 流，也可以把 `compat/v0` 挂在同一端点里。
 - **`TaskManager`** 决定执行策略，并按需持有状态：stateless 在请求内派生直接 Message 或临时 Task，不留存状态；memory 与 Redis 负责持久化事件、维护会话历史、取消、留存和订阅者扇出。
 - **`MessageProcessor`** 是你的 agent：它读取一份只读的 `ExecContext`，返回一个事件 channel。
 
@@ -85,7 +86,7 @@ sequenceDiagram
     P-->>TM: <-chan events（Message / status / artifact）
     Note over TM: memory/Redis 持久化任务事件；<br/>stateless 只在请求内应用事件
     TM-->>Server: Task、Message 或实时事件流
-    Server-->>Client: JSON-RPC 结果 / SSE 帧
+    Server-->>Client: binding 对应的结果 / SSE 帧
 ```
 
 核心思想只有一句：**agent 发事件，框架从事件流派生所有响应形状。**你的代码不需要判断这次是同步还是流式；`SendMessage` 默认等到终态或挂起态再返回，`SendStreamingMessage` 实时转发同一批事件。推荐先用 `TaskHandle` 写同步风格，确实需要控制底层事件字段时再返回裸 channel。
@@ -101,7 +102,7 @@ sequenceDiagram
 
 ## 当前边界
 
-- 当前只实现 JSON-RPC 传输绑定；gRPC 和 HTTP+JSON（REST）还没有落地。
+- 当前实现 JSON-RPC 与 HTTP+JSON（REST）传输绑定；gRPC 尚未落地。
 - Redis 后端可选择把 Task 事件写入 Redis Stream，使 `SubscribeToTask` 能跨节点接回；continuation、live cancel 和执行 single-writer 仍是节点本地能力，并非分布式工作队列。
 - A2A 没有定义“删除任务”API；生产环境需要通过 TTL 控制终态任务留存。
 

--- a/docs/mkdocs/zh/protocol.md
+++ b/docs/mkdocs/zh/protocol.md
@@ -14,7 +14,7 @@ AI agent 正在变成服务：报告生成器、差旅预订助手、代码评�
 - **编排 agent** 把工作分发给多个专家 agent；
 - **跨组织调用**：需要鉴权与 webhook 回调。
 
-传输层刻意保持朴素：client 先取 agent 的 **agent card** 了解其身份、技能与能力，然后走 JSON-RPC——一元调用基于 HTTP POST，流式基于 SSE。trpc-a2a-go 实现 A2A **v1.0**（legacy v0.2.x wire 由 [compat/v0](https://github.com/trpc-group/trpc-a2a-go/tree/v2/compat/v0) 层继续支持）。
+传输层刻意保持朴素：client 先取 agent 的 **agent card** 了解其身份、技能、能力与有序的 `supportedInterfaces`，再选择 JSON-RPC 或 HTTP+JSON；两种绑定的流式响应都使用 SSE。trpc-a2a-go 实现 A2A **v1.0**（legacy v0.2.x wire 由 [compat/v0](https://github.com/trpc-group/trpc-a2a-go/tree/v2/compat/v0) 层继续支持）。
 
 ## 心智模型
 
@@ -271,7 +271,7 @@ v1.0 JSON-RPC 绑定定义的方法名如下（v0.2.x wire 用的是斜杠分隔
 | `CreateTaskPushNotificationConfig` / `Get…` / `List…` / `Delete…` | 一元 | webhook 配置 CRUD，用于离线运行。 | `tasks/pushNotificationConfig/*` |
 | `GetExtendedAgentCard` | 一元 | 鉴权后的扩展 agent card。 | `agent/getAuthenticatedExtendedCard` |
 
-v1.0 spec 定义了三种功能等价的传输绑定——JSON-RPC、gRPC、HTTP+JSON/REST——各自有绑定特定的方法命名。本框架实现 JSON-RPC 绑定（上表方法名）；agent card 的 `supportedInterfaces` 声明一个 agent 提供哪些绑定。
+v1.0 spec 定义了三种功能等价的传输绑定——JSON-RPC、gRPC、HTTP+JSON/REST——各自有绑定特定的方法命名。本框架实现 JSON-RPC 与 HTTP+JSON；agent card 的有序 `supportedInterfaces` 声明一个 agent 提供哪些绑定及 endpoint URL，gRPC 仍在规划中。
 
 ### 请求配置
 
@@ -290,21 +290,21 @@ v1.0 spec 定义了三种功能等价的传输绑定——JSON-RPC、gRPC、HTTP
 
 > **v0.2.x 注**：老 wire 的默认值恰好*相反*——`blocking` 可选且缺席意味着"立即应答"。v1.0 把默认翻转了。compat 层为 legacy 客户端保留老默认；主动迁移的客户端必须显式选择（见[从 v0.x 迁移](migration.md)）。
 
-### 错误码
+### 错误映射
 
-标准 JSON-RPC 码适用（`-32700` 解析错误、`-32600` 无效请求、`-32601` 方法不存在、`-32602` 参数无效、`-32603` 内部错误），另加 A2A 专用区间：
+标准 JSON-RPC 码适用（`-32700` 解析错误、`-32600` 无效请求、`-32601` 方法不存在、`-32602` 参数无效、`-32603` 内部错误）。A2A 专用失败按 binding 映射；HTTP+JSON 返回 `google.rpc.Status` JSON body，并用 `google.rpc.ErrorInfo` 区分共享同一 HTTP status 的失败：
 
-| 码 | 含义 |
-| --- | --- |
-| `-32001` | 任务未找到 |
-| `-32002` | 任务不可取消（已终态） |
-| `-32003` | 不支持推送通知 |
-| `-32004` | 不支持该操作 |
-| `-32005` | 内容类型不兼容 |
-| `-32006` | agent 响应无效 |
-| `-32007` | 未配置扩展 agent card |
-| `-32008` | client 未选入某个必需的 extension |
-| `-32009` | 请求的 A2A 协议版本不受支持 |
+| 含义 | JSON-RPC 码 | HTTP status |
+| --- | --- | --- |
+| 任务未找到 | `-32001` | `404` |
+| 任务不可取消（已终态） | `-32002` | `400` |
+| 不支持推送通知 | `-32003` | `400` |
+| 不支持该操作 | `-32004` | `400` |
+| 内容类型不兼容 | `-32005` | `400` |
+| agent 响应无效 | `-32006` | `500` |
+| 未配置扩展 agent card | `-32007` | `400` |
+| client 未选入某个必需的 extension | `-32008` | `400` |
+| 请求的 A2A 协议版本不受支持 | `-32009` | `400` |
 
 ### 典型事件范式
 

--- a/docs/mkdocs/zh/server.md
+++ b/docs/mkdocs/zh/server.md
@@ -26,7 +26,7 @@ import (
 
 tm, _ := memory.NewTaskManager(&myProcessor{})
 srv, _ := server.NewA2AServer(tm, server.WithAgentCard(agentCard))
-srv.Start(":8080")   // 在 "/" 服务 JSON-RPC，在 /.well-known/agent-card.json 服务 card
+srv.Start(":8080")   // 在 "/" 服务 JSON-RPC，并提供 well-known card
 ```
 
 `NewA2AServer` 接收函数式 option:
@@ -36,11 +36,12 @@ srv.Start(":8080")   // 在 "/" 服务 JSON-RPC，在 /.well-known/agent-card.js
 | `WithAgentCard(card)` | 公开默认 agent card。单 agent server 必填；多租户 server 可作为默认目录 card。 |
 | `WithTenantCard(tenant, card)` / `WithTenantCardProvider(fn)` | 注册按租户解析的 card，多租户时使用。 |
 | `WithAuthenticatedExtendedCardHandler(fn)` | 开启鉴权后的 extended agent card。 |
-| `WithAuthProvider(p)` | 要求 JSON-RPC 请求鉴权。 |
+| `WithAuthProvider(p)` | 要求 JSON-RPC 与 HTTP+JSON 请求鉴权。 |
 | `WithPushNotificationJWKSHandler(handler)` | 发布 push sender 的验证公钥。`SignedSender` 传 `sender.JWKSHandler()`，也可传自定义 `http.Handler`。 |
 | `WithJWKSEndpoint(false, "")` | 公钥由别处发布时关闭内置 JWKS route；传非空 path 可修改该 route。 |
 | `WithBasePath(prefix)` | 挂载到子路径。 |
 | `WithJSONRPCEndpoint(path)` | 自定义 JSON-RPC endpoint。通常优先用 `WithBasePath`。 |
+| `WithHTTPJSONEndpoint(path)` | 启用 HTTP+JSON，并单独设置它的 base path；静态 card 声明 `HTTP+JSON` 时也会自动启用。 |
 | `WithCompatHandler(h)` | 同时服务 legacy v0.2.x wire。 |
 | `WithMiddleware(mw...)` | 包裹 HTTP handler 链。→ [middleware context 示例](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples/middleware) |
 | `WithCORSEnabled(true)` | 输出 CORS 头。 |
@@ -328,11 +329,11 @@ srv, _ := server.NewA2AServer(tm,
 
 ## 子路径部署
 
-把整个 server 挂到路径前缀下，比如放在网关后面。推荐显式使用 `WithBasePath`，它会同时调整 agent card、JSON-RPC 和 JWKS endpoint：
+把整个 server 挂到路径前缀下，比如放在网关后面。推荐显式使用 `WithBasePath`，它会同时调整 agent card、JSON-RPC、已启用的 HTTP+JSON 和 JWKS endpoint：
 
 ```go
 srv, _ := server.NewA2AServer(tm, server.WithAgentCard(card),
-    server.WithBasePath("/api/v1/agent"))   // card + JSON-RPC 位于 /api/v1/agent/…
+    server.WithBasePath("/api/v1/agent"))   // card + 已启用的 binding 位于 /api/v1/agent/…
 ```
 
 如果没有设置 `WithBasePath`，server 会尝试从 `agentCard.URL` 的 path 自动推导 base path；显式 `WithBasePath` 的优先级更高，适合外部 URL 和内部路由不一致的网关场景。
@@ -393,4 +394,4 @@ srv, _ := server.NewA2AServer(tm, server.WithAgentCard(card),
 | 兼容老客户端 | `WithCompatHandler(v0.NewJSONRPCHandler(tm))` | 必须挂在 server 内部，才能共享鉴权链。 |
 | 指标与 TTFT | `WithTelemetryMeterProvider` 或 `WithTelemetryMeterProviderOptions` | `WithFirstTokenPolicy` 可调整首 token 判定。 |
 
-当前框架服务 **JSON-RPC** 传输绑定。A2A v1.0 spec 还定义了 **gRPC** 与 **HTTP+JSON（REST）** 绑定，当前尚未实现。见 [框架概览](overview.md)。
+当前框架实现 **JSON-RPC** 与 **HTTP+JSON（REST）**。JSON-RPC 默认启用并继续使用 `application/json`。HTTP+JSON 由 `WithHTTPJSONEndpoint` 或静态 Agent Card 中声明的 `HTTP+JSON` interface 启用；它接受 `application/a2a+json` 与兼容性的 `application/json`，响应使用 `application/a2a+json`，SSE 的 `data:` 直接承载 `StreamResponse`。**gRPC** 尚未实现。Agent Card 必须在 `supportedInterfaces` 中准确声明实际启用的 endpoint；server 不会向已签名 card 增加 binding，也不会以其他方式改写它。

--- a/internal/jsonrpc/jsonrpc_test.go
+++ b/internal/jsonrpc/jsonrpc_test.go
@@ -14,7 +14,41 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
 )
+
+func TestFromTaskManagerError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		code     int
+		sentinel error
+	}{
+		{name: "plain error", err: errors.New("failed"), code: CodeInternalError, sentinel: ErrInternalErrorSentinel},
+		{name: "invalid params", err: taskmanager.ErrInvalidParams("invalid"), code: CodeInvalidParams, sentinel: taskmanager.ErrInvalidParamsSentinel},
+		{name: "task not found", err: taskmanager.ErrTaskNotFound("task-1"), code: CodeTaskNotFound, sentinel: taskmanager.ErrTaskNotFoundSentinel},
+		{name: "task not cancelable", err: taskmanager.ErrTaskNotCancelable("task-1", protocol.TaskStateCompleted), code: CodeTaskNotCancelable, sentinel: taskmanager.ErrTaskNotCancelableSentinel},
+		{name: "push unsupported", err: taskmanager.ErrPushNotificationNotSupported(), code: CodePushNotificationNotSupported, sentinel: taskmanager.ErrPushNotificationNotSupportedSentinel},
+		{name: "unsupported operation", err: taskmanager.ErrUnsupportedOperation("operation"), code: CodeUnsupportedOperation, sentinel: taskmanager.ErrUnsupportedOperationSentinel},
+		{name: "content type", err: taskmanager.ErrContentTypeNotSupported("text/plain"), code: CodeContentTypeNotSupported, sentinel: taskmanager.ErrContentTypeNotSupportedSentinel},
+		{name: "invalid response", err: taskmanager.ErrInvalidAgentResponse("invalid"), code: CodeInvalidAgentResponse, sentinel: taskmanager.ErrInvalidAgentResponseSentinel},
+		{name: "extended card", err: taskmanager.ErrAuthenticatedExtendedCardNotConfigured(), code: CodeAuthenticatedExtendedCardNotConfigured, sentinel: taskmanager.ErrAuthenticatedExtendedCardNotConfiguredSentinel},
+		{name: "extension", err: taskmanager.ErrExtensionSupportRequired("extension"), code: CodeExtensionSupportRequired, sentinel: taskmanager.ErrExtensionSupportRequiredSentinel},
+		{name: "version", err: taskmanager.ErrVersionNotSupported("2.0"), code: CodeVersionNotSupported, sentinel: taskmanager.ErrVersionNotSupportedSentinel},
+		{name: "task manager internal", err: taskmanager.ErrInternalError("failed"), code: CodeInternalError, sentinel: taskmanager.ErrInternalErrorSentinel},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rpcErr := FromTaskManagerError(tt.err)
+			require.NotNil(t, rpcErr)
+			assert.Equal(t, tt.code, rpcErr.Code)
+			assert.ErrorIs(t, rpcErr, tt.sentinel)
+		})
+	}
+}
 
 func TestJSONRPCRequest_MarshalUnmarshal(t *testing.T) {
 	tests := []struct {

--- a/internal/jsonrpc/types.go
+++ b/internal/jsonrpc/types.go
@@ -12,6 +12,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
 )
 
 // Version is the JSON-RPC version.
@@ -31,6 +33,19 @@ const (
 	// CodeInternalError indicates an internal JSON-RPC error.
 	CodeInternalError = -32603
 	// -32000 to -32099 are reserved for implementation-defined server-errors.
+)
+
+// A2A-specific JSON-RPC server error codes.
+const (
+	CodeTaskNotFound                           = -32001
+	CodeTaskNotCancelable                      = -32002
+	CodePushNotificationNotSupported           = -32003
+	CodeUnsupportedOperation                   = -32004
+	CodeContentTypeNotSupported                = -32005
+	CodeInvalidAgentResponse                   = -32006
+	CodeAuthenticatedExtendedCardNotConfigured = -32007
+	CodeExtensionSupportRequired               = -32008
+	CodeVersionNotSupported                    = -32009
 )
 
 // Message is the base structure embedding common fields for JSON-RPC
@@ -154,4 +169,37 @@ func ErrInvalidParams(data interface{}) *Error {
 func ErrInternalError(data interface{}) *Error {
 	return (&Error{Code: CodeInternalError, Message: "Internal error", Data: data}).
 		WithWrappedError(ErrInternalErrorSentinel)
+}
+
+// FromTaskManagerError maps a binding-neutral TaskManager error to its
+// JSON-RPC representation.
+func FromTaskManagerError(err error) *Error {
+	var taskErr *taskmanager.Error
+	if !errors.As(err, &taskErr) {
+		return ErrInternalError(err.Error())
+	}
+	code := CodeInternalError
+	switch taskErr.Code {
+	case taskmanager.ErrCodeInvalidParams:
+		code = CodeInvalidParams
+	case taskmanager.ErrCodeTaskNotFound:
+		code = CodeTaskNotFound
+	case taskmanager.ErrCodeTaskNotCancelable:
+		code = CodeTaskNotCancelable
+	case taskmanager.ErrCodePushNotificationNotSupported:
+		code = CodePushNotificationNotSupported
+	case taskmanager.ErrCodeUnsupportedOperation:
+		code = CodeUnsupportedOperation
+	case taskmanager.ErrCodeContentTypeNotSupported:
+		code = CodeContentTypeNotSupported
+	case taskmanager.ErrCodeInvalidAgentResponse:
+		code = CodeInvalidAgentResponse
+	case taskmanager.ErrCodeAuthenticatedExtendedCardNotConfigured:
+		code = CodeAuthenticatedExtendedCardNotConfigured
+	case taskmanager.ErrCodeExtensionSupportRequired:
+		code = CodeExtensionSupportRequired
+	case taskmanager.ErrCodeVersionNotSupported:
+		code = CodeVersionNotSupported
+	}
+	return (&Error{Code: code, Message: taskErr.Message, Data: taskErr.Data}).WithWrappedError(err)
 }

--- a/internal/sse/sse.go
+++ b/internal/sse/sse.go
@@ -141,6 +141,30 @@ type EventBatch struct {
 	Data      interface{}
 }
 
+// FormatEventBatch formats multiple raw SSE events in a single write. It is
+// used by the HTTP+JSON binding, whose data field contains StreamResponse JSON
+// directly rather than a JSON-RPC response envelope.
+func FormatEventBatch(w io.Writer, events []EventBatch) error {
+	if len(events) == 0 {
+		return nil
+	}
+
+	var buf bytes.Buffer
+	for _, event := range events {
+		jsonData, err := json.Marshal(event.Data)
+		if err != nil {
+			return fmt.Errorf("failed to marshal SSE event data: %w", err)
+		}
+		if _, err := fmt.Fprintf(&buf, "data: %s\n\n", jsonData); err != nil {
+			return fmt.Errorf("failed to format SSE event: %w", err)
+		}
+	}
+	if _, err := w.Write(buf.Bytes()); err != nil {
+		return fmt.Errorf("failed to write SSE event batch: %w", err)
+	}
+	return nil
+}
+
 // FormatJSONRPCEventBatch formats multiple JSON-RPC events in a single write operation.
 // This reduces the number of write calls and improves performance for high-frequency event streams.
 // All events are formatted into a single buffer and written once.

--- a/internal/sse/sse_test.go
+++ b/internal/sse/sse_test.go
@@ -15,7 +15,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/internal/jsonrpc"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
 )
 
 func TestNewEventReader(t *testing.T) {
@@ -341,6 +343,25 @@ func TestFormatJSONRPCEventBatch(t *testing.T) {
 	}
 
 	assert.Equal(t, 3, eventCount, "Should have processed 3 events")
+}
+
+func TestFormatEventBatchWritesRawData(t *testing.T) {
+	var buf bytes.Buffer
+	events := []EventBatch{{
+		EventType: protocol.EventMessage,
+		ID:        "request-id",
+		Data: &protocol.StreamResponse{Result: func() protocol.StreamEvent {
+			message := protocol.NewMessage(protocol.MessageRoleAgent, []*protocol.Part{protocol.NewTextPart("hello")})
+			return &message
+		}()},
+	}}
+
+	require.NoError(t, FormatEventBatch(&buf, events))
+	output := buf.String()
+	assert.Contains(t, output, "data: {\"message\":")
+	assert.NotContains(t, output, "jsonrpc")
+	assert.NotContains(t, output, "result")
+	assert.NotContains(t, output, "event:")
 }
 
 func TestFormatJSONRPCEventBatch_EmptySlice(t *testing.T) {

--- a/protocol/agentcard.go
+++ b/protocol/agentcard.go
@@ -86,7 +86,7 @@ func (c *AgentCard) NormalizeInterfaces() {
 	if len(c.SupportedInterfaces) > 0 || c.URL == "" {
 		return
 	}
-	binding := "JSONRPC"
+	binding := ProtocolBindingJSONRPC
 	if c.PreferredTransport != nil && *c.PreferredTransport != "" {
 		binding = *c.PreferredTransport
 	}

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -48,3 +48,16 @@ const (
 	JWKSPath           = "/.well-known/jwks.json"
 	DefaultJSONRPCPath = "/"
 )
+
+// Standard A2A protocol binding names.
+const (
+	ProtocolBindingJSONRPC  = "JSONRPC"
+	ProtocolBindingHTTPJSON = "HTTP+JSON"
+)
+
+// Standard HTTP media types used by A2A bindings.
+const (
+	MediaTypeJSON        = "application/json"
+	MediaTypeA2AJSON     = "application/a2a+json"
+	MediaTypeEventStream = "text/event-stream"
+)

--- a/push/sender.go
+++ b/push/sender.go
@@ -158,7 +158,7 @@ func (s *HTTPSender) SendPush(
 	}
 	// The A2A spec (§4.3.3 Push Notification Payload) uses application/a2a+json
 	// for the delivered StreamResponse body.
-	req.Header.Set("Content-Type", "application/a2a+json")
+	req.Header.Set("Content-Type", protocol.MediaTypeA2AJSON)
 
 	if err := s.applyAuthorization(ctx, cfg, body, req); err != nil {
 		return err

--- a/server/http_json.go
+++ b/server/http_json.go
@@ -1,0 +1,710 @@
+// Tencent is pleased to support the open source community by making trpc-a2a-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-a2a-go is licensed under the Apache License Version 2.0.
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"trpc.group/trpc-go/trpc-a2a-go/v2/internal/sse"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/log"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/push"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
+)
+
+type httpJSONRoute struct {
+	operation string
+	tenant    string
+	taskID    string
+	configID  string
+}
+
+func normalizeHTTPJSONBasePath(basePath string) string {
+	basePath = strings.TrimSpace(basePath)
+	if basePath == "" || basePath == "/" {
+		return ""
+	}
+	if !strings.HasPrefix(basePath, "/") {
+		basePath = "/" + basePath
+	}
+	return strings.TrimSuffix(basePath, "/")
+}
+
+func httpJSONServeMuxPattern(basePath string) string {
+	basePath = normalizeHTTPJSONBasePath(basePath)
+	if basePath == "" {
+		return "/"
+	}
+	return basePath + "/"
+}
+
+func agentInterfaceURL(card AgentCard, binding string) string {
+	for _, iface := range card.SupportedInterfaces {
+		if strings.EqualFold(iface.ProtocolBinding, binding) {
+			return iface.URL
+		}
+	}
+	return ""
+}
+
+func parseHTTPJSONRoute(requestPath, basePath string) (httpJSONRoute, bool) {
+	basePath = normalizeHTTPJSONBasePath(basePath)
+	escapedBasePath := (&url.URL{Path: basePath}).EscapedPath()
+	if escapedBasePath != "" {
+		if !strings.HasPrefix(requestPath, escapedBasePath+"/") {
+			return httpJSONRoute{}, false
+		}
+		requestPath = strings.TrimPrefix(requestPath, escapedBasePath)
+	}
+
+	rawSegments := strings.Split(strings.Trim(requestPath, "/"), "/")
+	if len(rawSegments) == 1 && rawSegments[0] == "" {
+		return httpJSONRoute{}, false
+	}
+	segments := make([]string, len(rawSegments))
+	for i, segment := range rawSegments {
+		decoded, err := url.PathUnescape(segment)
+		if err != nil || decoded == "" {
+			return httpJSONRoute{}, false
+		}
+		segments[i] = decoded
+	}
+
+	if route, ok := matchHTTPJSONRouteSegments(segments, ""); ok {
+		return route, true
+	}
+	if len(segments) > 1 {
+		return matchHTTPJSONRouteSegments(segments[1:], segments[0])
+	}
+	return httpJSONRoute{}, false
+}
+
+func agentCardsAdvertiseBinding(s *A2AServer, binding string) bool {
+	if s.agentCardSet && agentInterfaceURL(s.agentCard, binding) != "" {
+		return true
+	}
+	for _, card := range s.tenantCards {
+		if agentInterfaceURL(card, binding) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func matchHTTPJSONRouteSegments(segments []string, tenant string) (httpJSONRoute, bool) {
+	if len(segments) == 1 {
+		switch segments[0] {
+		case "message:send":
+			return httpJSONRoute{operation: protocol.MethodMessageSend, tenant: tenant}, true
+		case "message:stream":
+			return httpJSONRoute{operation: protocol.MethodMessageStream, tenant: tenant}, true
+		case "tasks":
+			return httpJSONRoute{operation: protocol.MethodTasksList, tenant: tenant}, true
+		case "extendedAgentCard":
+			return httpJSONRoute{operation: protocol.MethodAgentAuthenticatedExtendedCard, tenant: tenant}, true
+		}
+	}
+	if len(segments) < 2 || segments[0] != "tasks" {
+		return httpJSONRoute{}, false
+	}
+	if len(segments) == 2 {
+		taskSegment := segments[1]
+		switch {
+		case strings.HasSuffix(taskSegment, ":cancel"):
+			taskID := strings.TrimSuffix(taskSegment, ":cancel")
+			if taskID == "" {
+				return httpJSONRoute{}, false
+			}
+			return httpJSONRoute{
+				operation: protocol.MethodTasksCancel,
+				tenant:    tenant,
+				taskID:    taskID,
+			}, true
+		case strings.HasSuffix(taskSegment, ":subscribe"):
+			taskID := strings.TrimSuffix(taskSegment, ":subscribe")
+			if taskID == "" {
+				return httpJSONRoute{}, false
+			}
+			return httpJSONRoute{
+				operation: protocol.MethodTasksResubscribe,
+				tenant:    tenant,
+				taskID:    taskID,
+			}, true
+		default:
+			return httpJSONRoute{operation: protocol.MethodTasksGet, tenant: tenant, taskID: taskSegment}, true
+		}
+	}
+	if len(segments) == 3 && segments[2] == "pushNotificationConfigs" {
+		return httpJSONRoute{
+			operation: protocol.MethodTasksPushNotificationConfigList,
+			tenant:    tenant,
+			taskID:    segments[1],
+		}, true
+	}
+	if len(segments) == 4 && segments[2] == "pushNotificationConfigs" {
+		return httpJSONRoute{
+			operation: protocol.MethodTasksPushNotificationConfigGet,
+			tenant:    tenant,
+			taskID:    segments[1],
+			configID:  segments[3],
+		}, true
+	}
+	return httpJSONRoute{}, false
+}
+
+func (s *A2AServer) handleHTTPJSON(w http.ResponseWriter, r *http.Request) {
+	if s.corsEnabled {
+		setCORSHeaders(w)
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+	}
+
+	route, ok := parseHTTPJSONRoute(r.URL.EscapedPath(), s.httpJSONBasePath)
+	if !ok {
+		s.writeHTTPJSONStatus(w, http.StatusNotFound, "NOT_FOUND", "HTTP+JSON endpoint not found")
+		return
+	}
+	if !httpJSONMethodAllowed(route.operation, r.Method) {
+		w.Header().Set("Allow", strings.Join(httpJSONAllowedMethods(route.operation), ", "))
+		s.writeHTTPJSONStatus(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "HTTP method not allowed")
+		return
+	}
+	requestedVersion := r.Header.Get("A2A-Version")
+	if requestedVersion == "" {
+		requestedVersion = r.URL.Query().Get("A2A-Version")
+	}
+	if requestedVersion != "" && requestedVersion != protocol.ProtocolVersionV1 {
+		s.writeHTTPJSONError(w, taskmanager.ErrVersionNotSupported(requestedVersion), route.taskID)
+		return
+	}
+	if err := validateHTTPJSONContentType(r); err != nil {
+		s.writeHTTPJSONError(w, err, route.taskID)
+		return
+	}
+
+	switch route.operation {
+	case protocol.MethodMessageSend:
+		s.handleHTTPJSONMessageSend(w, r, route)
+	case protocol.MethodMessageStream:
+		s.handleHTTPJSONMessageStream(w, r, route)
+	case protocol.MethodTasksGet:
+		s.handleHTTPJSONTaskGet(w, r, route)
+	case protocol.MethodTasksList:
+		s.handleHTTPJSONTasksList(w, r, route)
+	case protocol.MethodTasksCancel:
+		s.handleHTTPJSONTaskCancel(w, r, route)
+	case protocol.MethodTasksResubscribe:
+		s.handleHTTPJSONTaskSubscribe(w, r, route)
+	case protocol.MethodTasksPushNotificationConfigList:
+		if r.Method == http.MethodPost {
+			s.handleHTTPJSONPushConfigCreate(w, r, route)
+		} else {
+			s.handleHTTPJSONPushConfigList(w, r, route)
+		}
+	case protocol.MethodTasksPushNotificationConfigGet:
+		if r.Method == http.MethodDelete {
+			s.handleHTTPJSONPushConfigDelete(w, r, route)
+		} else {
+			s.handleHTTPJSONPushConfigGet(w, r, route)
+		}
+	case protocol.MethodAgentAuthenticatedExtendedCard:
+		s.handleHTTPJSONExtendedAgentCard(w, r, route)
+	default:
+		s.writeHTTPJSONStatus(w, http.StatusNotFound, "NOT_FOUND", "HTTP+JSON endpoint not found")
+	}
+}
+
+func httpJSONAllowedMethods(operation string) []string {
+	switch operation {
+	case protocol.MethodMessageSend, protocol.MethodMessageStream, protocol.MethodTasksCancel:
+		return []string{http.MethodPost}
+	case protocol.MethodTasksResubscribe:
+		return []string{http.MethodGet, http.MethodPost}
+	case protocol.MethodTasksPushNotificationConfigList:
+		return []string{http.MethodGet, http.MethodPost}
+	case protocol.MethodTasksPushNotificationConfigGet:
+		return []string{http.MethodGet, http.MethodDelete}
+	default:
+		return []string{http.MethodGet}
+	}
+}
+
+func httpJSONMethodAllowed(operation, method string) bool {
+	for _, allowed := range httpJSONAllowedMethods(operation) {
+		if method == allowed {
+			return true
+		}
+	}
+	return false
+}
+
+func validateHTTPJSONContentType(r *http.Request) error {
+	contentType := r.Header.Get("Content-Type")
+	if contentType == "" {
+		return nil
+	}
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil || (mediaType != protocol.MediaTypeA2AJSON && mediaType != protocol.MediaTypeJSON) {
+		return taskmanager.ErrContentTypeNotSupported(contentType)
+	}
+	return nil
+}
+
+func decodeHTTPJSONBody(r *http.Request, target any, required bool) error {
+	if r.Body == nil {
+		if required {
+			return taskmanager.ErrInvalidParams("request body is required")
+		}
+		return nil
+	}
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(target); err != nil {
+		if errors.Is(err, io.EOF) && !required {
+			return nil
+		}
+		return taskmanager.ErrInvalidParams(fmt.Sprintf("failed to parse request body: %v", err))
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return taskmanager.ErrInvalidParams("request body must contain exactly one JSON value")
+	}
+	return nil
+}
+
+func reconcileHTTPJSONTenant(pathTenant, payloadTenant string) (string, error) {
+	if pathTenant == "" {
+		return payloadTenant, nil
+	}
+	if payloadTenant != "" && payloadTenant != pathTenant {
+		return "", taskmanager.ErrInvalidParams("tenant in request does not match tenant in URL path")
+	}
+	return pathTenant, nil
+}
+
+func (s *A2AServer) handleHTTPJSONMessageSend(w http.ResponseWriter, r *http.Request, route httpJSONRoute) {
+	tracker := newMetricsTracker(protocol.MethodMessageSend, false, s.firstTokenPolicy, s.telemetryMetrics)
+	defer tracker.record(r.Context())
+
+	var params protocol.SendMessageParams
+	if err := decodeHTTPJSONBody(r, &params, true); err != nil {
+		tracker.setError(errTypeInvalidParams)
+		s.writeHTTPJSONError(w, err, "")
+		return
+	}
+	tenant, err := reconcileHTTPJSONTenant(route.tenant, params.Tenant)
+	if err != nil {
+		tracker.setError(errTypeInvalidParams)
+		s.writeHTTPJSONError(w, err, "")
+		return
+	}
+	params.Tenant = tenant
+	if err := s.validateSendMessageParams(r.Context(), &params); err != nil {
+		tracker.setValidateSendMessageError(err)
+		s.writeHTTPJSONError(w, err, "")
+		return
+	}
+	result, err := s.taskManager.OnSendMessage(r.Context(), params)
+	if err != nil {
+		tracker.setError(errTypeMessageProcessingFailed)
+		taskID := ""
+		if params.Message.TaskID != nil {
+			taskID = *params.Message.TaskID
+		}
+		s.writeHTTPJSONError(w, err, taskID)
+		return
+	}
+	tracker.observeNonStreamingResult(result)
+	s.writeHTTPJSONResponse(w, http.StatusOK, result)
+}
+
+func (s *A2AServer) handleHTTPJSONMessageStream(w http.ResponseWriter, r *http.Request, route httpJSONRoute) {
+	tracker := newMetricsTracker(protocol.MethodMessageStream, true, s.firstTokenPolicy, s.telemetryMetrics)
+
+	var params protocol.SendMessageParams
+	if err := decodeHTTPJSONBody(r, &params, true); err != nil {
+		tracker.setError(errTypeInvalidParams)
+		tracker.record(r.Context())
+		s.writeHTTPJSONError(w, err, "")
+		return
+	}
+	tenant, err := reconcileHTTPJSONTenant(route.tenant, params.Tenant)
+	if err != nil {
+		tracker.setError(errTypeInvalidParams)
+		tracker.record(r.Context())
+		s.writeHTTPJSONError(w, err, "")
+		return
+	}
+	params.Tenant = tenant
+	if err := s.validateSendMessageParams(r.Context(), &params); err != nil {
+		tracker.setValidateSendMessageError(err)
+		tracker.record(r.Context())
+		s.writeHTTPJSONError(w, err, "")
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		tracker.setError(errTypeStreamingNotSupported)
+		tracker.record(r.Context())
+		s.writeHTTPJSONError(w, taskmanager.ErrInternalError("server does not support streaming"), "")
+		return
+	}
+	events, err := s.taskManager.OnSendMessageStream(r.Context(), params)
+	if err != nil {
+		tracker.setError(errTypeSubscribeFailed)
+		tracker.record(r.Context())
+		taskID := ""
+		if params.Message.TaskID != nil {
+			taskID = *params.Message.TaskID
+		}
+		s.writeHTTPJSONError(w, err, taskID)
+		return
+	}
+	streamID := params.Message.MessageID
+	if params.Message.TaskID != nil {
+		streamID = *params.Message.TaskID
+	}
+	handleSSEStream(r.Context(), s.corsEnabled, w, flusher, events, streamID, tracker, sse.FormatEventBatch)
+}
+
+func (s *A2AServer) handleHTTPJSONTaskGet(w http.ResponseWriter, r *http.Request, route httpJSONRoute) {
+	params := protocol.TaskQueryParams{ID: route.taskID}
+	var err error
+	params.Tenant, err = reconcileHTTPJSONTenant(route.tenant, r.URL.Query().Get("tenant"))
+	if err == nil {
+		params.HistoryLength, err = parseOptionalIntQuery(r, "historyLength")
+	}
+	if err != nil {
+		s.writeHTTPJSONError(w, err, route.taskID)
+		return
+	}
+	result, err := s.taskManager.OnGetTask(r.Context(), params)
+	if err != nil {
+		s.writeHTTPJSONError(w, err, route.taskID)
+		return
+	}
+	s.writeHTTPJSONResponse(w, http.StatusOK, result)
+}
+
+func (s *A2AServer) handleHTTPJSONTasksList(w http.ResponseWriter, r *http.Request, route httpJSONRoute) {
+	query := r.URL.Query()
+	params := protocol.ListTasksParams{
+		ContextID:            query.Get("contextId"),
+		Status:               protocol.TaskState(query.Get("status")),
+		PageToken:            query.Get("pageToken"),
+		StatusTimestampAfter: query.Get("statusTimestampAfter"),
+	}
+	var err error
+	params.Tenant, err = reconcileHTTPJSONTenant(route.tenant, query.Get("tenant"))
+	if err == nil {
+		params.PageSize, err = parseOptionalIntQuery(r, "pageSize")
+	}
+	if err == nil {
+		params.HistoryLength, err = parseOptionalIntQuery(r, "historyLength")
+	}
+	if err == nil {
+		params.IncludeArtifacts, err = parseOptionalBoolQuery(r, "includeArtifacts")
+	}
+	if err != nil {
+		s.writeHTTPJSONError(w, err, "")
+		return
+	}
+	result, err := s.taskManager.OnListTasks(r.Context(), params)
+	if err != nil {
+		s.writeHTTPJSONError(w, err, "")
+		return
+	}
+	s.writeHTTPJSONResponse(w, http.StatusOK, result)
+}
+
+func (s *A2AServer) handleHTTPJSONTaskCancel(w http.ResponseWriter, r *http.Request, route httpJSONRoute) {
+	params := protocol.TaskIDParams{}
+	if err := decodeHTTPJSONBody(r, &params, false); err != nil {
+		s.writeHTTPJSONError(w, err, route.taskID)
+		return
+	}
+	if params.ID != "" && params.ID != route.taskID {
+		s.writeHTTPJSONError(w, taskmanager.ErrInvalidParams("task ID in request does not match URL path"), route.taskID)
+		return
+	}
+	tenant, err := reconcileHTTPJSONTenant(route.tenant, params.Tenant)
+	if err != nil {
+		s.writeHTTPJSONError(w, err, route.taskID)
+		return
+	}
+	params.ID = route.taskID
+	params.Tenant = tenant
+	result, err := s.taskManager.OnCancelTask(r.Context(), params)
+	if err != nil {
+		s.writeHTTPJSONError(w, err, route.taskID)
+		return
+	}
+	s.writeHTTPJSONResponse(w, http.StatusOK, result)
+}
+
+func (s *A2AServer) handleHTTPJSONTaskSubscribe(w http.ResponseWriter, r *http.Request, route httpJSONRoute) {
+	tenant, err := reconcileHTTPJSONTenant(route.tenant, r.URL.Query().Get("tenant"))
+	if err != nil {
+		s.writeHTTPJSONError(w, err, route.taskID)
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		s.writeHTTPJSONError(w, taskmanager.ErrInternalError("server does not support streaming"), route.taskID)
+		return
+	}
+	events, err := s.taskManager.OnResubscribe(r.Context(), protocol.TaskIDParams{ID: route.taskID, Tenant: tenant})
+	if err != nil {
+		s.writeHTTPJSONError(w, err, route.taskID)
+		return
+	}
+	handleSSEStream(r.Context(), s.corsEnabled, w, flusher, events, route.taskID, nil, sse.FormatEventBatch)
+}
+
+func (s *A2AServer) handleHTTPJSONPushConfigCreate(w http.ResponseWriter, r *http.Request, route httpJSONRoute) {
+	var params protocol.TaskPushNotificationConfig
+	if err := decodeHTTPJSONBody(r, &params, true); err != nil {
+		s.writeHTTPJSONError(w, err, route.taskID)
+		return
+	}
+	if params.TaskID != "" && params.TaskID != route.taskID {
+		s.writeHTTPJSONError(w, taskmanager.ErrInvalidParams("task ID in request does not match URL path"), route.taskID)
+		return
+	}
+	tenant, err := reconcileHTTPJSONTenant(route.tenant, params.Tenant)
+	if err != nil {
+		s.writeHTTPJSONError(w, err, route.taskID)
+		return
+	}
+	params.TaskID = route.taskID
+	params.Tenant = tenant
+	if err := push.ValidateConfig(params); err != nil {
+		s.writeHTTPJSONError(w, taskmanager.ErrInvalidParams(err.Error()), route.taskID)
+		return
+	}
+	if !s.pushAvailableForTenant(r.Context(), tenant) {
+		s.writeHTTPJSONError(w, taskmanager.ErrPushNotificationNotSupported(), route.taskID)
+		return
+	}
+	result, err := s.taskManager.OnPushNotificationSet(r.Context(), params)
+	if err != nil {
+		s.writeHTTPJSONError(w, err, route.taskID)
+		return
+	}
+	s.writeHTTPJSONResponse(w, http.StatusCreated, result)
+}
+
+func (s *A2AServer) handleHTTPJSONPushConfigGet(w http.ResponseWriter, r *http.Request, route httpJSONRoute) {
+	tenant, err := reconcileHTTPJSONTenant(route.tenant, r.URL.Query().Get("tenant"))
+	if err != nil {
+		s.writeHTTPJSONError(w, err, route.taskID)
+		return
+	}
+	if !s.pushAvailableForTenant(r.Context(), tenant) {
+		s.writeHTTPJSONError(w, taskmanager.ErrPushNotificationNotSupported(), route.taskID)
+		return
+	}
+	params := protocol.GetTaskPushNotificationConfigParams{
+		TaskID: route.taskID,
+		ID:     route.configID,
+		Tenant: tenant,
+	}
+	result, err := s.taskManager.OnPushNotificationGet(r.Context(), params)
+	if err != nil {
+		s.writeHTTPJSONError(w, err, route.taskID)
+		return
+	}
+	s.writeHTTPJSONResponse(w, http.StatusOK, result)
+}
+
+func (s *A2AServer) handleHTTPJSONPushConfigList(w http.ResponseWriter, r *http.Request, route httpJSONRoute) {
+	query := r.URL.Query()
+	params := protocol.ListTaskPushNotificationConfigsParams{
+		TaskID:    route.taskID,
+		PageToken: query.Get("pageToken"),
+	}
+	var err error
+	params.Tenant, err = reconcileHTTPJSONTenant(route.tenant, query.Get("tenant"))
+	if err == nil {
+		params.PageSize, err = parseOptionalIntQuery(r, "pageSize")
+	}
+	if err != nil {
+		s.writeHTTPJSONError(w, err, route.taskID)
+		return
+	}
+	if !s.pushAvailableForTenant(r.Context(), params.Tenant) {
+		s.writeHTTPJSONError(w, taskmanager.ErrPushNotificationNotSupported(), route.taskID)
+		return
+	}
+	result, err := s.taskManager.OnPushNotificationList(r.Context(), params)
+	if err != nil {
+		s.writeHTTPJSONError(w, err, route.taskID)
+		return
+	}
+	s.writeHTTPJSONResponse(w, http.StatusOK, result)
+}
+
+func (s *A2AServer) handleHTTPJSONPushConfigDelete(w http.ResponseWriter, r *http.Request, route httpJSONRoute) {
+	tenant, err := reconcileHTTPJSONTenant(route.tenant, r.URL.Query().Get("tenant"))
+	if err != nil {
+		s.writeHTTPJSONError(w, err, route.taskID)
+		return
+	}
+	if !s.pushAvailableForTenant(r.Context(), tenant) {
+		s.writeHTTPJSONError(w, taskmanager.ErrPushNotificationNotSupported(), route.taskID)
+		return
+	}
+	params := protocol.DeleteTaskPushNotificationConfigParams{
+		TaskID: route.taskID,
+		ID:     route.configID,
+		Tenant: tenant,
+	}
+	if err := s.taskManager.OnPushNotificationDelete(r.Context(), params); err != nil {
+		s.writeHTTPJSONError(w, err, route.taskID)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *A2AServer) handleHTTPJSONExtendedAgentCard(w http.ResponseWriter, r *http.Request, route httpJSONRoute) {
+	tenant, err := reconcileHTTPJSONTenant(route.tenant, r.URL.Query().Get("tenant"))
+	if err != nil {
+		s.writeHTTPJSONError(w, err, "")
+		return
+	}
+	card, err := s.resolveExtendedAgentCard(r.Context(), tenant)
+	if err != nil {
+		s.writeHTTPJSONError(w, err, "")
+		return
+	}
+	s.writeHTTPJSONResponse(w, http.StatusOK, card)
+}
+
+func (s *A2AServer) resolveExtendedAgentCard(ctx context.Context, tenant string) (AgentCard, error) {
+	baseCard, ok := s.resolveAgentCard(ctx, tenant)
+	if !ok {
+		return AgentCard{}, taskmanager.ErrInvalidParams("unknown tenant")
+	}
+	if !baseCard.ExtendedAgentCardEnabled() {
+		return AgentCard{}, taskmanager.ErrAuthenticatedExtendedCardNotConfigured()
+	}
+	if s.authenticatedCardHandler == nil {
+		return s.finalizePushCapability(baseCard), nil
+	}
+	card, err := s.authenticatedCardHandler(ctx, baseCard)
+	if err != nil {
+		return AgentCard{}, taskmanager.ErrInternalError("failed to handle extended card")
+	}
+	return s.finalizePushCapability(card), nil
+}
+
+func parseOptionalIntQuery(r *http.Request, name string) (*int, error) {
+	value := r.URL.Query().Get(name)
+	if value == "" {
+		return nil, nil
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return nil, taskmanager.ErrInvalidParams(fmt.Sprintf("%s must be an integer", name))
+	}
+	return &parsed, nil
+}
+
+func parseOptionalBoolQuery(r *http.Request, name string) (*bool, error) {
+	value := r.URL.Query().Get(name)
+	if value == "" {
+		return nil, nil
+	}
+	parsed, err := strconv.ParseBool(value)
+	if err != nil {
+		return nil, taskmanager.ErrInvalidParams(fmt.Sprintf("%s must be true or false", name))
+	}
+	return &parsed, nil
+}
+
+func (s *A2AServer) writeHTTPJSONResponse(w http.ResponseWriter, statusCode int, result any) {
+	w.Header().Set("Content-Type", protocol.MediaTypeA2AJSON)
+	w.WriteHeader(statusCode)
+	if err := json.NewEncoder(w).Encode(result); err != nil {
+		log.Errorf("Failed to write HTTP+JSON response: %v", err)
+	}
+}
+
+func (s *A2AServer) writeHTTPJSONError(w http.ResponseWriter, err error, taskID string) {
+	statusCode, status, reason, message := httpJSONErrorMapping(err)
+	errorBody := map[string]any{
+		"code":    statusCode,
+		"status":  status,
+		"message": message,
+	}
+	if reason != "" {
+		detail := map[string]any{
+			"@type":  "type.googleapis.com/google.rpc.ErrorInfo",
+			"reason": reason,
+			"domain": "a2a-protocol.org",
+		}
+		if taskID != "" {
+			detail["metadata"] = map[string]string{"taskId": taskID}
+		}
+		errorBody["details"] = []any{detail}
+	}
+	s.writeHTTPJSONErrorBody(w, statusCode, map[string]any{"error": errorBody})
+}
+
+func (s *A2AServer) writeHTTPJSONStatus(w http.ResponseWriter, statusCode int, status, message string) {
+	s.writeHTTPJSONErrorBody(w, statusCode, map[string]any{
+		"error": map[string]any{
+			"code":    statusCode,
+			"status":  status,
+			"message": message,
+		},
+	})
+}
+
+func (s *A2AServer) writeHTTPJSONErrorBody(w http.ResponseWriter, statusCode int, body any) {
+	w.Header().Set("Content-Type", protocol.MediaTypeA2AJSON)
+	w.WriteHeader(statusCode)
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		log.Errorf("Failed to write HTTP+JSON error response: %v", err)
+	}
+}
+
+func httpJSONErrorMapping(err error) (int, string, string, string) {
+	var taskErr *taskmanager.Error
+	if !errors.As(err, &taskErr) {
+		return http.StatusInternalServerError, "INTERNAL", "", "Internal error"
+	}
+	switch taskErr.Code {
+	case taskmanager.ErrCodeInvalidParams:
+		return http.StatusBadRequest, "INVALID_ARGUMENT", "", taskErr.Message
+	case taskmanager.ErrCodeTaskNotFound:
+		return http.StatusNotFound, "NOT_FOUND", string(taskErr.Code), taskErr.Message
+	case taskmanager.ErrCodeTaskNotCancelable,
+		taskmanager.ErrCodePushNotificationNotSupported,
+		taskmanager.ErrCodeUnsupportedOperation,
+		taskmanager.ErrCodeAuthenticatedExtendedCardNotConfigured,
+		taskmanager.ErrCodeExtensionSupportRequired,
+		taskmanager.ErrCodeVersionNotSupported:
+		return http.StatusBadRequest, "FAILED_PRECONDITION", string(taskErr.Code), taskErr.Message
+	case taskmanager.ErrCodeContentTypeNotSupported:
+		return http.StatusBadRequest, "INVALID_ARGUMENT", string(taskErr.Code), taskErr.Message
+	case taskmanager.ErrCodeInvalidAgentResponse:
+		return http.StatusInternalServerError, "INTERNAL", string(taskErr.Code), taskErr.Message
+	default:
+		return http.StatusInternalServerError, "INTERNAL", "", "Internal error"
+	}
+}

--- a/server/http_json_test.go
+++ b/server/http_json_test.go
@@ -9,6 +9,7 @@ package server
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"mime"
 	"net/http"
 	"net/http/httptest"
@@ -18,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
 )
 
 func TestParseHTTPJSONRoute(t *testing.T) {
@@ -170,4 +172,162 @@ func TestHTTPJSONStreamUsesRawSSEData(t *testing.T) {
 	assert.Contains(t, recorder.Body.String(), "data: {\"message\":")
 	assert.NotContains(t, recorder.Body.String(), "jsonrpc")
 	assert.NotContains(t, recorder.Body.String(), "\"result\"")
+}
+
+func TestHTTPJSONTaskPushAndExtendedCardRoutes(t *testing.T) {
+	manager := newMockTaskManager()
+	manager.pushSupported = true
+	manager.tasks["task-1"] = &protocol.Task{
+		ID:        "task-1",
+		ContextID: "context-1",
+		Status:    protocol.TaskStatus{State: protocol.TaskStateWorking},
+	}
+	manager.pushNotificationGetResponse = &protocol.TaskPushNotificationConfig{
+		ID:     "config-1",
+		TaskID: "task-1",
+		URL:    "https://example.com/webhook",
+	}
+	extended := true
+	card := defaultAgentCard()
+	card.Capabilities.ExtendedAgentCard = &extended
+	srv, err := NewA2AServer(manager, WithAgentCard(card), WithHTTPJSONEndpoint("/"))
+	require.NoError(t, err)
+
+	request := func(method, target string, body any) *httptest.ResponseRecorder {
+		t.Helper()
+		var encoded []byte
+		if body != nil {
+			encoded, err = json.Marshal(body)
+			require.NoError(t, err)
+		}
+		req := httptest.NewRequest(method, target, bytes.NewReader(encoded))
+		if body != nil {
+			req.Header.Set("Content-Type", protocol.MediaTypeA2AJSON)
+		}
+		recorder := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(recorder, req)
+		return recorder
+	}
+
+	recorder := request(
+		http.MethodGet,
+		"/tasks?contextId=context-1&status=TASK_STATE_WORKING&pageSize=5&historyLength=2&includeArtifacts=true",
+		nil,
+	)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "\"tasks\"")
+
+	recorder = request(http.MethodGet, "/tasks?pageSize=invalid", nil)
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	recorder = request(http.MethodGet, "/tasks?includeArtifacts=invalid", nil)
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+
+	recorder = request(http.MethodPost, "/tasks/task-1:cancel", protocol.TaskIDParams{ID: "task-1"})
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "TASK_STATE_CANCELED")
+	recorder = request(http.MethodPost, "/tasks/task-1:cancel", protocol.TaskIDParams{ID: "other-task"})
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+
+	recorder = request(http.MethodPost, "/tasks/task-1:subscribe", nil)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.Equal(t, protocol.MediaTypeEventStream, recorder.Header().Get("Content-Type"))
+	assert.Contains(t, recorder.Body.String(), "data:")
+
+	config := protocol.TaskPushNotificationConfig{
+		ID:     "config-1",
+		TaskID: "task-1",
+		URL:    "https://example.com/webhook",
+	}
+	recorder = request(http.MethodPost, "/tasks/task-1/pushNotificationConfigs", config)
+	assert.Equal(t, http.StatusCreated, recorder.Code)
+	recorder = request(http.MethodGet, "/tasks/task-1/pushNotificationConfigs/config-1", nil)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	recorder = request(http.MethodGet, "/tasks/task-1/pushNotificationConfigs?pageSize=5&pageToken=next", nil)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	recorder = request(http.MethodDelete, "/tasks/task-1/pushNotificationConfigs/config-1", nil)
+	assert.Equal(t, http.StatusNoContent, recorder.Code)
+
+	recorder = request(http.MethodGet, "/extendedAgentCard", nil)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "Test Agent")
+
+	recorder = request(http.MethodPut, "/tasks", nil)
+	assert.Equal(t, http.StatusMethodNotAllowed, recorder.Code)
+	assert.Equal(t, http.MethodGet, recorder.Header().Get("Allow"))
+	recorder = request(http.MethodGet, "/unknown", nil)
+	assert.Equal(t, http.StatusNotFound, recorder.Code)
+}
+
+func TestHTTPJSONValidationAndCapabilityErrors(t *testing.T) {
+	manager := newMockTaskManager()
+	srv, err := NewA2AServer(manager, WithAgentCard(defaultAgentCard()), WithHTTPJSONEndpoint("/"))
+	require.NoError(t, err)
+
+	request := func(method, target, body string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(method, target, bytes.NewBufferString(body))
+		if body != "" {
+			req.Header.Set("Content-Type", protocol.MediaTypeA2AJSON)
+		}
+		recorder := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(recorder, req)
+		return recorder
+	}
+
+	recorder := request(http.MethodPost, "/message:send", "")
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	recorder = request(http.MethodPost, "/message:send", `{}`)
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	recorder = request(http.MethodPost, "/message:send", `{"message":{"role":"ROLE_AGENT","parts":[{"text":"bad"}]}}`)
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	recorder = request(http.MethodPost, "/tasks/task-1:cancel", `{invalid`)
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	recorder = request(http.MethodPost, "/tenant-a/tasks/task-1:cancel", `{"tenant":"tenant-b"}`)
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+
+	recorder = request(
+		http.MethodPost,
+		"/tasks/task-1/pushNotificationConfigs",
+		`{"taskId":"task-1","url":"not-a-url"}`,
+	)
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	recorder = request(http.MethodGet, "/tasks/task-1/pushNotificationConfigs/config-1", "")
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "PUSH_NOTIFICATION_NOT_SUPPORTED")
+
+	recorder = request(http.MethodGet, "/extendedAgentCard", "")
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "EXTENDED_AGENT_CARD_NOT_CONFIGURED")
+}
+
+func TestHTTPJSONErrorMapping(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		statusCode int
+		status     string
+		reason     string
+	}{
+		{name: "plain error", err: errors.New("boom"), statusCode: http.StatusInternalServerError, status: "INTERNAL"},
+		{name: "invalid params", err: taskmanager.ErrInvalidParams("bad"), statusCode: http.StatusBadRequest, status: "INVALID_ARGUMENT"},
+		{name: "task not found", err: taskmanager.ErrTaskNotFound("task"), statusCode: http.StatusNotFound, status: "NOT_FOUND", reason: "TASK_NOT_FOUND"},
+		{name: "not cancelable", err: taskmanager.ErrTaskNotCancelable("task", protocol.TaskStateCompleted), statusCode: http.StatusBadRequest, status: "FAILED_PRECONDITION", reason: "TASK_NOT_CANCELABLE"},
+		{name: "push unsupported", err: taskmanager.ErrPushNotificationNotSupported(), statusCode: http.StatusBadRequest, status: "FAILED_PRECONDITION", reason: "PUSH_NOTIFICATION_NOT_SUPPORTED"},
+		{name: "unsupported", err: taskmanager.ErrUnsupportedOperation("operation"), statusCode: http.StatusBadRequest, status: "FAILED_PRECONDITION", reason: "UNSUPPORTED_OPERATION"},
+		{name: "content type", err: taskmanager.ErrContentTypeNotSupported("type"), statusCode: http.StatusBadRequest, status: "INVALID_ARGUMENT", reason: "CONTENT_TYPE_NOT_SUPPORTED"},
+		{name: "invalid agent response", err: taskmanager.ErrInvalidAgentResponse("bad"), statusCode: http.StatusInternalServerError, status: "INTERNAL", reason: "INVALID_AGENT_RESPONSE"},
+		{name: "extended card", err: taskmanager.ErrAuthenticatedExtendedCardNotConfigured(), statusCode: http.StatusBadRequest, status: "FAILED_PRECONDITION", reason: "EXTENDED_AGENT_CARD_NOT_CONFIGURED"},
+		{name: "extension", err: taskmanager.ErrExtensionSupportRequired("extension"), statusCode: http.StatusBadRequest, status: "FAILED_PRECONDITION", reason: "EXTENSION_SUPPORT_REQUIRED"},
+		{name: "version", err: taskmanager.ErrVersionNotSupported("2.0"), statusCode: http.StatusBadRequest, status: "FAILED_PRECONDITION", reason: "VERSION_NOT_SUPPORTED"},
+		{name: "internal", err: taskmanager.ErrInternalError("boom"), statusCode: http.StatusInternalServerError, status: "INTERNAL"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			statusCode, status, reason, message := httpJSONErrorMapping(tt.err)
+			assert.Equal(t, tt.statusCode, statusCode)
+			assert.Equal(t, tt.status, status)
+			assert.Equal(t, tt.reason, reason)
+			assert.NotEmpty(t, message)
+		})
+	}
 }

--- a/server/http_json_test.go
+++ b/server/http_json_test.go
@@ -1,0 +1,173 @@
+// Tencent is pleased to support the open source community by making trpc-a2a-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-a2a-go is licensed under the Apache License Version 2.0.
+
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"mime"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
+)
+
+func TestParseHTTPJSONRoute(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		basePath  string
+		operation string
+		tenant    string
+		taskID    string
+		configID  string
+	}{
+		{name: "send", path: "/message:send", operation: protocol.MethodMessageSend},
+		{name: "stream tenant", path: "/tenant-a/message:stream", operation: protocol.MethodMessageStream, tenant: "tenant-a"},
+		{name: "get task", path: "/tasks/task-1", operation: protocol.MethodTasksGet, taskID: "task-1"},
+		{name: "list tasks under base", path: "/api/a2a/tasks", basePath: "/api/a2a", operation: protocol.MethodTasksList},
+		{name: "cancel", path: "/tasks/task-1:cancel", operation: protocol.MethodTasksCancel, taskID: "task-1"},
+		{name: "subscribe", path: "/tasks/task-1:subscribe", operation: protocol.MethodTasksResubscribe, taskID: "task-1"},
+		{name: "create or list push", path: "/tasks/task-1/pushNotificationConfigs", operation: protocol.MethodTasksPushNotificationConfigList, taskID: "task-1"},
+		{name: "get or delete push", path: "/tenant-a/tasks/task-1/pushNotificationConfigs/config-1", operation: protocol.MethodTasksPushNotificationConfigGet, tenant: "tenant-a", taskID: "task-1", configID: "config-1"},
+		{name: "extended card", path: "/extendedAgentCard", operation: protocol.MethodAgentAuthenticatedExtendedCard},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			route, ok := parseHTTPJSONRoute(tt.path, tt.basePath)
+			require.True(t, ok)
+			assert.Equal(t, tt.operation, route.operation)
+			assert.Equal(t, tt.tenant, route.tenant)
+			assert.Equal(t, tt.taskID, route.taskID)
+			assert.Equal(t, tt.configID, route.configID)
+		})
+	}
+}
+
+func TestHTTPJSONMediaTypesAndRawResponse(t *testing.T) {
+	srv, err := NewA2AServer(
+		newMockTaskManager(),
+		WithAgentCard(defaultAgentCard()),
+		WithHTTPJSONEndpoint("/"),
+	)
+	require.NoError(t, err)
+
+	params := protocol.SendMessageParams{Message: protocol.Message{
+		MessageID: "message-1",
+		Role:      protocol.MessageRoleUser,
+		Parts:     []*protocol.Part{protocol.NewTextPart("hello")},
+	}}
+	body, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	for _, contentType := range []string{
+		protocol.MediaTypeA2AJSON + "; charset=utf-8",
+		protocol.MediaTypeJSON,
+	} {
+		t.Run(contentType, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/message:send", bytes.NewReader(body))
+			req.Header.Set("Content-Type", contentType)
+			recorder := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(recorder, req)
+
+			assert.Equal(t, http.StatusOK, recorder.Code)
+			assert.Equal(t, protocol.MediaTypeA2AJSON, recorder.Header().Get("Content-Type"))
+			mediaType, _, parseErr := mime.ParseMediaType(recorder.Header().Get("Content-Type"))
+			require.NoError(t, parseErr)
+			assert.Equal(t, protocol.MediaTypeA2AJSON, mediaType)
+			var response map[string]any
+			require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+			assert.Contains(t, response, "message")
+			assert.NotContains(t, response, "jsonrpc")
+			assert.NotContains(t, response, "result")
+		})
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/message:send", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/xml")
+	recorder := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "CONTENT_TYPE_NOT_SUPPORTED")
+
+	req = httptest.NewRequest(http.MethodPost, "/message:send", bytes.NewReader(body))
+	req.Header.Set("Content-Type", protocol.MediaTypeA2AJSON)
+	req.Header.Set("A2A-Version", "2.0")
+	recorder = httptest.NewRecorder()
+	srv.Handler().ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "VERSION_NOT_SUPPORTED")
+
+	req = httptest.NewRequest(http.MethodPost, "/message:send?A2A-Version=2.0", bytes.NewReader(body))
+	req.Header.Set("Content-Type", protocol.MediaTypeA2AJSON)
+	recorder = httptest.NewRecorder()
+	srv.Handler().ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "VERSION_NOT_SUPPORTED")
+}
+
+func TestHTTPJSONTaskNotFoundError(t *testing.T) {
+	srv, err := NewA2AServer(
+		newMockTaskManager(),
+		WithAgentCard(defaultAgentCard()),
+		WithHTTPJSONEndpoint("/"),
+	)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/tasks/missing-task", nil)
+	recorder := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusNotFound, recorder.Code)
+	var response struct {
+		Error struct {
+			Code    int              `json:"code"`
+			Status  string           `json:"status"`
+			Details []map[string]any `json:"details"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	assert.Equal(t, http.StatusNotFound, response.Error.Code)
+	assert.Equal(t, "NOT_FOUND", response.Error.Status)
+	require.Len(t, response.Error.Details, 1)
+	assert.Equal(t, "TASK_NOT_FOUND", response.Error.Details[0]["reason"])
+}
+
+func TestHTTPJSONStreamUsesRawSSEData(t *testing.T) {
+	manager := newMockTaskManager()
+	message := protocol.NewMessage(protocol.MessageRoleAgent, []*protocol.Part{protocol.NewTextPart("hello")})
+	manager.sendMessageStreamEvents = []protocol.StreamResponse{{Result: &message}}
+	srv, err := NewA2AServer(
+		manager,
+		WithAgentCard(defaultAgentCard()),
+		WithHTTPJSONEndpoint("/"),
+	)
+	require.NoError(t, err)
+
+	params := protocol.SendMessageParams{Message: protocol.Message{
+		MessageID: "message-1",
+		Role:      protocol.MessageRoleUser,
+		Parts:     []*protocol.Part{protocol.NewTextPart("hello")},
+	}}
+	body, err := json.Marshal(params)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/message:stream", bytes.NewReader(body))
+	req.Header.Set("Content-Type", protocol.MediaTypeA2AJSON)
+	recorder := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.Equal(t, protocol.MediaTypeEventStream, recorder.Header().Get("Content-Type"))
+	assert.Contains(t, recorder.Body.String(), "data: {\"message\":")
+	assert.NotContains(t, recorder.Body.String(), "jsonrpc")
+	assert.NotContains(t, recorder.Body.String(), "\"result\"")
+}

--- a/server/options.go
+++ b/server/options.go
@@ -63,6 +63,18 @@ func WithJSONRPCEndpoint(path string) Option {
 	}
 }
 
+// WithHTTPJSONEndpoint enables the HTTP+JSON/REST binding and sets its base path.
+// The standard operation paths, such as /message:send and /tasks/{id}, are
+// appended to this base path. The binding is also enabled automatically when a
+// static Agent Card advertises an HTTP+JSON interface.
+func WithHTTPJSONEndpoint(basePath string) Option {
+	return func(s *A2AServer) {
+		s.httpJSONBasePath = normalizeHTTPJSONBasePath(basePath)
+		s.httpJSONPathExplicitlySet = true
+		s.httpJSONEnabled = true
+	}
+}
+
 // WithCompatHandler installs a fallback handler for JSON-RPC requests whose
 // method name is not a v1.0 method (e.g. the legacy slash-delimited names
 // served by compat/v0). The handler is mounted on the same JSON-RPC endpoint
@@ -198,11 +210,13 @@ func WithPushNotificationJWKSHandler(handler http.Handler) Option {
 // The base path will be automatically prepended to all standard A2A endpoints:
 // - Agent card: basePath + "/.well-known/agent-card.json"
 // - JSON-RPC: basePath + "/"
+// - HTTP+JSON: basePath + "/message:send", basePath + "/tasks/{id}", etc.
 // - JWKS: basePath + "/.well-known/jwks.json"
 //
 // Example: WithBasePath("/api/v1/agent") creates endpoints:
 // - /api/v1/agent/.well-known/agent-card.json
 // - /api/v1/agent/
+// - /api/v1/agent/message:send
 // - /api/v1/agent/.well-known/jwks.json
 //
 // The base path should start with "/" and not end with "/".
@@ -228,13 +242,15 @@ func WithBasePath(basePath string) Option {
 		s.agentCardPath = basePath + protocol.AgentCardPath
 		s.oldAgentCardPath = basePath + protocol.OldAgentCardPath
 		s.jwksEndpoint = basePath + protocol.JWKSPath
+		s.httpJSONBasePath = basePath
+		s.httpJSONPathExplicitlySet = true
 	}
 }
 
 // WithMiddleware adds HTTP middleware(s) to the server's chain.
 // Multiple middlewares can be provided and will be chained together.
 // The first middleware in the slice will be the outermost wrapper.
-// Middlewares only take effect on the JSON-RPC endpoint.
+// Middlewares take effect on both JSON-RPC and HTTP+JSON protocol endpoints.
 func WithMiddleware(middlewares ...Middleware) Option {
 	return func(s *A2AServer) {
 		s.middleWare = append(s.middleWare, middlewares...)

--- a/server/server.go
+++ b/server/server.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 
 	"trpc.group/trpc-go/trpc-a2a-go/v2/internal/jsonrpc"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/internal/sse"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/log"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/push"
@@ -33,7 +34,8 @@ import (
 )
 
 // A2AServer implements the HTTP server for the A2A protocol.
-// It handles agent card requests and routes JSON-RPC calls to the TaskManager.
+// It handles Agent Card requests and routes JSON-RPC and HTTP+JSON operations
+// to the TaskManager.
 type A2AServer struct {
 	agentCard        AgentCard               // Default (single-agent) card; optional when multi-tenant.
 	agentCardSet     bool                    // Whether a default card was provided (WithAgentCard).
@@ -42,13 +44,16 @@ type A2AServer struct {
 	httpServerMu     sync.Mutex              // Guards httpServer: Start writes it, Stop reads it.
 	corsEnabled      bool                    // Flag to enable/disable CORS headers.
 	jsonRPCEndpoint  string                  // Path for the JSON-RPC endpoint.
+	httpJSONBasePath string                  // Base path for HTTP+JSON/REST endpoints.
+	httpJSONEnabled  bool                    // Whether the HTTP+JSON binding is mounted.
 	agentCardPath    string                  // Path for the agent card endpoint.
 	oldAgentCardPath string                  // Path for the old agent card endpoint.
 	// pathsExplicitlySet records whether serving paths were configured via an
 	// option (WithBasePath / WithJSONRPCEndpoint / WithJWKSEndpoint). When false,
 	// the base path is derived from the agent card URL. This replaces a fragile
 	// "did the paths change from their defaults?" heuristic.
-	pathsExplicitlySet bool
+	pathsExplicitlySet        bool
+	httpJSONPathExplicitlySet bool
 	// tenantCards is the static tenant -> AgentCard registry (WithTenantCards).
 	// tenantCardProvider resolves a tenant's card dynamically (WithTenantCardProvider).
 	// When either is set the server is multi-tenant: it routes by params.Tenant
@@ -102,6 +107,7 @@ func NewA2AServer(taskManager taskmanager.TaskManager, opts ...Option) (*A2AServ
 		taskManager:      taskManager,
 		corsEnabled:      true, // Enable CORS by default for easier development.
 		jsonRPCEndpoint:  protocol.DefaultJSONRPCPath,
+		httpJSONBasePath: "",
 		agentCardPath:    protocol.AgentCardPath,
 		oldAgentCardPath: protocol.OldAgentCardPath,
 		readTimeout:      defaultReadTimeout,
@@ -130,12 +136,28 @@ func NewA2AServer(taskManager taskmanager.TaskManager, opts ...Option) (*A2AServ
 	// A pure multi-tenant server (no default card) defaults to the root paths;
 	// tenant cards share that single endpoint and use WithBasePath when needed.
 	if !server.pathsExplicitlySet && server.agentCardSet {
-		if basePath := extractBasePathFromURL(server.agentCard.PrimaryURL()); basePath != "" {
-			server.jsonRPCEndpoint = basePath + "/"
-			server.agentCardPath = basePath + protocol.AgentCardPath
-			server.jwksEndpoint = basePath + protocol.JWKSPath
-			server.oldAgentCardPath = basePath + protocol.OldAgentCardPath
+		primaryBasePath := extractBasePathFromURL(server.agentCard.PrimaryURL())
+		if primaryBasePath != "" {
+			server.agentCardPath = primaryBasePath + protocol.AgentCardPath
+			server.jwksEndpoint = primaryBasePath + protocol.JWKSPath
+			server.oldAgentCardPath = primaryBasePath + protocol.OldAgentCardPath
+			if !server.httpJSONPathExplicitlySet {
+				server.httpJSONBasePath = primaryBasePath
+			}
 		}
+		if endpoint := agentInterfaceURL(server.agentCard, protocol.ProtocolBindingJSONRPC); endpoint != "" {
+			if basePath := extractBasePathFromURL(endpoint); basePath != "" {
+				server.jsonRPCEndpoint = basePath + "/"
+			}
+		}
+	}
+	if !server.httpJSONPathExplicitlySet && server.agentCardSet {
+		if endpoint := agentInterfaceURL(server.agentCard, protocol.ProtocolBindingHTTPJSON); endpoint != "" {
+			server.httpJSONBasePath = extractBasePathFromURL(endpoint)
+		}
+	}
+	if agentCardsAdvertiseBinding(server, protocol.ProtocolBindingHTTPJSON) {
+		server.httpJSONEnabled = true
 	}
 
 	if err := server.resolvePushPosture(taskManager); err != nil {
@@ -347,11 +369,38 @@ func (s *A2AServer) Handler() http.Handler {
 		jsonRPCHandler = s.dispatchByProtocol(jsonRPCHandler, s.compatHandler)
 	}
 
-	// Mount the JSON-RPC endpoint inside the authentication middleware chain.
+	if !s.httpJSONEnabled {
+		if len(s.middleWare) > 0 {
+			jsonRPCHandler = MiddlewareChain(s.middleWare).Wrap(jsonRPCHandler)
+		}
+		router.Handle(s.jsonRPCEndpoint, jsonRPCHandler)
+		return router
+	}
+
+	httpJSONHandler := http.Handler(http.HandlerFunc(s.handleHTTPJSON))
+	httpJSONPattern := httpJSONServeMuxPattern(s.httpJSONBasePath)
+	if httpJSONPattern == s.jsonRPCEndpoint {
+		combined := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == s.jsonRPCEndpoint {
+				jsonRPCHandler.ServeHTTP(w, r)
+				return
+			}
+			httpJSONHandler.ServeHTTP(w, r)
+		}))
+		if len(s.middleWare) > 0 {
+			combined = MiddlewareChain(s.middleWare).Wrap(combined)
+		}
+		router.Handle(s.jsonRPCEndpoint, combined)
+		return router
+	}
+
 	if len(s.middleWare) > 0 {
-		jsonRPCHandler = MiddlewareChain(s.middleWare).Wrap(jsonRPCHandler)
+		chain := MiddlewareChain(s.middleWare)
+		jsonRPCHandler = chain.Wrap(jsonRPCHandler)
+		httpJSONHandler = chain.Wrap(httpJSONHandler)
 	}
 	router.Handle(s.jsonRPCEndpoint, jsonRPCHandler)
+	router.Handle(httpJSONPattern, httpJSONHandler)
 	return router
 }
 
@@ -404,7 +453,7 @@ func (s *A2AServer) handleAgentCard(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Content-Type", protocol.MediaTypeJSON+"; charset=utf-8")
 	if err := json.NewEncoder(w).Encode(card); err != nil {
 		log.Errorf("Failed to encode agent card: %v", err)
 		// Avoid writing JSON-RPC error here; it's a standard HTTP endpoint.
@@ -510,7 +559,7 @@ func (s *A2AServer) validateJSONRPCRequest(w http.ResponseWriter, r *http.Reques
 	// Check Content-Type using mime parsing
 	contentType := r.Header.Get("Content-Type")
 	mediaType, _, err := mime.ParseMediaType(contentType)
-	if err != nil || mediaType != "application/json" {
+	if err != nil || mediaType != protocol.MediaTypeJSON {
 		log.Warnf("Rejecting request due to invalid Content-Type: '%s' (Parse Err: %v)", contentType, err)
 		s.writeJSONRPCError(w, nil,
 			jsonrpc.ErrInvalidRequest(
@@ -602,16 +651,16 @@ func (s *A2AServer) unmarshalParams(params json.RawMessage, v interface{}) *json
 // request shape before either handler opens a task-manager round.
 func (s *A2AServer) validateSendMessageParams(
 	ctx context.Context, params *protocol.SendMessageParams,
-) *jsonrpc.Error {
+) error {
 	if params.Message.Role != protocol.MessageRoleUser {
-		return jsonrpc.ErrInvalidParams("message role must be ROLE_USER")
+		return taskmanager.ErrInvalidParams("message role must be ROLE_USER")
 	}
 	if len(params.Message.Parts) == 0 {
-		return jsonrpc.ErrInvalidParams("message with at least one part is required")
+		return taskmanager.ErrInvalidParams("message with at least one part is required")
 	}
 	for _, part := range params.Message.Parts {
 		if part == nil {
-			return jsonrpc.ErrInvalidParams("message parts must not contain null")
+			return taskmanager.ErrInvalidParams("message parts must not contain null")
 		}
 	}
 	if params.Configuration != nil && params.Configuration.PushConfig != nil &&
@@ -665,7 +714,7 @@ func (s *A2AServer) handleTasksPushNotificationList(
 		return
 	}
 	if !s.pushAvailableForTenant(ctx, params.Tenant) {
-		s.writeJSONRPCError(w, request.ID, taskmanager.ErrPushNotificationNotSupported())
+		s.writeJSONRPCError(w, request.ID, jsonrpc.FromTaskManagerError(taskmanager.ErrPushNotificationNotSupported()))
 		return
 	}
 	result, err := s.taskManager.OnPushNotificationList(ctx, params)
@@ -695,7 +744,7 @@ func (s *A2AServer) handleTasksPushNotificationDelete(
 		return
 	}
 	if !s.pushAvailableForTenant(ctx, params.Tenant) {
-		s.writeJSONRPCError(w, request.ID, taskmanager.ErrPushNotificationNotSupported())
+		s.writeJSONRPCError(w, request.ID, jsonrpc.FromTaskManagerError(taskmanager.ErrPushNotificationNotSupported()))
 		return
 	}
 	if err := s.taskManager.OnPushNotificationDelete(ctx, params); err != nil {
@@ -721,8 +770,7 @@ func (s *A2AServer) handleTasksCancel(ctx context.Context, w http.ResponseWriter
 	s.writeJSONRPCResponse(w, request.ID, task)
 }
 
-// handleTaskManagerError handles errors from task manager operations.
-// It checks if the error is already a JSON-RPC error and logs/writes it appropriately.
+// handleTaskManagerError maps a binding-neutral TaskManager error to JSON-RPC.
 func (s *A2AServer) handleTaskManagerError(
 	w http.ResponseWriter,
 	id interface{},
@@ -730,21 +778,26 @@ func (s *A2AServer) handleTaskManagerError(
 	operation string,
 	taskID string,
 ) {
-	// Check if the error is already a JSONRPCError (e.g., TaskNotFound, TaskNotCancelable).
-	if rpcErr, ok := err.(*jsonrpc.Error); ok {
+	var taskErr *taskmanager.Error
+	if errors.As(err, &taskErr) {
+		log.Errorf("Error calling %s for task %s: %v", operation, taskID, taskErr)
+		s.writeJSONRPCError(w, id, jsonrpc.FromTaskManagerError(taskErr))
+		return
+	}
+	var rpcErr *jsonrpc.Error
+	if errors.As(err, &rpcErr) {
 		log.Errorf("Error calling %s for task %s: %v", operation, taskID, rpcErr)
 		s.writeJSONRPCError(w, id, rpcErr)
-	} else {
-		// Otherwise, wrap it as a generic internal error.
-		log.Errorf("Unexpected error calling %s for task %s: %v", operation, taskID, err)
-		s.writeJSONRPCError(w, id, jsonrpc.ErrInternalError(fmt.Sprintf("%s failed: %v", operation, err)))
+		return
 	}
+	log.Errorf("Unexpected error calling %s for task %s: %v", operation, taskID, err)
+	s.writeJSONRPCError(w, id, jsonrpc.ErrInternalError(fmt.Sprintf("%s failed: %v", operation, err)))
 }
 
 // writeJSONRPCResponse encodes and writes a successful JSON-RPC response.
 func (s *A2AServer) writeJSONRPCResponse(w http.ResponseWriter, id interface{}, result interface{}) {
 	response := jsonrpc.NewResponse(id, result)
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Content-Type", protocol.MediaTypeJSON+"; charset=utf-8")
 	w.WriteHeader(http.StatusOK) // Success is always 200 OK for JSON-RPC itself.
 	if err := json.NewEncoder(w).Encode(response); err != nil {
 		// Log error, but can't change response if headers are already sent.
@@ -761,7 +814,7 @@ func (s *A2AServer) writeJSONRPCError(w http.ResponseWriter, id interface{}, err
 		log.Errorf("Programming ERROR: writeJSONRPCError called with nil error (Request ID: %v)", id)
 	}
 	response := jsonrpc.NewErrorResponse(id, err)
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Content-Type", protocol.MediaTypeJSON+"; charset=utf-8")
 	// Map JSON-RPC error codes to HTTP status codes where appropriate.
 	httpStatus := http.StatusInternalServerError // Default for Internal errors.
 	switch err.Code {
@@ -773,15 +826,15 @@ func (s *A2AServer) writeJSONRPCError(w http.ResponseWriter, id interface{}, err
 		httpStatus = http.StatusNotFound
 	case jsonrpc.CodeInvalidParams:
 		httpStatus = http.StatusBadRequest
-	case taskmanager.ErrCodeTaskNotFound:
+	case jsonrpc.CodeTaskNotFound:
 		httpStatus = http.StatusNotFound
-	case taskmanager.ErrCodeTaskNotCancelable,
-		taskmanager.ErrCodePushNotificationNotSupported,
-		taskmanager.ErrCodeUnsupportedOperation,
-		taskmanager.ErrCodeContentTypeNotSupported,
-		taskmanager.ErrCodeAuthenticatedExtendedCardNotConfigured,
-		taskmanager.ErrCodeExtensionSupportRequired,
-		taskmanager.ErrCodeVersionNotSupported:
+	case jsonrpc.CodeTaskNotCancelable,
+		jsonrpc.CodePushNotificationNotSupported,
+		jsonrpc.CodeUnsupportedOperation,
+		jsonrpc.CodeContentTypeNotSupported,
+		jsonrpc.CodeAuthenticatedExtendedCardNotConfigured,
+		jsonrpc.CodeExtensionSupportRequired,
+		jsonrpc.CodeVersionNotSupported:
 		httpStatus = http.StatusBadRequest
 		// ErrCodeInvalidAgentResponse and other internal errors keep the 500 default.
 	}
@@ -796,8 +849,8 @@ func (s *A2AServer) writeJSONRPCError(w http.ResponseWriter, id interface{}, err
 // WARNING: This is insecure for production. Configure origins explicitly.
 func setCORSHeaders(w http.ResponseWriter) {
 	w.Header().Set("Access-Control-Allow-Origin", "*") // INSECURE
-	w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+	w.Header().Set("Access-Control-Allow-Methods", "POST, GET, DELETE, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, A2A-Version, A2A-Extensions")
 	// Max-Age might be useful but not strictly necessary here.
 }
 
@@ -816,7 +869,7 @@ func (s *A2AServer) handleTasksPushNotificationSet(
 		return
 	}
 	if !s.pushAvailableForTenant(ctx, params.Tenant) {
-		s.writeJSONRPCError(w, request.ID, taskmanager.ErrPushNotificationNotSupported())
+		s.writeJSONRPCError(w, request.ID, jsonrpc.FromTaskManagerError(taskmanager.ErrPushNotificationNotSupported()))
 		return
 	}
 	result, err := s.taskManager.OnPushNotificationSet(ctx, params)
@@ -848,7 +901,7 @@ func (s *A2AServer) handleTasksPushNotificationGet(
 		return
 	}
 	if !s.pushAvailableForTenant(ctx, params.Tenant) {
-		s.writeJSONRPCError(w, request.ID, taskmanager.ErrPushNotificationNotSupported())
+		s.writeJSONRPCError(w, request.ID, jsonrpc.FromTaskManagerError(taskmanager.ErrPushNotificationNotSupported()))
 		return
 	}
 	result, err := s.taskManager.OnPushNotificationGet(ctx, params)
@@ -890,7 +943,7 @@ func (s *A2AServer) handleTasksResubscribe(ctx context.Context, w http.ResponseW
 
 	// Use the helper function to handle the SSE stream
 	log.Debugf("SSE stream reopened for request ID: %v)", request.ID)
-	handleSSEStream(ctx, s.corsEnabled, w, flusher, eventsChan, request.ID, nil)
+	handleSSEStream(ctx, s.corsEnabled, w, flusher, eventsChan, request.ID, nil, sse.FormatJSONRPCEventBatch)
 }
 
 // handleMessageSend handles the message_send method.
@@ -906,7 +959,7 @@ func (s *A2AServer) handleMessageSend(ctx context.Context, w http.ResponseWriter
 	}
 	if err := s.validateSendMessageParams(ctx, &params); err != nil {
 		tracker.setValidateSendMessageError(err)
-		s.writeJSONRPCError(w, request.ID, err)
+		s.writeJSONRPCError(w, request.ID, jsonrpc.FromTaskManagerError(err))
 		return
 	}
 	// Delegate to the task manager.
@@ -934,7 +987,7 @@ func (s *A2AServer) handleMessageStream(ctx context.Context, w http.ResponseWrit
 	if err := s.validateSendMessageParams(ctx, &params); err != nil {
 		tracker.setValidateSendMessageError(err)
 		tracker.record(ctx)
-		s.writeJSONRPCError(w, request.ID, err)
+		s.writeJSONRPCError(w, request.ID, jsonrpc.FromTaskManagerError(err))
 		return
 	}
 
@@ -960,7 +1013,7 @@ func (s *A2AServer) handleMessageStream(ctx context.Context, w http.ResponseWrit
 
 	// Use the helper function to handle the SSE stream
 	log.Debugf("SSE stream opened for request ID: %v)", request.ID)
-	handleSSEStream(ctx, s.corsEnabled, w, flusher, eventsChan, request.ID, tracker)
+	handleSSEStream(ctx, s.corsEnabled, w, flusher, eventsChan, request.ID, tracker, sse.FormatJSONRPCEventBatch)
 }
 
 // handleSSEStream handles an SSE stream for a task, including setup and event forwarding.
@@ -973,6 +1026,7 @@ func handleSSEStream(
 	eventsChan <-chan protocol.StreamResponse,
 	rpcID interface{},
 	tracker *metricsTracker,
+	formatBatch func(io.Writer, []sse.EventBatch) error,
 ) {
 	if tracker != nil {
 		defer tracker.record(ctx)
@@ -981,7 +1035,7 @@ func handleSSEStream(
 		rpcID = ""
 	}
 	// Set headers for SSE.
-	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Content-Type", protocol.MediaTypeEventStream)
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 	if corsEnabled {
@@ -1000,7 +1054,7 @@ func handleSSEStream(
 	}
 
 	// Use optimized tunnel for batching events
-	tunnel := newSSETunnel(w, flusher, rpcID)
+	tunnel := newSSETunnel(w, flusher, rpcID, formatBatch)
 	tunnel.start(ctx, eventsChan, clientClosed)
 }
 
@@ -1082,25 +1136,21 @@ func (s *A2AServer) handleAgentGetAuthenticatedExtendedCard(
 	w http.ResponseWriter,
 	request jsonrpc.Request,
 ) {
-	if !s.agentCard.ExtendedAgentCardEnabled() {
-		rpcErr := taskmanager.ErrAuthenticatedExtendedCardNotConfigured()
-		log.Warnf("Authenticated extended card unavailable (Request ID: %v): %v", request.ID, rpcErr)
-		s.writeJSONRPCError(w, request.ID, rpcErr)
-		return
+	var params struct {
+		Tenant string `json:"tenant,omitempty"`
 	}
-	cardToServe := s.agentCard
-	if s.authenticatedCardHandler != nil {
-		var err error
-		cardToServe, err = s.authenticatedCardHandler(ctx, s.agentCard)
-		if err != nil {
-			log.Errorf("Error applying authenticated card handler: %v", err)
-			s.writeJSONRPCError(w, request.ID,
-				jsonrpc.ErrInternalError(fmt.Sprintf("failed to handle extended card: %v", err)))
+	if len(request.Params) != 0 {
+		if err := s.unmarshalParams(request.Params, &params); err != nil {
+			s.writeJSONRPCError(w, request.ID, err)
 			return
 		}
 	}
-
-	cardToServe = s.finalizePushCapability(cardToServe)
+	cardToServe, err := s.resolveExtendedAgentCard(ctx, params.Tenant)
+	if err != nil {
+		log.Warnf("Authenticated extended card unavailable (Request ID: %v): %v", request.ID, err)
+		s.handleTaskManagerError(w, request.ID, err, "GetExtendedAgentCard", "")
+		return
+	}
 	log.Debugf("Serving authenticated extended card (Request ID: %v)", request.ID)
 	s.writeJSONRPCResponse(w, request.ID, cardToServe)
 }

--- a/server/server_handlers_test.go
+++ b/server/server_handlers_test.go
@@ -481,7 +481,7 @@ func TestA2AServer_Resubscribe(t *testing.T) {
 
 		assert.NotNil(t, resp.Error, "Should have an error")
 		assert.Nil(t, resp.Result, "Should not have a result")
-		assert.Equal(t, taskmanager.ErrCodeTaskNotFound, resp.Error.Code)
+		assert.Equal(t, jsonrpc.CodeTaskNotFound, resp.Error.Code)
 	})
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -360,7 +360,7 @@ func TestA2AServer_HandleJSONRPC_Methods(t *testing.T) {
 
 		assert.Nil(t, resp.Result, "Response result should be nil")
 		require.NotNil(t, resp.Error, "Response error should not be nil")
-		assert.Equal(t, taskmanager.ErrCodeTaskNotFound, resp.Error.Code)
+		assert.Equal(t, jsonrpc.CodeTaskNotFound, resp.Error.Code)
 	})
 
 	// --- Test tasks/cancel ---
@@ -397,7 +397,7 @@ func TestA2AServer_HandleJSONRPC_Methods(t *testing.T) {
 
 		assert.Nil(t, resp.Result, "Response result should be nil")
 		require.NotNil(t, resp.Error, "Response error should not be nil")
-		assert.Equal(t, taskmanager.ErrCodeTaskNotFound, resp.Error.Code)
+		assert.Equal(t, jsonrpc.CodeTaskNotFound, resp.Error.Code)
 	})
 
 	// --- Test unknown method ---
@@ -944,13 +944,13 @@ func TestA2AServer_HandleAgentGetAuthenticatedExtendedCard(t *testing.T) {
 			name:                 "not_configured",
 			supportsExtendedCard: nil,
 			expectedError:        true,
-			expectedErrorCode:    taskmanager.ErrCodeAuthenticatedExtendedCardNotConfigured,
+			expectedErrorCode:    jsonrpc.CodeAuthenticatedExtendedCardNotConfigured,
 		},
 		{
 			name:                 "disabled",
 			supportsExtendedCard: func() *bool { b := false; return &b }(),
 			expectedError:        true,
-			expectedErrorCode:    taskmanager.ErrCodeAuthenticatedExtendedCardNotConfigured,
+			expectedErrorCode:    jsonrpc.CodeAuthenticatedExtendedCardNotConfigured,
 		},
 		{
 			name:                 "enabled_no_handler",

--- a/server/sse_tunnel.go
+++ b/server/sse_tunnel.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"time"
 
@@ -23,10 +24,16 @@ type sseTunnel struct {
 	batchSize     int
 	flushInterval time.Duration
 	batch         []protocol.StreamResponse
+	formatBatch   func(io.Writer, []sse.EventBatch) error
 }
 
 // newSSETunnel creates a new SSE tunnel with default settings
-func newSSETunnel(w http.ResponseWriter, flusher http.Flusher, rpcID interface{}) *sseTunnel {
+func newSSETunnel(
+	w http.ResponseWriter,
+	flusher http.Flusher,
+	rpcID interface{},
+	formatBatch func(io.Writer, []sse.EventBatch) error,
+) *sseTunnel {
 	return &sseTunnel{
 		w:             w,
 		flusher:       flusher,
@@ -34,6 +41,7 @@ func newSSETunnel(w http.ResponseWriter, flusher http.Flusher, rpcID interface{}
 		batchSize:     defaultSSEBatchSize,
 		flushInterval: defaultSSEFlushInterval,
 		batch:         make([]protocol.StreamResponse, 0, defaultSSEBatchSize),
+		formatBatch:   formatBatch,
 	}
 }
 
@@ -124,7 +132,7 @@ func (t *sseTunnel) flushBatch() bool {
 	}
 
 	// Write the entire batch using optimized batch function
-	if err := sse.FormatJSONRPCEventBatch(t.w, events); err != nil {
+	if err := t.formatBatch(t.w, events); err != nil {
 		log.Errorf("Error writing SSE batch for request ID: %s (client likely disconnected): %v", t.rpcID, err)
 		return false
 	}

--- a/server/tracker.go
+++ b/server/tracker.go
@@ -8,13 +8,13 @@ package server
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 
-	"trpc.group/trpc-go/trpc-a2a-go/v2/internal/jsonrpc"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/telemetry"
@@ -99,8 +99,8 @@ func (t *metricsTracker) setError(errType string) {
 }
 
 // setValidateSendMessageError classifies errors from validateSendMessageParams.
-func (t *metricsTracker) setValidateSendMessageError(err *jsonrpc.Error) {
-	if err != nil && err.Code == taskmanager.ErrCodePushNotificationNotSupported {
+func (t *metricsTracker) setValidateSendMessageError(err error) {
+	if errors.Is(err, taskmanager.ErrPushNotificationNotSupportedSentinel) {
 		t.setError(errTypePushNotificationNotSupported)
 		return
 	}

--- a/taskmanager/errors.go
+++ b/taskmanager/errors.go
@@ -11,170 +11,193 @@ import (
 	"errors"
 	"fmt"
 
-	"trpc.group/trpc-go/trpc-a2a-go/v2/internal/jsonrpc"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
 )
 
-// JSON-RPC standard error codes
+// ErrorCode identifies a binding-neutral A2A operation error. Protocol
+// adapters map these codes to JSON-RPC codes, HTTP statuses, or gRPC statuses.
+type ErrorCode string
+
 const (
-	ErrCodeJSONParse      int = -32700 // Invalid JSON was received by the server
-	ErrCodeInvalidRequest int = -32600 // The JSON sent is not a valid Request object
-	ErrCodeMethodNotFound int = -32601 // The method does not exist or is not available
-	ErrCodeInvalidParams  int = -32602 // Invalid method parameter(s)
-	ErrCodeInternalError  int = -32603 // Internal JSON-RPC error
+	ErrCodeInvalidParams                          ErrorCode = "INVALID_PARAMS"
+	ErrCodeInternalError                          ErrorCode = "INTERNAL_ERROR"
+	ErrCodeTaskNotFound                           ErrorCode = "TASK_NOT_FOUND"
+	ErrCodeTaskNotCancelable                      ErrorCode = "TASK_NOT_CANCELABLE"
+	ErrCodePushNotificationNotSupported           ErrorCode = "PUSH_NOTIFICATION_NOT_SUPPORTED"
+	ErrCodeUnsupportedOperation                   ErrorCode = "UNSUPPORTED_OPERATION"
+	ErrCodeContentTypeNotSupported                ErrorCode = "CONTENT_TYPE_NOT_SUPPORTED"
+	ErrCodeInvalidAgentResponse                   ErrorCode = "INVALID_AGENT_RESPONSE"
+	ErrCodeAuthenticatedExtendedCardNotConfigured ErrorCode = "EXTENDED_AGENT_CARD_NOT_CONFIGURED"
+	ErrCodeExtensionSupportRequired               ErrorCode = "EXTENSION_SUPPORT_REQUIRED"
+	ErrCodeVersionNotSupported                    ErrorCode = "VERSION_NOT_SUPPORTED"
 )
 
-// Custom JSON-RPC error codes specific to the A2A specification
+// Deprecated JSON-RPC error codes retained for source compatibility. Protocol
+// adapters own transport-specific error mapping; TaskManager implementations
+// should return ErrInvalidParams or ErrInternalError instead.
 const (
-	ErrCodeTaskNotFound                           int = -32001 // Task not found
-	ErrCodeTaskNotCancelable                      int = -32002 // Task cannot be canceled
-	ErrCodePushNotificationNotSupported           int = -32003 // Push Notification is not supported
-	ErrCodeUnsupportedOperation                   int = -32004 // This operation is not supported
-	ErrCodeContentTypeNotSupported                int = -32005 // Incompatible content types
-	ErrCodeInvalidAgentResponse                   int = -32006 // Invalid agent response
-	ErrCodeAuthenticatedExtendedCardNotConfigured int = -32007 // Authenticated extended card not configured
-	ErrCodeExtensionSupportRequired               int = -32008 // A required extension was not opted into by the client
-	ErrCodeVersionNotSupported                    int = -32009 // The requested A2A protocol version is not supported
+	ErrCodeJSONParse      int = -32700
+	ErrCodeInvalidRequest int = -32600
+	ErrCodeMethodNotFound int = -32601
 )
 
-// ErrCodePushNotificationNotConfigured is deprecated: Use ErrCodePushNotificationNotSupported instead
+// ErrCodePushNotificationNotConfigured is deprecated: Use
+// ErrCodePushNotificationNotSupported instead.
 const ErrCodePushNotificationNotConfigured int = -32003
 
-// Sentinel errors for type checking with errors.Is()
+// Error is the binding-neutral error returned by TaskManager implementations.
+// Data carries optional diagnostic context for protocol adapters and logs.
+type Error struct {
+	Code    ErrorCode
+	Message string
+	Data    any
+	cause   error
+}
+
+// Error implements the standard error interface.
+func (e *Error) Error() string {
+	if e == nil {
+		return "<nil taskmanager error>"
+	}
+	return fmt.Sprintf("a2a error %s: %s", e.Code, e.Message)
+}
+
+// Unwrap exposes the stable sentinel associated with this error.
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+func newError(code ErrorCode, message string, data any, cause error) *Error {
+	return &Error{Code: code, Message: message, Data: data, cause: cause}
+}
+
+// Sentinel errors for type checking with errors.Is().
 var (
-	// ErrTaskNotFoundSentinel is a sentinel error for task not found
-	ErrTaskNotFoundSentinel = errors.New("task not found")
-	// ErrTaskNotCancelableSentinel is a sentinel error for task not cancelable
-	ErrTaskNotCancelableSentinel = errors.New("task not cancelable")
-	// ErrPushNotificationNotSupportedSentinel is a sentinel error for push notification not supported
-	ErrPushNotificationNotSupportedSentinel = errors.New("push notification not supported")
-	// ErrUnsupportedOperationSentinel is a sentinel error for unsupported operation
-	ErrUnsupportedOperationSentinel = errors.New("unsupported operation")
-	// ErrContentTypeNotSupportedSentinel is a sentinel error for content type not supported
-	ErrContentTypeNotSupportedSentinel = errors.New("content type not supported")
-	// ErrInvalidAgentResponseSentinel is a sentinel error for invalid agent response
-	ErrInvalidAgentResponseSentinel = errors.New("invalid agent response")
-	// ErrAuthenticatedExtendedCardNotConfiguredSentinel is a sentinel error for authenticated extended card not configured
+	ErrInvalidParamsSentinel                          = errors.New("invalid params")
+	ErrInternalErrorSentinel                          = errors.New("internal error")
+	ErrTaskNotFoundSentinel                           = errors.New("task not found")
+	ErrTaskNotCancelableSentinel                      = errors.New("task not cancelable")
+	ErrPushNotificationNotSupportedSentinel           = errors.New("push notification not supported")
+	ErrUnsupportedOperationSentinel                   = errors.New("unsupported operation")
+	ErrContentTypeNotSupportedSentinel                = errors.New("content type not supported")
+	ErrInvalidAgentResponseSentinel                   = errors.New("invalid agent response")
 	ErrAuthenticatedExtendedCardNotConfiguredSentinel = errors.New("authenticated extended card not configured")
-	// ErrExtensionSupportRequiredSentinel is a sentinel error for a required extension not opted into
-	ErrExtensionSupportRequiredSentinel = errors.New("extension support required")
-	// ErrVersionNotSupportedSentinel is a sentinel error for an unsupported A2A protocol version
-	ErrVersionNotSupportedSentinel = errors.New("version not supported")
-	// ErrPushConfigNotFoundSentinel is a sentinel error for a missing push notification config
-	ErrPushConfigNotFoundSentinel = errors.New("push notification config not found")
+	ErrExtensionSupportRequiredSentinel               = errors.New("extension support required")
+	ErrVersionNotSupportedSentinel                    = errors.New("version not supported")
+	ErrPushConfigNotFoundSentinel                     = errors.New("push notification config not found")
 )
 
-// A2A specific error functions
-
-// ErrTaskNotFound creates a JSON-RPC error for task not found.
-// The returned error wraps ErrTaskNotFoundSentinel for use with errors.Is().
-func ErrTaskNotFound(taskID string) *jsonrpc.Error {
-	return (&jsonrpc.Error{
-		Code:    ErrCodeTaskNotFound,
-		Message: "Task not found",
-		Data:    fmt.Sprintf("Task with ID '%s' was not found.", taskID),
-	}).WithWrappedError(ErrTaskNotFoundSentinel)
+// ErrTaskNotFound creates an A2A task-not-found error.
+func ErrTaskNotFound(taskID string) *Error {
+	return newError(
+		ErrCodeTaskNotFound,
+		"Task not found",
+		fmt.Sprintf("Task with ID '%s' was not found.", taskID),
+		ErrTaskNotFoundSentinel,
+	)
 }
 
-// ErrTaskNotCancelable creates a JSON-RPC error for task that cannot be canceled.
-// The returned error wraps ErrTaskNotCancelableSentinel for use with errors.Is().
-func ErrTaskNotCancelable(taskID string, state protocol.TaskState) *jsonrpc.Error {
-	return (&jsonrpc.Error{
-		Code:    ErrCodeTaskNotCancelable,
-		Message: "Task cannot be canceled",
-		Data:    fmt.Sprintf("Task '%s' is in state '%s' and cannot be canceled", taskID, state),
-	}).WithWrappedError(ErrTaskNotCancelableSentinel)
+// ErrTaskNotCancelable creates an A2A task-not-cancelable error.
+func ErrTaskNotCancelable(taskID string, state protocol.TaskState) *Error {
+	return newError(
+		ErrCodeTaskNotCancelable,
+		"Task cannot be canceled",
+		fmt.Sprintf("Task '%s' is in state '%s' and cannot be canceled", taskID, state),
+		ErrTaskNotCancelableSentinel,
+	)
 }
 
-// ErrPushNotificationNotSupported creates a JSON-RPC error for unsupported push notifications.
-// The returned error wraps ErrPushNotificationNotSupportedSentinel for use with errors.Is().
-func ErrPushNotificationNotSupported() *jsonrpc.Error {
-	return (&jsonrpc.Error{
-		Code:    ErrCodePushNotificationNotSupported,
-		Message: "Push Notification is not supported",
-		Data:    "This agent does not support push notifications",
-	}).WithWrappedError(ErrPushNotificationNotSupportedSentinel)
+// ErrPushNotificationNotSupported creates an unsupported-push error.
+func ErrPushNotificationNotSupported() *Error {
+	return newError(
+		ErrCodePushNotificationNotSupported,
+		"Push Notification is not supported",
+		"This agent does not support push notifications",
+		ErrPushNotificationNotSupportedSentinel,
+	)
 }
 
 // ErrPushConfigNotFound creates the TaskNotFoundError required by the A2A
 // push-config methods when the addressed configuration does not exist.
-// The returned error wraps ErrPushConfigNotFoundSentinel for use with errors.Is().
-func ErrPushConfigNotFound(taskID string) *jsonrpc.Error {
-	return (&jsonrpc.Error{
-		Code:    ErrCodeTaskNotFound,
-		Message: "Task not found",
-		Data:    fmt.Sprintf("Task '%s' has no push notification config.", taskID),
-	}).WithWrappedError(ErrPushConfigNotFoundSentinel)
+func ErrPushConfigNotFound(taskID string) *Error {
+	return newError(
+		ErrCodeTaskNotFound,
+		"Task not found",
+		fmt.Sprintf("Task '%s' has no push notification config.", taskID),
+		ErrPushConfigNotFoundSentinel,
+	)
 }
 
-// ErrUnsupportedOperation creates a JSON-RPC error for unsupported operations.
-// The returned error wraps ErrUnsupportedOperationSentinel for use with errors.Is().
-func ErrUnsupportedOperation(operation string) *jsonrpc.Error {
-	return (&jsonrpc.Error{
-		Code:    ErrCodeUnsupportedOperation,
-		Message: "This operation is not supported",
-		Data:    fmt.Sprintf("Operation '%s' is not supported by this agent", operation),
-	}).WithWrappedError(ErrUnsupportedOperationSentinel)
+// ErrUnsupportedOperation creates an unsupported-operation error.
+func ErrUnsupportedOperation(operation string) *Error {
+	return newError(
+		ErrCodeUnsupportedOperation,
+		"This operation is not supported",
+		fmt.Sprintf("Operation '%s' is not supported by this agent", operation),
+		ErrUnsupportedOperationSentinel,
+	)
 }
 
-// ErrContentTypeNotSupported creates a JSON-RPC error for incompatible content types.
-// The returned error wraps ErrContentTypeNotSupportedSentinel for use with errors.Is().
-func ErrContentTypeNotSupported(contentType string) *jsonrpc.Error {
-	return (&jsonrpc.Error{
-		Code:    ErrCodeContentTypeNotSupported,
-		Message: "Incompatible content types",
-		Data:    fmt.Sprintf("Content type '%s' is not supported", contentType),
-	}).WithWrappedError(ErrContentTypeNotSupportedSentinel)
+// ErrContentTypeNotSupported creates an incompatible-content-type error.
+func ErrContentTypeNotSupported(contentType string) *Error {
+	return newError(
+		ErrCodeContentTypeNotSupported,
+		"Incompatible content types",
+		fmt.Sprintf("Content type '%s' is not supported", contentType),
+		ErrContentTypeNotSupportedSentinel,
+	)
 }
 
-// ErrInvalidAgentResponse creates a JSON-RPC error for invalid agent response.
-// The returned error wraps ErrInvalidAgentResponseSentinel for use with errors.Is().
-func ErrInvalidAgentResponse(details string) *jsonrpc.Error {
-	return (&jsonrpc.Error{
-		Code:    ErrCodeInvalidAgentResponse,
-		Message: "Invalid agent response",
-		Data:    details,
-	}).WithWrappedError(ErrInvalidAgentResponseSentinel)
+// ErrInvalidAgentResponse creates an invalid-agent-response error.
+func ErrInvalidAgentResponse(details string) *Error {
+	return newError(
+		ErrCodeInvalidAgentResponse,
+		"Invalid agent response",
+		details,
+		ErrInvalidAgentResponseSentinel,
+	)
 }
 
-// ErrAuthenticatedExtendedCardNotConfigured creates a JSON-RPC error for authenticated extended card not configured.
-// The returned error wraps ErrAuthenticatedExtendedCardNotConfiguredSentinel for use with errors.Is().
-func ErrAuthenticatedExtendedCardNotConfigured() *jsonrpc.Error {
-	return (&jsonrpc.Error{
-		Code:    ErrCodeAuthenticatedExtendedCardNotConfigured,
-		Message: "Authenticated extended card not configured",
-		Data:    "This agent does not have an authenticated extended card configured",
-	}).WithWrappedError(ErrAuthenticatedExtendedCardNotConfiguredSentinel)
+// ErrAuthenticatedExtendedCardNotConfigured creates an extended-card error.
+func ErrAuthenticatedExtendedCardNotConfigured() *Error {
+	return newError(
+		ErrCodeAuthenticatedExtendedCardNotConfigured,
+		"Authenticated extended card not configured",
+		"This agent does not have an authenticated extended card configured",
+		ErrAuthenticatedExtendedCardNotConfiguredSentinel,
+	)
 }
 
-// ErrExtensionSupportRequired creates a JSON-RPC error for a required extension the client did not opt into.
-// The returned error wraps ErrExtensionSupportRequiredSentinel for use with errors.Is().
-func ErrExtensionSupportRequired(extensionURI string) *jsonrpc.Error {
-	return (&jsonrpc.Error{
-		Code:    ErrCodeExtensionSupportRequired,
-		Message: "Extension support required",
-		Data:    fmt.Sprintf("Required extension '%s' was not opted into by the client", extensionURI),
-	}).WithWrappedError(ErrExtensionSupportRequiredSentinel)
+// ErrExtensionSupportRequired creates an error for a required extension that
+// the client did not opt into.
+func ErrExtensionSupportRequired(extensionURI string) *Error {
+	return newError(
+		ErrCodeExtensionSupportRequired,
+		"Extension support required",
+		fmt.Sprintf("Required extension '%s' was not opted into by the client", extensionURI),
+		ErrExtensionSupportRequiredSentinel,
+	)
 }
 
-// ErrVersionNotSupported creates a JSON-RPC error for an unsupported A2A protocol version.
-// The returned error wraps ErrVersionNotSupportedSentinel for use with errors.Is().
-func ErrVersionNotSupported(requested string) *jsonrpc.Error {
-	return (&jsonrpc.Error{
-		Code:    ErrCodeVersionNotSupported,
-		Message: "Version not supported",
-		Data:    fmt.Sprintf("Requested A2A protocol version '%s' is not supported by this agent", requested),
-	}).WithWrappedError(ErrVersionNotSupportedSentinel)
+// ErrVersionNotSupported creates an unsupported-version error.
+func ErrVersionNotSupported(requested string) *Error {
+	return newError(
+		ErrCodeVersionNotSupported,
+		"Version not supported",
+		fmt.Sprintf("Requested A2A protocol version '%s' is not supported by this agent", requested),
+		ErrVersionNotSupportedSentinel,
+	)
 }
 
-// ErrInvalidParams creates a standard JSON-RPC invalid-params error.
-// It is exposed for TaskManager implementations that live in another module.
+// ErrInvalidParams creates a binding-neutral invalid-parameters error.
 func ErrInvalidParams(details string) error {
-	return jsonrpc.ErrInvalidParams(details)
+	return newError(ErrCodeInvalidParams, "Invalid params", details, ErrInvalidParamsSentinel)
 }
 
-// ErrInternalError creates a standard JSON-RPC internal error.
-// It is exposed for TaskManager implementations that live in another module.
+// ErrInternalError creates a binding-neutral internal error.
 func ErrInternalError(details string) error {
-	return jsonrpc.ErrInternalError(details)
+	return newError(ErrCodeInternalError, "Internal error", details, ErrInternalErrorSentinel)
 }

--- a/taskmanager/errors.go
+++ b/taskmanager/errors.go
@@ -18,6 +18,7 @@ import (
 // adapters map these codes to JSON-RPC codes, HTTP statuses, or gRPC statuses.
 type ErrorCode string
 
+// ErrCodeInvalidParams and the remaining values identify binding-neutral A2A operation errors.
 const (
 	ErrCodeInvalidParams                          ErrorCode = "INVALID_PARAMS"
 	ErrCodeInternalError                          ErrorCode = "INTERNAL_ERROR"

--- a/taskmanager/errors_test.go
+++ b/taskmanager/errors_test.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"testing"
 
-	"trpc.group/trpc-go/trpc-a2a-go/v2/internal/jsonrpc"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
 )
 
@@ -19,7 +18,7 @@ func TestErrorSentinels(t *testing.T) {
 		name         string
 		errorFunc    func() error
 		sentinel     error
-		expectedCode int
+		expectedCode ErrorCode
 		expectedMsg  string
 	}{
 		{
@@ -72,16 +71,30 @@ func TestErrorSentinels(t *testing.T) {
 			expectedMsg:  "Authenticated extended card not configured",
 		},
 		{
+			name:         "ExtensionSupportRequired",
+			errorFunc:    func() error { return ErrExtensionSupportRequired("urn:example:extension") },
+			sentinel:     ErrExtensionSupportRequiredSentinel,
+			expectedCode: ErrCodeExtensionSupportRequired,
+			expectedMsg:  "Extension support required",
+		},
+		{
+			name:         "VersionNotSupported",
+			errorFunc:    func() error { return ErrVersionNotSupported("2.0") },
+			sentinel:     ErrVersionNotSupportedSentinel,
+			expectedCode: ErrCodeVersionNotSupported,
+			expectedMsg:  "Version not supported",
+		},
+		{
 			name:         "InvalidParams",
 			errorFunc:    func() error { return ErrInvalidParams("bad parameter") },
-			sentinel:     jsonrpc.ErrInvalidParamsSentinel,
+			sentinel:     ErrInvalidParamsSentinel,
 			expectedCode: ErrCodeInvalidParams,
 			expectedMsg:  "Invalid params",
 		},
 		{
 			name:         "InternalError",
 			errorFunc:    func() error { return ErrInternalError("failed operation") },
-			sentinel:     jsonrpc.ErrInternalErrorSentinel,
+			sentinel:     ErrInternalErrorSentinel,
 			expectedCode: ErrCodeInternalError,
 			expectedMsg:  "Internal error",
 		},
@@ -96,14 +109,14 @@ func TestErrorSentinels(t *testing.T) {
 				t.Errorf("errors.Is() failed: expected error to wrap %v", tt.sentinel)
 			}
 
-			// Test error code and message by type asserting to *jsonrpc.Error
-			jErr, ok := err.(*jsonrpc.Error)
+			// Test error code and message by type asserting to *Error.
+			jErr, ok := err.(*Error)
 			if !ok {
-				t.Fatalf("error is not *jsonrpc.Error, got %T", err)
+				t.Fatalf("error is not *taskmanager.Error, got %T", err)
 			}
 
 			if jErr.Code != tt.expectedCode {
-				t.Errorf("expected code %d, got %d", tt.expectedCode, jErr.Code)
+				t.Errorf("expected code %s, got %s", tt.expectedCode, jErr.Code)
 			}
 			if jErr.Message != tt.expectedMsg {
 				t.Errorf("expected message %q, got %q", tt.expectedMsg, jErr.Message)

--- a/taskmanager/interface.go
+++ b/taskmanager/interface.go
@@ -116,9 +116,9 @@ type ExecContext struct {
 // a synchronous body — its emits before Events() never block.
 //
 // Returning a non-nil error means the round failed to start: no events are
-// consumed and the error is mapped to a JSON-RPC error. To report a business
-// failure, emit a TASK_STATE_FAILED status or a direct agent Message and close
-// the channel.
+// consumed and the error is mapped to the active protocol binding's error
+// representation. To report a business failure, emit a TASK_STATE_FAILED status
+// or a direct agent Message and close the channel.
 type MessageProcessor interface {
 	ProcessMessage(ctx context.Context, ec *ExecContext) (<-chan protocol.StreamEvent, error)
 }

--- a/taskmanager/memory/memory.go
+++ b/taskmanager/memory/memory.go
@@ -18,7 +18,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"trpc.group/trpc-go/trpc-a2a-go/v2/internal/jsonrpc"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/log"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/push"
@@ -458,7 +457,7 @@ func (m *TaskManager) OnPushNotificationSet(
 		return nil, taskmanager.ErrPushNotificationNotSupported()
 	}
 	if err := push.ValidateConfig(params); err != nil {
-		return nil, jsonrpc.ErrInvalidParams(err.Error())
+		return nil, taskmanager.ErrInvalidParams(err.Error())
 	}
 	if err := m.ensurePushTaskExists(params.TaskID); err != nil {
 		return nil, err
@@ -480,7 +479,7 @@ func (m *TaskManager) OnPushNotificationGet(
 		return nil, taskmanager.ErrPushNotificationNotSupported()
 	}
 	if params.ID == "" {
-		return nil, jsonrpc.ErrInvalidParams("push notification config ID is required")
+		return nil, taskmanager.ErrInvalidParams("push notification config ID is required")
 	}
 	if err := m.ensurePushTaskExists(params.TaskID); err != nil {
 		return nil, err
@@ -541,7 +540,7 @@ func (m *TaskManager) OnPushNotificationDelete(
 		return taskmanager.ErrPushNotificationNotSupported()
 	}
 	if params.ID == "" {
-		return jsonrpc.ErrInvalidParams("push notification config ID is required")
+		return taskmanager.ErrInvalidParams("push notification config ID is required")
 	}
 	if err := m.ensurePushTaskExists(params.TaskID); err != nil {
 		return err

--- a/taskmanager/memory/memory_engine.go
+++ b/taskmanager/memory/memory_engine.go
@@ -12,7 +12,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"trpc.group/trpc-go/trpc-a2a-go/v2/internal/jsonrpc"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/log"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/push"
@@ -247,7 +246,7 @@ func (m *TaskManager) prepareExecConfiguration(
 		pushConfig.ID = taskID
 	}
 	if err := push.ValidateConfig(pushConfig); err != nil {
-		return nil, nil, jsonrpc.ErrInvalidParams(err.Error())
+		return nil, nil, taskmanager.ErrInvalidParams(err.Error())
 	}
 	if continuation {
 		stored, err := m.pushStore.save(pushConfig)
@@ -302,14 +301,14 @@ func (m *TaskManager) resolveContinuation(message *protocol.Message) (*protocol.
 	}
 	if isFinalState(stored.Status.State) {
 		// A terminal task is immutable: reject without invoking the MessageProcessor.
-		return nil, jsonrpc.ErrInvalidParams(
+		return nil, taskmanager.ErrInvalidParams(
 			fmt.Sprintf("task %s is in terminal state %s", taskID, stored.Status.State))
 	}
 	if message.ContextID != nil && *message.ContextID != "" && *message.ContextID != stored.ContextID {
 		// A continuation must stay in the task's own conversation: a foreign
 		// contextId would resolve the wrong ec.History and contradict the
 		// task snapshot's ContextID.
-		return nil, jsonrpc.ErrInvalidParams(fmt.Sprintf("message contextId does not match task %s context", taskID))
+		return nil, taskmanager.ErrInvalidParams(fmt.Sprintf("message contextId does not match task %s context", taskID))
 	}
 	return copyTask(stored), nil
 }
@@ -365,7 +364,7 @@ func (m *TaskManager) startExecution(
 	if events == nil {
 		m.releaseExecution(ec.TaskID, exec)
 		cancel()
-		return nil, jsonrpc.ErrInternalError("processor returned nil channel")
+		return nil, taskmanager.ErrInternalError("processor returned nil channel")
 	}
 
 	eng := &engine{
@@ -392,7 +391,7 @@ func (m *TaskManager) registerExecution(ctx context.Context, taskID string, exec
 		m.execMu.Lock()
 		if m.closed {
 			m.execMu.Unlock()
-			return jsonrpc.ErrInternalError("task manager is closed")
+			return taskmanager.ErrInternalError("task manager is closed")
 		}
 		current, exists := m.executions[taskID]
 		if !exists {
@@ -406,7 +405,7 @@ func (m *TaskManager) registerExecution(ctx context.Context, taskID string, exec
 		yieldDone := current.yieldDone
 		m.execMu.Unlock()
 		if yieldDone == nil {
-			return jsonrpc.ErrInvalidParams(
+			return taskmanager.ErrInvalidParams(
 				fmt.Sprintf("task %s already has an active execution", taskID))
 		}
 		select {
@@ -1004,7 +1003,7 @@ func (m *TaskManager) buildSendResponse(
 	if message != nil {
 		return protocol.NewSendMessageResponseMessage(message), nil
 	}
-	return nil, jsonrpc.ErrInternalError("processor produced no result")
+	return nil, taskmanager.ErrInternalError("processor produced no result")
 }
 
 // historyLengthFromConfig extracts the response historyLength, nil-safe.

--- a/taskmanager/memory/memory_engine_test.go
+++ b/taskmanager/memory/memory_engine_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 	"time"
 
-	"trpc.group/trpc-go/trpc-a2a-go/v2/internal/jsonrpc"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
 )
@@ -321,7 +320,7 @@ func TestOnSendMessage_EmptyExecutionIsInternalError(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected an error for an empty execution")
 	}
-	if !errors.Is(err, jsonrpc.ErrInternalErrorSentinel) {
+	if !errors.Is(err, taskmanager.ErrInternalErrorSentinel) {
 		t.Errorf("Expected InternalError, got %v", err)
 	}
 }
@@ -334,7 +333,7 @@ func TestOnSendMessage_NilChannelIsInternalError(t *testing.T) {
 		}))
 
 	_, err := manager.OnSendMessage(context.Background(), userParams("nil"))
-	if !errors.Is(err, jsonrpc.ErrInternalErrorSentinel) {
+	if !errors.Is(err, taskmanager.ErrInternalErrorSentinel) {
 		t.Errorf("Expected InternalError for nil channel, got %v", err)
 	}
 	if n := liveExecutionCount(manager); n != 0 {
@@ -519,7 +518,7 @@ func TestOnSendMessage_TerminalTaskRejected(t *testing.T) {
 	taskID := "done-task"
 	params.Message.TaskID = &taskID
 	_, err := manager.OnSendMessage(context.Background(), params)
-	if !errors.Is(err, jsonrpc.ErrInvalidParamsSentinel) {
+	if !errors.Is(err, taskmanager.ErrInvalidParamsSentinel) {
 		t.Errorf("Expected InvalidParams for a terminal task, got %v", err)
 	}
 	if invoked.Load() {
@@ -1306,12 +1305,12 @@ func TestEngine_SynchronousTaskHandle(t *testing.T) {
 // Review-fix regressions: single-writer, terminal immutability, immediateResult
 // =============================================================================
 
-// assertRPCCode fails unless err is a *jsonrpc.Error with the wanted code.
-func assertRPCCode(t *testing.T, err error, code int) {
+// assertRPCCode fails unless err is a *taskmanager.Error with the wanted code.
+func assertRPCCode(t *testing.T, err error, code taskmanager.ErrorCode) {
 	t.Helper()
-	var rpcErr *jsonrpc.Error
+	var rpcErr *taskmanager.Error
 	if !errors.As(err, &rpcErr) || rpcErr.Code != code {
-		t.Fatalf("expected JSON-RPC error code %d, got %v", code, err)
+		t.Fatalf("expected task-manager error code %s, got %v", code, err)
 	}
 }
 

--- a/taskmanager/redis/redis_engine_test.go
+++ b/taskmanager/redis/redis_engine_test.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 	"sync/atomic"
@@ -58,29 +59,29 @@ func collectStream(t *testing.T, ch <-chan protocol.StreamResponse) []protocol.S
 	}
 }
 
-type rpcErrorPayload struct {
-	Code int `json:"code"`
+type taskManagerErrorPayload struct {
+	Code any `json:"code"`
 	Data any `json:"data"`
 }
 
-func decodeRPCError(t *testing.T, err error) rpcErrorPayload {
+func decodeTaskManagerError(t *testing.T, err error) taskManagerErrorPayload {
 	t.Helper()
 	payload, marshalErr := json.Marshal(err)
 	if marshalErr != nil {
-		t.Fatalf("marshal JSON-RPC error: %v", marshalErr)
+		t.Fatalf("marshal task-manager error: %v", marshalErr)
 	}
-	var rpcErr rpcErrorPayload
-	if unmarshalErr := json.Unmarshal(payload, &rpcErr); unmarshalErr != nil {
-		t.Fatalf("unmarshal JSON-RPC error: %v", unmarshalErr)
+	var taskErr taskManagerErrorPayload
+	if unmarshalErr := json.Unmarshal(payload, &taskErr); unmarshalErr != nil {
+		t.Fatalf("unmarshal task-manager error: %v", unmarshalErr)
 	}
-	return rpcErr
+	return taskErr
 }
 
-// assertRPCCode fails unless err carries the wanted JSON-RPC code.
-func assertRPCCode(t *testing.T, err error, code int) {
+// assertTaskManagerCode fails unless err carries the wanted semantic error code.
+func assertTaskManagerCode(t *testing.T, err error, code any) {
 	t.Helper()
-	if rpcErr := decodeRPCError(t, err); rpcErr.Code != code {
-		t.Fatalf("expected JSON-RPC error code %d, got %v", code, err)
+	if taskErr := decodeTaskManagerError(t, err); fmt.Sprint(taskErr.Code) != fmt.Sprint(code) {
+		t.Fatalf("expected task-manager error code %v, got %v", code, err)
 	}
 }
 
@@ -242,7 +243,7 @@ func TestOnSendMessage_ConcurrentContinuationRejected(t *testing.T) {
 	followUp := sendParams("again", "ctx-concurrent")
 	followUp.Message.TaskID = &taskID
 	_, err = m.OnSendMessage(context.Background(), followUp)
-	assertRPCCode(t, err, taskmanager.ErrCodeInvalidParams)
+	assertTaskManagerCode(t, err, taskmanager.ErrCodeInvalidParams)
 	if got := invocations.Load(); got != 1 {
 		t.Fatalf("processor must not run for the rejected round, invocations=%d", got)
 	}
@@ -293,7 +294,7 @@ func TestOnCancelTask_LiveButTerminalNotCancelable(t *testing.T) {
 	// The round is still live (channel not yet closed) but the stored state is
 	// terminal: cancel must be rejected.
 	_, err = m.OnCancelTask(context.Background(), protocol.TaskIDParams{ID: taskID})
-	assertRPCCode(t, err, taskmanager.ErrCodeTaskNotCancelable)
+	assertTaskManagerCode(t, err, taskmanager.ErrCodeTaskNotCancelable)
 	close(release)
 	collectStream(t, pipe)
 }
@@ -329,7 +330,7 @@ func TestOnSendMessage_ContinuationContextMismatchRejected(t *testing.T) {
 	followUp.Message.TaskID = &taskID
 	followUp.Message.ContextID = &foreignContext
 	_, err = m.OnSendMessage(context.Background(), followUp)
-	assertRPCCode(t, err, taskmanager.ErrCodeInvalidParams)
+	assertTaskManagerCode(t, err, taskmanager.ErrCodeInvalidParams)
 	if got := invocations.Load(); got != 1 {
 		t.Fatalf("processor must not run for the rejected round, invocations=%d", got)
 	}
@@ -377,7 +378,7 @@ func TestOnSendMessage_RejectedContinuationLeavesPersistenceUntouched(t *testing
 		PushConfig: &protocol.TaskPushNotificationConfig{URL: "https://example.com/hook"},
 	}
 	_, err = m.OnSendMessage(context.Background(), followUp)
-	assertRPCCode(t, err, taskmanager.ErrPushNotificationNotSupported().Code)
+	assertTaskManagerCode(t, err, taskmanager.ErrPushNotificationNotSupported().Code)
 
 	afterTask, err := m.client.Get(context.Background(), taskKey).Bytes()
 	if err != nil {
@@ -438,7 +439,7 @@ func TestEngine_UnspecifiedStateIsViolation(t *testing.T) {
 	// task:* keys.
 	m2, mr2 := setupTest(t, scriptedExecutor(statusEvent(protocol.TaskStateUnspecified, nil)))
 	_, err = m2.OnSendMessage(context.Background(), sendParams("go", "ctx-unspec2"))
-	assertRPCCode(t, err, taskmanager.ErrCodeInternalError)
+	assertTaskManagerCode(t, err, taskmanager.ErrCodeInternalError)
 	for _, key := range mr2.Keys() {
 		if strings.HasPrefix(key, taskPrefix) {
 			t.Errorf("violation before any task must leave no task key, found %s", key)
@@ -582,7 +583,7 @@ func TestOnSendMessageStream_StartupFailureLeavesNoTrace(t *testing.T) {
 		return nil, nil
 	}))
 	_, err = m2.OnSendMessageStream(context.Background(), sendParams("x", "ctx-boot2"))
-	assertRPCCode(t, err, taskmanager.ErrCodeInternalError)
+	assertTaskManagerCode(t, err, taskmanager.ErrCodeInternalError)
 	if n := liveExecutionCount(m2); n != 0 {
 		t.Fatalf("nil channel must deregister the execution, %d live", n)
 	}
@@ -600,7 +601,7 @@ func TestOnSendMessage_ReturnImmediatelyEmptyRound(t *testing.T) {
 	params := sendParams("empty", "ctx-ri-empty")
 	params.Configuration = &protocol.SendMessageConfiguration{ReturnImmediately: &returnImmediately}
 	_, err := m.OnSendMessage(context.Background(), params)
-	assertRPCCode(t, err, taskmanager.ErrCodeInternalError)
+	assertTaskManagerCode(t, err, taskmanager.ErrCodeInternalError)
 }
 
 // §3.4 regression (parity with memory): a streaming client that fires its

--- a/taskmanager/redis/redis_manager_test.go
+++ b/taskmanager/redis/redis_manager_test.go
@@ -340,7 +340,7 @@ func TestOnSendMessageNoEvents(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for empty execution")
 	}
-	assertRPCCode(t, err, taskmanager.ErrCodeInternalError)
+	assertTaskManagerCode(t, err, taskmanager.ErrCodeInternalError)
 }
 
 func TestOnSendMessageExecuteError(t *testing.T) {
@@ -365,7 +365,7 @@ func TestOnSendMessageNilChannel(t *testing.T) {
 	}))
 
 	_, err := m.OnSendMessage(context.Background(), sendParams("hello", "ctx-nil"))
-	assertRPCCode(t, err, taskmanager.ErrCodeInternalError)
+	assertTaskManagerCode(t, err, taskmanager.ErrCodeInternalError)
 }
 
 // =============================================================================
@@ -564,12 +564,10 @@ func TestTerminalTaskSendRejected(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for terminal task")
 	}
-	rpcErr := decodeRPCError(t, err)
-	if rpcErr.Code != taskmanager.ErrCodeInvalidParams {
-		t.Errorf("expected invalid params (-32602), got %v", err)
-	}
-	if data, _ := rpcErr.Data.(string); !strings.Contains(data, "task task-frozen is in terminal state") {
-		t.Errorf("expected terminal-state reason in error data, got %v", rpcErr.Data)
+	taskErr := decodeTaskManagerError(t, err)
+	assertTaskManagerCode(t, err, taskmanager.ErrCodeInvalidParams)
+	if data, _ := taskErr.Data.(string); !strings.Contains(data, "task task-frozen is in terminal state") {
+		t.Errorf("expected terminal-state reason in error data, got %v", taskErr.Data)
 	}
 	if invoked {
 		t.Error("processor must not be invoked for a terminal task")
@@ -653,7 +651,7 @@ func TestTaskSnapshotEventWithoutTaskLeavesNoTrace(t *testing.T) {
 	m, mr := setupTest(t, scriptedExecutor(&protocol.Task{ID: "task-x"}))
 
 	_, err := m.OnSendMessage(context.Background(), sendParams("go", "ctx-trace"))
-	assertRPCCode(t, err, taskmanager.ErrCodeInternalError)
+	assertTaskManagerCode(t, err, taskmanager.ErrCodeInternalError)
 	for _, key := range mr.Keys() {
 		if strings.HasPrefix(key, taskPrefix) {
 			t.Errorf("violation before task creation must not persist a task, found %s", key)
@@ -1326,7 +1324,7 @@ func TestPushNotificationCRUD(t *testing.T) { //nolint:gocyclo // One lifecycle 
 
 	err = m.OnPushNotificationDelete(context.Background(),
 		protocol.DeleteTaskPushNotificationConfigParams{TaskID: config.TaskID})
-	assertRPCCode(t, err, taskmanager.ErrCodeInvalidParams)
+	assertTaskManagerCode(t, err, taskmanager.ErrCodeInvalidParams)
 
 	// Public CRUD must not create or expose orphan configs for missing tasks.
 	_, err = m.OnPushNotificationSet(context.Background(), protocol.TaskPushNotificationConfig{

--- a/taskmanager/redis/redis_push_dispatch_test.go
+++ b/taskmanager/redis/redis_push_dispatch_test.go
@@ -95,7 +95,7 @@ func waitPushCount(t *testing.T, s *recordingSender, n int) {
 
 func assertPushUnsupported(t *testing.T, err error) {
 	t.Helper()
-	assertRPCCode(t, err, taskmanager.ErrCodePushNotificationNotSupported)
+	assertTaskManagerCode(t, err, taskmanager.ErrCodePushNotificationNotSupported)
 }
 
 // TestRedisPushInlineConfigDelivered covers the full loop: a message carrying an

--- a/taskmanager/stateless/stateless.go
+++ b/taskmanager/stateless/stateless.go
@@ -15,7 +15,6 @@ import (
 	"sync"
 	"time"
 
-	"trpc.group/trpc-go/trpc-a2a-go/v2/internal/jsonrpc"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/log"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
@@ -270,7 +269,7 @@ func (m *TaskManager) registerExecution(
 	m.executionMu.Lock()
 	if m.closed {
 		m.executionMu.Unlock()
-		return nil, jsonrpc.ErrInternalError("task manager is closed")
+		return nil, taskmanager.ErrInternalError("task manager is closed")
 	}
 	m.nextID++
 	id := m.nextID


### PR DESCRIPTION
## Summary

- Implement the A2A v1.0 HTTP+JSON protocol binding, including the standard REST routes, direct protocol-object responses, raw `StreamResponse` SSE data, and `google.rpc.Status` JSON errors.
- Add client-side binding selection through `WithProtocolBinding` and ordered Agent Card interface selection through `NewA2AClientFromAgentCard`, without mutating signed cards.
- Add server-side opt-in through `WithHTTPJSONEndpoint`, with automatic enablement for static Agent Cards that advertise `HTTP+JSON`.
- Make TaskManager operation errors binding-neutral so JSON-RPC and HTTP+JSON adapters can map the same semantic failure independently.

## Compatibility

- Direct client construction and server behavior continue to default to JSON-RPC with `application/json`.
- HTTP+JSON responses use `application/a2a+json`; requests also accept `application/json` for compatibility with the v1.0.0 media-type guidance.
- The TaskManager error constructors that previously exposed `internal/jsonrpc.Error` now return public binding-neutral errors. This is an intentional prerelease API change; unrelated legacy constants and generic `error` return signatures remain source-compatible.

## Validation

- `go test -count=1 ./...`
- `go test -count=1 -race ./client ./server ./taskmanager ./internal/jsonrpc ./internal/sse ./compat/v0`
- `go vet ./...`
- Redis nested module tests against both the published dependency and a local `go.work`
- Example modules: `go test -count=1 ./...`
- `mkdocs build --strict --clean`
- `go-apidiff origin/v2 HEAD --print-compatible`