### PR TITLE
taskmanager: add tenant data isolation and indexed task listing

### DIFF
--- a/taskmanager/memory/memory.go
+++ b/taskmanager/memory/memory.go
@@ -43,6 +43,17 @@ type ConversationHistory struct {
 	LastAccessTime time.Time
 }
 
+// scopedID is the internal identity of tenant-owned data. Tenant remains
+// request scope and is deliberately not written into protocol.Task.
+type scopedID struct {
+	tenant string
+	id     string
+}
+
+func newScopedID(tenant, id string) scopedID {
+	return scopedID{tenant: tenant, id: id}
+}
+
 // taskSubscriber is one fan-out endpoint of a task's event stream: the
 // message/stream request pipe or a tasks/resubscribe subscription. Events are
 // queued on a buffered channel; with blockingSend the producer waits for a
@@ -132,13 +143,12 @@ type TaskManager struct {
 	// processor is the user-provided agent logic invoked for every incoming message.
 	processor taskmanager.MessageProcessor
 
-	// messages stores all Messages, indexed by messageID
-	// key: messageID, value: Message
-	messages map[string]protocol.Message
+	// messages stores all Messages, indexed by tenant and message ID.
+	messages map[scopedID]protocol.Message
 
 	// conversations stores the message history of each conversation, indexed by contextID
 	// key: contextID, value: ConversationHistory
-	conversations map[string]*ConversationHistory
+	conversations map[scopedID]*ConversationHistory
 
 	// conversationMu protects the messages and conversations fields
 	conversationMu sync.RWMutex
@@ -146,14 +156,14 @@ type TaskManager struct {
 	// tasks stores the task snapshots, indexed by taskID. The drain engine is
 	// the writer while an execution is live; OnCancelTask writes only when no
 	// execution is live (see OnCancelTask).
-	tasks map[string]*protocol.Task
+	tasks map[scopedID]*protocol.Task
 
 	// taskMu protects the tasks and subscribers fields
 	taskMu sync.RWMutex
 
 	// subscribers stores the fan-out endpoints of each task's event stream
 	// key: taskID, value: subscriber list
-	subscribers map[string][]*taskSubscriber
+	subscribers map[scopedID][]*taskSubscriber
 
 	// pushStore persists push-notification configs (multiple per task, addressed
 	// by config ID). It is an internal detail; pluggable storage backends are
@@ -171,7 +181,7 @@ type TaskManager struct {
 	// executions tracks the cancellation handle of every live MessageProcessor run,
 	// keyed by task ID. Registered before ProcessMessage, removed when the engine
 	// finishes; OnCancelTask cancels through it.
-	executions map[string]*execution
+	executions map[scopedID]*execution
 	// execMu protects the executions and closed fields
 	execMu sync.Mutex
 	// closed rejects new runs once Close has begun tearing the manager down.
@@ -211,13 +221,13 @@ func NewTaskManager(processor taskmanager.MessageProcessor, opts ...TaskManagerO
 
 	manager := &TaskManager{
 		processor:     processor,
-		messages:      make(map[string]protocol.Message),
-		conversations: make(map[string]*ConversationHistory),
-		tasks:         make(map[string]*protocol.Task),
-		subscribers:   make(map[string][]*taskSubscriber),
+		messages:      make(map[scopedID]protocol.Message),
+		conversations: make(map[scopedID]*ConversationHistory),
+		tasks:         make(map[scopedID]*protocol.Task),
+		subscribers:   make(map[scopedID][]*taskSubscriber),
 		pushStore:     newPushConfigStore(),
 		pushEnabled:   options.Push.Sender != nil || options.Push.ManualDelivery,
-		executions:    make(map[string]*execution),
+		executions:    make(map[scopedID]*execution),
 		options:       options,
 		stopCleanup:   make(chan struct{}),
 	}
@@ -279,10 +289,10 @@ func (m *TaskManager) OnSendMessage(
 		// engine keep running; later state is retrievable via GetTask/subscribe.
 		select {
 		case out := <-eng.immediateResult:
-			return m.buildSendResponse(out.task, out.message, historyLength)
+			return m.buildSendResponse(request.Tenant, out.task, out.message, historyLength)
 		case <-eng.done:
 			// The stream closed before any immediate result: same derivation as blocking.
-			return m.buildSendResponse(eng.finalOutcome.task, eng.finalOutcome.message, historyLength)
+			return m.buildSendResponse(request.Tenant, eng.finalOutcome.task, eng.finalOutcome.message, historyLength)
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		}
@@ -290,7 +300,7 @@ func (m *TaskManager) OnSendMessage(
 
 	select {
 	case <-eng.done:
-		return m.buildSendResponse(eng.finalOutcome.task, eng.finalOutcome.message, historyLength)
+		return m.buildSendResponse(request.Tenant, eng.finalOutcome.task, eng.finalOutcome.message, historyLength)
 	case <-ctx.Done():
 		// The request died first. The execution is detached (§3.3): it keeps
 		// running and its results stay retrievable via GetTask/resubscribe.
@@ -329,8 +339,9 @@ func (m *TaskManager) OnSendMessageStream(
 
 // OnGetTask handles the tasks/get request
 func (m *TaskManager) OnGetTask(ctx context.Context, params protocol.TaskQueryParams) (*protocol.Task, error) {
+	key := newScopedID(params.Tenant, params.ID)
 	m.taskMu.RLock()
-	task, exists := m.tasks[params.ID]
+	task, exists := m.tasks[key]
 	if !exists {
 		m.taskMu.RUnlock()
 		return nil, taskmanager.ErrTaskNotFound(params.ID)
@@ -340,7 +351,7 @@ func (m *TaskManager) OnGetTask(ctx context.Context, params protocol.TaskQueryPa
 	taskCopy := copyTask(task)
 	m.taskMu.RUnlock()
 
-	m.fillTaskHistory(taskCopy, params.HistoryLength)
+	m.fillTaskHistory(params.Tenant, taskCopy, params.HistoryLength)
 	return taskCopy, nil
 }
 
@@ -353,7 +364,7 @@ func (m *TaskManager) OnGetTask(ctx context.Context, params protocol.TaskQueryPa
 // sentinel so no continuation can start (and write) concurrently.
 func (m *TaskManager) OnCancelTask(ctx context.Context, params protocol.TaskIDParams) (*protocol.Task, error) {
 	for {
-		live, sentinel, yieldDone := m.claimCancelSlot(params.ID)
+		live, sentinel, yieldDone := m.claimCancelSlot(params.Tenant, params.ID)
 		if yieldDone != nil {
 			select {
 			case <-yieldDone:
@@ -363,14 +374,14 @@ func (m *TaskManager) OnCancelTask(ctx context.Context, params protocol.TaskIDPa
 			}
 		}
 		if live == nil {
-			defer m.deregisterExecution(params.ID, sentinel)
+			defer m.deregisterExecution(params.Tenant, params.ID, sentinel)
 			return m.cancelWithoutLiveRun(params)
 		}
 
 		// A stored terminal state is immutable even while the round is still
 		// draining: canceling it must fail like the no-live path does.
 		m.taskMu.RLock()
-		task, exists := m.tasks[params.ID]
+		task, exists := m.tasks[newScopedID(params.Tenant, params.ID)]
 		var snapshot *protocol.Task
 		var terminal protocol.TaskState
 		if exists {
@@ -387,7 +398,7 @@ func (m *TaskManager) OnCancelTask(ctx context.Context, params protocol.TaskIDPa
 		// Linearize cancellation against a concurrent suspend handoff. If the
 		// handoff won, wait for it and retry as a no-live cancel; otherwise the
 		// close rule is guaranteed to observe cancelRequested.
-		yieldDone, accepted := m.requestExecutionCancel(params.ID, live)
+		yieldDone, accepted := m.requestExecutionCancel(params.Tenant, params.ID, live)
 		if yieldDone != nil {
 			select {
 			case <-yieldDone:
@@ -400,7 +411,7 @@ func (m *TaskManager) OnCancelTask(ctx context.Context, params protocol.TaskIDPa
 			continue
 		}
 
-		if m.liveExecution(params.ID) != live {
+		if m.liveExecution(params.Tenant, params.ID) != live {
 			// The run yielded (suspend) or finished while we were canceling, so
 			// its close rule will not persist CANCELED on our behalf. Reassess:
 			// the next pass either claims the free slot and persists CANCELED
@@ -420,8 +431,9 @@ func (m *TaskManager) OnCancelTask(ctx context.Context, params protocol.TaskIDPa
 // persist first, then broadcast (§3.6). The caller holds the task's execution
 // slot (sentinel), making this the task's single writer.
 func (m *TaskManager) cancelWithoutLiveRun(params protocol.TaskIDParams) (*protocol.Task, error) {
+	key := newScopedID(params.Tenant, params.ID)
 	m.taskMu.Lock()
-	task, exists := m.tasks[params.ID]
+	task, exists := m.tasks[key]
 	if !exists {
 		m.taskMu.Unlock()
 		return nil, taskmanager.ErrTaskNotFound(params.ID)
@@ -444,8 +456,8 @@ func (m *TaskManager) cancelWithoutLiveRun(params protocol.TaskIDParams) (*proto
 	result := copyTask(task)
 	m.taskMu.Unlock()
 
-	m.notifySubscribers(params.ID, protocol.NewStreamResponseStatusUpdate(event))
-	m.cleanSubscribers(params.ID)
+	m.notifySubscribers(params.Tenant, params.ID, protocol.NewStreamResponseStatusUpdate(event))
+	m.cleanSubscribers(params.Tenant, params.ID)
 	return result, nil
 }
 
@@ -460,7 +472,7 @@ func (m *TaskManager) OnPushNotificationSet(
 	if err := push.ValidateConfig(params); err != nil {
 		return nil, jsonrpc.ErrInvalidParams(err.Error())
 	}
-	if err := m.ensurePushTaskExists(params.TaskID); err != nil {
+	if err := m.ensurePushTaskExists(params.Tenant, params.TaskID); err != nil {
 		return nil, err
 	}
 	stored, err := m.pushStore.save(params)
@@ -482,10 +494,10 @@ func (m *TaskManager) OnPushNotificationGet(
 	if params.ID == "" {
 		return nil, jsonrpc.ErrInvalidParams("push notification config ID is required")
 	}
-	if err := m.ensurePushTaskExists(params.TaskID); err != nil {
+	if err := m.ensurePushTaskExists(params.Tenant, params.TaskID); err != nil {
 		return nil, err
 	}
-	config, found := m.pushStore.get(params.TaskID, params.ID)
+	config, found := m.pushStore.get(params.Tenant, params.TaskID, params.ID)
 	if !found {
 		return nil, taskmanager.ErrPushConfigNotFound(params.TaskID)
 	}
@@ -507,7 +519,10 @@ func (m *TaskManager) OnListTasks(
 	m.taskMu.RLock()
 	defer m.taskMu.RUnlock()
 	var filtered []*protocol.Task
-	for _, task := range m.tasks {
+	for key, task := range m.tasks {
+		if key.tenant != params.Tenant {
+			continue
+		}
 		if taskmanager.TaskMatchesListFilter(task, params, afterTime) {
 			filtered = append(filtered, task)
 		}
@@ -524,10 +539,10 @@ func (m *TaskManager) OnPushNotificationList(
 	if !m.pushEnabled {
 		return nil, taskmanager.ErrPushNotificationNotSupported()
 	}
-	if err := m.ensurePushTaskExists(params.TaskID); err != nil {
+	if err := m.ensurePushTaskExists(params.Tenant, params.TaskID); err != nil {
 		return nil, err
 	}
-	configs := m.pushStore.list(params.TaskID)
+	configs := m.pushStore.list(params.Tenant, params.TaskID)
 	return &protocol.ListTaskPushNotificationConfigsResult{Configs: configs}, nil
 }
 
@@ -543,17 +558,17 @@ func (m *TaskManager) OnPushNotificationDelete(
 	if params.ID == "" {
 		return jsonrpc.ErrInvalidParams("push notification config ID is required")
 	}
-	if err := m.ensurePushTaskExists(params.TaskID); err != nil {
+	if err := m.ensurePushTaskExists(params.Tenant, params.TaskID); err != nil {
 		return err
 	}
-	m.pushStore.remove(params.TaskID, params.ID)
+	m.pushStore.remove(params.Tenant, params.TaskID, params.ID)
 	log.Debugf("TaskManager: Push notification config %s deleted for task %s", params.ID, params.TaskID)
 	return nil
 }
 
-func (m *TaskManager) ensurePushTaskExists(taskID string) error {
+func (m *TaskManager) ensurePushTaskExists(tenant, taskID string) error {
 	m.taskMu.RLock()
-	_, exists := m.tasks[taskID]
+	_, exists := m.tasks[newScopedID(tenant, taskID)]
 	m.taskMu.RUnlock()
 	if !exists {
 		return taskmanager.ErrTaskNotFound(taskID)
@@ -568,9 +583,10 @@ func (m *TaskManager) OnResubscribe(
 ) (<-chan protocol.StreamResponse, error) {
 	m.taskMu.Lock()
 	defer m.taskMu.Unlock()
+	key := newScopedID(params.Tenant, params.ID)
 
 	// Check if task exists
-	task, exists := m.tasks[params.ID]
+	task, exists := m.tasks[key]
 	if !exists {
 		return nil, taskmanager.ErrTaskNotFound(params.ID)
 	}
@@ -597,7 +613,7 @@ func (m *TaskManager) OnResubscribe(
 	}
 
 	// Add to subscribers list
-	m.subscribers[params.ID] = append(m.subscribers[params.ID], subscriber)
+	m.subscribers[key] = append(m.subscribers[key], subscriber)
 
 	// Tie the subscription to the request: when the client goes away the
 	// subscriber is removed and closed, so the server-side drain ends and the
@@ -606,7 +622,7 @@ func (m *TaskManager) OnResubscribe(
 	go func() {
 		select {
 		case <-ctx.Done():
-			m.cleanupFailedSubscribers(params.ID, []*taskSubscriber{subscriber})
+			m.cleanupFailedSubscribers(params.Tenant, params.ID, []*taskSubscriber{subscriber})
 		case <-subscriber.done:
 		}
 	}()
@@ -619,23 +635,24 @@ func (m *TaskManager) OnResubscribe(
 // =============================================================================
 
 // storeMessage stores messages
-func (m *TaskManager) storeMessage(message protocol.Message) {
+func (m *TaskManager) storeMessage(tenant string, message protocol.Message) {
 	m.conversationMu.Lock()
 	defer m.conversationMu.Unlock()
 
 	// Store the message
-	m.messages[message.MessageID] = message
+	m.messages[newScopedID(tenant, message.MessageID)] = message
 
 	// If the message has a contextID, add it to conversation history
 	if message.ContextID != nil {
 		contextID := *message.ContextID
-		conv, exists := m.conversations[contextID]
+		conversationKey := newScopedID(tenant, contextID)
+		conv, exists := m.conversations[conversationKey]
 		if !exists {
 			conv = &ConversationHistory{
 				MessageIDs:     make([]string, 0),
 				LastAccessTime: time.Now(),
 			}
-			m.conversations[contextID] = conv
+			m.conversations[conversationKey] = conv
 		}
 		conv.LastAccessTime = time.Now()
 
@@ -659,13 +676,13 @@ func (m *TaskManager) storeMessage(message protocol.Message) {
 			removedMsgID := conv.MessageIDs[0]
 			conv.MessageIDs = conv.MessageIDs[1:]
 			// Delete old message from message storage
-			delete(m.messages, removedMsgID)
+			delete(m.messages, newScopedID(tenant, removedMsgID))
 		}
 	}
 }
 
 // getConversationHistory gets conversation history of specified length
-func (m *TaskManager) getConversationHistory(contextID string, length int) []protocol.Message {
+func (m *TaskManager) getConversationHistory(tenant, contextID string, length int) []protocol.Message {
 	// LastAccessTime is mutated below: this must be the write lock (a read
 	// lock here races concurrent history reads and tears the time value).
 	m.conversationMu.Lock()
@@ -673,7 +690,7 @@ func (m *TaskManager) getConversationHistory(contextID string, length int) []pro
 
 	var history []protocol.Message
 
-	if conversation, exists := m.conversations[contextID]; exists {
+	if conversation, exists := m.conversations[newScopedID(tenant, contextID)]; exists {
 		// Update last access time
 		conversation.LastAccessTime = time.Now()
 
@@ -683,7 +700,7 @@ func (m *TaskManager) getConversationHistory(contextID string, length int) []pro
 		}
 
 		for i := start; i < len(conversation.MessageIDs); i++ {
-			if msg, exists := m.messages[conversation.MessageIDs[i]]; exists {
+			if msg, exists := m.messages[newScopedID(tenant, conversation.MessageIDs[i])]; exists {
 				history = append(history, msg)
 			}
 		}
@@ -697,22 +714,22 @@ func (m *TaskManager) getConversationHistory(contextID string, length int) []pro
 //   - historyLength unset -> no limit (full history)
 //   - historyLength == 0  -> no messages
 //   - historyLength > 0   -> the most recent N messages
-func (m *TaskManager) fillTaskHistory(task *protocol.Task, historyLength *int) {
+func (m *TaskManager) fillTaskHistory(tenant string, task *protocol.Task, historyLength *int) {
 	if task.ContextID == "" {
 		return
 	}
 	switch {
 	case historyLength == nil:
-		task.History = m.getConversationHistory(task.ContextID, unlimitedHistoryLength)
+		task.History = m.getConversationHistory(tenant, task.ContextID, unlimitedHistoryLength)
 	case *historyLength > 0:
-		task.History = m.getConversationHistory(task.ContextID, *historyLength)
+		task.History = m.getConversationHistory(tenant, task.ContextID, *historyLength)
 	default: // == 0 (or negative): no messages
 		task.History = nil
 	}
 }
 
 // processReplyMessage processes the reply message, add messageID and contextID if not set
-func (m *TaskManager) processReplyMessage(ctxID *string, message *protocol.Message) {
+func (m *TaskManager) processReplyMessage(tenant string, ctxID *string, message *protocol.Message) {
 	message.ContextID = ctxID
 	message.Role = protocol.MessageRoleAgent
 
@@ -725,7 +742,7 @@ func (m *TaskManager) processReplyMessage(ctxID *string, message *protocol.Messa
 		message.ContextID = &contextID
 	}
 
-	m.storeMessage(*message)
+	m.storeMessage(tenant, *message)
 }
 
 // isFinalState checks if it's a final state
@@ -772,11 +789,11 @@ func (m *TaskManager) SupportsPushNotifications() bool {
 // It is a no-op unless automatic delivery is configured. The bounded dispatcher
 // preserves order per config; when its queue is full this call applies
 // backpressure rather than dropping an event.
-func (m *TaskManager) dispatchPush(taskID string, event protocol.StreamResponse) {
+func (m *TaskManager) dispatchPush(tenant, taskID string, event protocol.StreamResponse) {
 	if m.pushDispatcher == nil {
 		return
 	}
-	registrations := m.pushStore.registrations(taskID)
+	registrations := m.pushStore.registrations(tenant, taskID)
 	if len(registrations) == 0 {
 		return
 	}
@@ -792,18 +809,19 @@ func (m *TaskManager) dispatchPush(taskID string, event protocol.StreamResponse)
 }
 
 // notifySubscribers notifies all subscribers of the task
-func (m *TaskManager) notifySubscribers(taskID string, event protocol.StreamResponse) {
+func (m *TaskManager) notifySubscribers(tenant, taskID string, event protocol.StreamResponse) {
 	// Deliver push notifications independently of live SSE subscribers: reaching
 	// clients that are not currently streaming is the whole point of push.
-	m.dispatchPush(taskID, event)
-	m.notifyLiveSubscribers(taskID, event)
+	m.dispatchPush(tenant, taskID, event)
+	m.notifyLiveSubscribers(tenant, taskID, event)
 }
 
 // notifyLiveSubscribers fans out to process-local task subscribers without
 // dispatching push a second time.
-func (m *TaskManager) notifyLiveSubscribers(taskID string, event protocol.StreamResponse) {
+func (m *TaskManager) notifyLiveSubscribers(tenant, taskID string, event protocol.StreamResponse) {
+	key := newScopedID(tenant, taskID)
 	m.taskMu.RLock()
-	subs, exists := m.subscribers[taskID]
+	subs, exists := m.subscribers[key]
 	if !exists || len(subs) == 0 {
 		m.taskMu.RUnlock()
 		return
@@ -833,15 +851,19 @@ func (m *TaskManager) notifyLiveSubscribers(taskID string, event protocol.Stream
 
 	// Clean up failed or closed subscribers
 	if len(failedSubscribers) > 0 {
-		m.cleanupFailedSubscribers(taskID, failedSubscribers)
+		m.cleanupFailedSubscribers(tenant, taskID, failedSubscribers)
 	}
 }
 
 // cleanupFailedSubscribers cleans up failed or closed subscribers
-func (m *TaskManager) cleanupFailedSubscribers(taskID string, failedSubscribers []*taskSubscriber) {
+func (m *TaskManager) cleanupFailedSubscribers(
+	tenant, taskID string,
+	failedSubscribers []*taskSubscriber,
+) {
+	key := newScopedID(tenant, taskID)
 	m.taskMu.Lock()
 
-	subs, exists := m.subscribers[taskID]
+	subs, exists := m.subscribers[key]
 	if !exists {
 		m.taskMu.Unlock()
 		return
@@ -866,12 +888,12 @@ func (m *TaskManager) cleanupFailedSubscribers(taskID string, failedSubscribers 
 	}
 
 	if len(removedSubs) > 0 {
-		m.subscribers[taskID] = filteredSubs
+		m.subscribers[key] = filteredSubs
 		log.Debugf("Removed %d failed subscribers for task %s", len(removedSubs), taskID)
 
 		// If there are no subscribers left, delete the entire entry
 		if len(filteredSubs) == 0 {
-			delete(m.subscribers, taskID)
+			delete(m.subscribers, key)
 		}
 	}
 	m.taskMu.Unlock()
@@ -882,15 +904,16 @@ func (m *TaskManager) cleanupFailedSubscribers(taskID string, failedSubscribers 
 }
 
 // cleanSubscribers closes and removes all subscribers for a task.
-func (m *TaskManager) cleanSubscribers(taskID string) {
+func (m *TaskManager) cleanSubscribers(tenant, taskID string) {
+	key := newScopedID(tenant, taskID)
 	m.taskMu.Lock()
 
-	subs, exists := m.subscribers[taskID]
+	subs, exists := m.subscribers[key]
 	if !exists {
 		m.taskMu.Unlock()
 		return
 	}
-	delete(m.subscribers, taskID)
+	delete(m.subscribers, key)
 	m.taskMu.Unlock()
 
 	for _, sub := range subs {
@@ -906,14 +929,16 @@ func (m *TaskManager) CleanExpiredConversations(maxAge time.Duration) int {
 	defer m.conversationMu.Unlock()
 
 	now := time.Now()
-	expiredContexts := make([]string, 0)
-	expiredMessageIDs := make([]string, 0)
+	expiredContexts := make([]scopedID, 0)
+	expiredMessages := make([]scopedID, 0)
 
 	// Find expired conversations
-	for contextID, conversation := range m.conversations {
+	for contextKey, conversation := range m.conversations {
 		if now.Sub(conversation.LastAccessTime) > maxAge {
-			expiredContexts = append(expiredContexts, contextID)
-			expiredMessageIDs = append(expiredMessageIDs, conversation.MessageIDs...)
+			expiredContexts = append(expiredContexts, contextKey)
+			for _, messageID := range conversation.MessageIDs {
+				expiredMessages = append(expiredMessages, newScopedID(contextKey.tenant, messageID))
+			}
 		}
 	}
 
@@ -923,13 +948,13 @@ func (m *TaskManager) CleanExpiredConversations(maxAge time.Duration) int {
 	}
 
 	// Delete messages from expired conversations
-	for _, messageID := range expiredMessageIDs {
-		delete(m.messages, messageID)
+	for _, messageKey := range expiredMessages {
+		delete(m.messages, messageKey)
 	}
 
 	if len(expiredContexts) > 0 {
 		log.Debugf("Cleaned %d expired conversations, removed %d messages",
-			len(expiredContexts), len(expiredMessageIDs))
+			len(expiredContexts), len(expiredMessages))
 	}
 
 	return len(expiredContexts)
@@ -945,10 +970,10 @@ func (m *TaskManager) cleanExpiredTasks(maxAge time.Duration) int {
 	m.taskMu.Lock()
 
 	now := time.Now()
-	expiredTaskIDs := make([]string, 0)
+	expiredTaskIDs := make([]scopedID, 0)
 	subsToClose := make([]*taskSubscriber, 0)
 
-	for taskID, task := range m.tasks {
+	for taskKey, task := range m.tasks {
 		if !isFinalState(task.Status.State) {
 			continue
 		}
@@ -959,19 +984,19 @@ func (m *TaskManager) cleanExpiredTasks(maxAge time.Duration) int {
 			// use RFC3339), but log it so a future bad-timestamp path is observable
 			// instead of leaking silently.
 			log.Debugf("Skipping task %s in cleanup: unparsable timestamp %q: %v",
-				taskID, task.Status.Timestamp, err)
+				taskKey.id, task.Status.Timestamp, err)
 			continue
 		}
 		if now.Sub(ts) > maxAge {
-			expiredTaskIDs = append(expiredTaskIDs, taskID)
+			expiredTaskIDs = append(expiredTaskIDs, taskKey)
 		}
 	}
 
-	for _, taskID := range expiredTaskIDs {
-		delete(m.tasks, taskID)
-		if subs, exists := m.subscribers[taskID]; exists {
+	for _, taskKey := range expiredTaskIDs {
+		delete(m.tasks, taskKey)
+		if subs, exists := m.subscribers[taskKey]; exists {
 			subsToClose = append(subsToClose, subs...)
-			delete(m.subscribers, taskID)
+			delete(m.subscribers, taskKey)
 		}
 	}
 
@@ -986,14 +1011,14 @@ func (m *TaskManager) cleanExpiredTasks(maxAge time.Duration) int {
 
 		// A terminal task normally has no live execution, but its engine may
 		// still be draining; cancel the MessageProcessor ctx so a stuck run can exit.
-		for _, taskID := range expiredTaskIDs {
-			if exec := m.liveExecution(taskID); exec != nil {
+		for _, taskKey := range expiredTaskIDs {
+			if exec := m.liveExecution(taskKey.tenant, taskKey.id); exec != nil {
 				exec.cancel()
 			}
 		}
 
-		for _, taskID := range expiredTaskIDs {
-			m.pushStore.removeAll(taskID)
+		for _, taskKey := range expiredTaskIDs {
+			m.pushStore.removeAll(taskKey.tenant, taskKey.id)
 		}
 	}
 
@@ -1042,7 +1067,7 @@ func (m *TaskManager) Close() error {
 		for _, subs := range m.subscribers {
 			subsToClose = append(subsToClose, subs...)
 		}
-		m.subscribers = make(map[string][]*taskSubscriber)
+		m.subscribers = make(map[scopedID][]*taskSubscriber)
 		m.taskMu.Unlock()
 		for _, sub := range subsToClose {
 			sub.Close()
@@ -1054,7 +1079,7 @@ func (m *TaskManager) Close() error {
 		m.engineWg.Wait()
 
 		m.taskMu.Lock()
-		m.tasks = make(map[string]*protocol.Task)
+		m.tasks = make(map[scopedID]*protocol.Task)
 		m.taskMu.Unlock()
 		m.pushStore.close()
 	})

--- a/taskmanager/memory/memory_engine.go
+++ b/taskmanager/memory/memory_engine.go
@@ -160,18 +160,18 @@ func (m *TaskManager) prepareExecContext(
 	// write — the slot frees only after that write — so the snapshot below can
 	// never be a stale pre-terminal copy that would smuggle writes past a
 	// terminal state.
-	if err := m.registerExecution(ctx, taskID, exec); err != nil {
+	if err := m.registerExecution(ctx, request.Tenant, taskID, exec); err != nil {
 		return nil, err
 	}
 	releaseOnError := true
 	defer func() {
 		if releaseOnError {
-			m.releaseExecution(taskID, exec)
+			m.releaseExecution(request.Tenant, taskID, exec)
 		}
 	}()
 
 	// Continuation: a message carrying a taskId targets an existing task (§3.4).
-	taskCopy, err := m.resolveContinuation(message)
+	taskCopy, err := m.resolveContinuation(request.Tenant, message)
 	if err != nil {
 		return nil, err
 	}
@@ -193,6 +193,7 @@ func (m *TaskManager) prepareExecContext(
 	// the conversation history.
 	acceptedOutputModes, pushConfig, err := m.prepareExecConfiguration(
 		request.Configuration,
+		request.Tenant,
 		taskID,
 		taskCopy != nil,
 	)
@@ -200,10 +201,10 @@ func (m *TaskManager) prepareExecContext(
 		return nil, err
 	}
 
-	m.commitIncomingMessage(taskID, message, taskCopy)
+	m.commitIncomingMessage(request.Tenant, taskID, message, taskCopy)
 	// The manager's history limit shapes the processor snapshot; the request's
 	// historyLength only shapes the task returned to the client.
-	history := m.getConversationHistory(*message.ContextID, m.options.MaxHistoryLength)
+	history := m.getConversationHistory(request.Tenant, *message.ContextID, m.options.MaxHistoryLength)
 
 	releaseOnError = false
 	return &taskmanager.ExecContext{
@@ -224,6 +225,7 @@ func (m *TaskManager) prepareExecContext(
 // task event materializes the task.
 func (m *TaskManager) prepareExecConfiguration(
 	configuration *protocol.SendMessageConfiguration,
+	tenant string,
 	taskID string,
 	continuation bool,
 ) ([]string, *protocol.TaskPushNotificationConfig, error) {
@@ -240,6 +242,7 @@ func (m *TaskManager) prepareExecConfiguration(
 	}
 
 	pushConfig := clonePushConfig(*configuration.PushConfig)
+	pushConfig.Tenant = tenant
 	pushConfig.TaskID = taskID
 	if pushConfig.ID == "" {
 		// Inline registration retains the legacy stable default ID so a
@@ -263,6 +266,7 @@ func (m *TaskManager) prepareExecConfiguration(
 // validation has succeeded. On a continuation, the suspended status message
 // becomes history immediately before the new user turn.
 func (m *TaskManager) commitIncomingMessage(
+	tenant string,
 	taskID string,
 	message *protocol.Message,
 	taskCopy *protocol.Task,
@@ -275,20 +279,20 @@ func (m *TaskManager) commitIncomingMessage(
 		statusMessage := taskCopy.Status.Message
 		taskCopy.Status.Message = nil
 		m.taskMu.Lock()
-		if stored, exists := m.tasks[taskID]; exists {
+		if stored, exists := m.tasks[newScopedID(tenant, taskID)]; exists {
 			stored.Status.Message = nil
 		}
 		m.taskMu.Unlock()
-		m.storeStatusMessage(taskID, *message.ContextID, statusMessage)
+		m.storeStatusMessage(tenant, taskID, *message.ContextID, statusMessage)
 	}
-	m.storeMessage(*message)
+	m.storeMessage(tenant, *message)
 }
 
 // resolveContinuation loads and validates the task a continuation message
 // targets (§3.4), returning a copy for ec.Task. A message without a taskId is
 // a fresh round and resolves to nil. When taskId is set it is the same value
 // the caller registered the execution under (see startExecution).
-func (m *TaskManager) resolveContinuation(message *protocol.Message) (*protocol.Task, error) {
+func (m *TaskManager) resolveContinuation(tenant string, message *protocol.Message) (*protocol.Task, error) {
 	if message.TaskID == nil || *message.TaskID == "" {
 		return nil, nil
 	}
@@ -296,7 +300,7 @@ func (m *TaskManager) resolveContinuation(message *protocol.Message) (*protocol.
 
 	m.taskMu.RLock()
 	defer m.taskMu.RUnlock()
-	stored, exists := m.tasks[taskID]
+	stored, exists := m.tasks[newScopedID(tenant, taskID)]
 	if !exists {
 		return nil, taskmanager.ErrTaskNotFound(taskID)
 	}
@@ -355,15 +359,20 @@ func (m *TaskManager) startExecution(
 		return nil, err
 	}
 
-	events, err := m.processor.ProcessMessage(execCtx, ec)
+	processorEC := *ec
+	if ec.PushConfig != nil {
+		pushConfig := clonePushConfig(*ec.PushConfig)
+		processorEC.PushConfig = &pushConfig
+	}
+	events, err := m.processor.ProcessMessage(execCtx, &processorEC)
 	if err != nil {
 		// Failed start (§3.5): no events are consumed, nothing was persisted.
-		m.releaseExecution(ec.TaskID, exec)
+		m.releaseExecution(ec.Tenant, ec.TaskID, exec)
 		cancel()
 		return nil, err
 	}
 	if events == nil {
-		m.releaseExecution(ec.TaskID, exec)
+		m.releaseExecution(ec.Tenant, ec.TaskID, exec)
 		cancel()
 		return nil, jsonrpc.ErrInternalError("processor returned nil channel")
 	}
@@ -387,16 +396,21 @@ func (m *TaskManager) startExecution(
 // registerExecution publishes the cancellation handle of a starting run. A
 // task admits at most one live run; a continuation waits through the previous
 // round's short suspend handoff, while any other concurrent round is rejected.
-func (m *TaskManager) registerExecution(ctx context.Context, taskID string, exec *execution) error {
+func (m *TaskManager) registerExecution(
+	ctx context.Context,
+	tenant, taskID string,
+	exec *execution,
+) error {
+	key := newScopedID(tenant, taskID)
 	for {
 		m.execMu.Lock()
 		if m.closed {
 			m.execMu.Unlock()
 			return jsonrpc.ErrInternalError("task manager is closed")
 		}
-		current, exists := m.executions[taskID]
+		current, exists := m.executions[key]
 		if !exists {
-			m.executions[taskID] = exec
+			m.executions[key] = exec
 			// Counted under the registry lock so Close (which flips m.closed first)
 			// can never begin waiting before a just-admitted run is counted.
 			m.engineWg.Add(1)
@@ -421,8 +435,8 @@ func (m *TaskManager) registerExecution(ctx context.Context, taskID string, exec
 
 // releaseExecution aborts a registered run whose engine never started: it
 // undoes registerExecution's registration and engine count.
-func (m *TaskManager) releaseExecution(taskID string, exec *execution) {
-	m.deregisterExecution(taskID, exec)
+func (m *TaskManager) releaseExecution(tenant, taskID string, exec *execution) {
+	m.deregisterExecution(tenant, taskID, exec)
 	m.engineWg.Done()
 }
 
@@ -431,18 +445,20 @@ func (m *TaskManager) releaseExecution(taskID string, exec *execution) {
 // CANCELED write gets the same single-writer guarantee as a run: no
 // continuation can register (and then write) concurrently with it.
 func (m *TaskManager) claimCancelSlot(
+	tenant string,
 	taskID string,
 ) (live *execution, sentinel *execution, yieldDone <-chan struct{}) {
+	key := newScopedID(tenant, taskID)
 	m.execMu.Lock()
 	defer m.execMu.Unlock()
-	if exec, ok := m.executions[taskID]; ok {
+	if exec, ok := m.executions[key]; ok {
 		if exec.yieldDone != nil {
 			return nil, nil, exec.yieldDone
 		}
 		return exec, nil, nil
 	}
 	sentinel = &execution{cancel: func() {}}
-	m.executions[taskID] = sentinel
+	m.executions[key] = sentinel
 	return nil, sentinel, nil
 }
 
@@ -450,11 +466,13 @@ func (m *TaskManager) claimCancelSlot(
 // suspend handoff. It returns the handoff channel when yield won, or accepted
 // after publishing cancelRequested under the registry lock.
 func (m *TaskManager) requestExecutionCancel(
+	tenant string,
 	taskID string,
 	exec *execution,
 ) (yieldDone <-chan struct{}, accepted bool) {
+	key := newScopedID(tenant, taskID)
 	m.execMu.Lock()
-	if m.executions[taskID] != exec {
+	if m.executions[key] != exec {
 		m.execMu.Unlock()
 		return nil, false
 	}
@@ -470,11 +488,12 @@ func (m *TaskManager) requestExecutionCancel(
 }
 
 // deregisterExecution removes the handle if it still belongs to this run.
-func (m *TaskManager) deregisterExecution(taskID string, exec *execution) {
+func (m *TaskManager) deregisterExecution(tenant, taskID string, exec *execution) {
+	key := newScopedID(tenant, taskID)
 	m.execMu.Lock()
 	defer m.execMu.Unlock()
-	if m.executions[taskID] == exec {
-		delete(m.executions, taskID)
+	if m.executions[key] == exec {
+		delete(m.executions, key)
 		if exec.yieldDone != nil {
 			close(exec.yieldDone)
 			exec.yieldDone = nil
@@ -485,10 +504,11 @@ func (m *TaskManager) deregisterExecution(taskID string, exec *execution) {
 // beginExecutionYield turns an active slot into a short handoff barrier. The
 // slot remains owned by exec until its suspend frame has reached every local
 // observer, but continuations wait for the handoff instead of failing.
-func (m *TaskManager) beginExecutionYield(taskID string, exec *execution) bool {
+func (m *TaskManager) beginExecutionYield(tenant, taskID string, exec *execution) bool {
+	key := newScopedID(tenant, taskID)
 	m.execMu.Lock()
 	defer m.execMu.Unlock()
-	if m.executions[taskID] == exec && exec.yieldDone == nil && !exec.cancelRequested.Load() {
+	if m.executions[key] == exec && exec.yieldDone == nil && !exec.cancelRequested.Load() {
 		exec.yieldDone = make(chan struct{})
 		return true
 	}
@@ -497,20 +517,21 @@ func (m *TaskManager) beginExecutionYield(taskID string, exec *execution) bool {
 
 // abortExecutionYield restores an active slot when committing the suspended
 // state fails. Waiters wake and re-evaluate it as an ordinary active run.
-func (m *TaskManager) abortExecutionYield(taskID string, exec *execution) {
+func (m *TaskManager) abortExecutionYield(tenant, taskID string, exec *execution) {
+	key := newScopedID(tenant, taskID)
 	m.execMu.Lock()
 	defer m.execMu.Unlock()
-	if m.executions[taskID] == exec && exec.yieldDone != nil {
+	if m.executions[key] == exec && exec.yieldDone != nil {
 		close(exec.yieldDone)
 		exec.yieldDone = nil
 	}
 }
 
 // liveExecution returns the cancellation handle of the task's live run, if any.
-func (m *TaskManager) liveExecution(taskID string) *execution {
+func (m *TaskManager) liveExecution(tenant, taskID string) *execution {
 	m.execMu.Lock()
 	defer m.execMu.Unlock()
-	return m.executions[taskID]
+	return m.executions[newScopedID(tenant, taskID)]
 }
 
 // run consumes the MessageProcessor channel until it closes. After a terminal state or
@@ -599,7 +620,7 @@ func (eng *engine) handleMessage(message *protocol.Message) {
 	}
 	m := eng.manager
 	contextID := eng.ec.ContextID
-	m.processReplyMessage(&contextID, message)
+	m.processReplyMessage(eng.ec.Tenant, &contextID, message)
 	eng.finalOutcome = sendOutcome{message: message}
 	eng.offerImmediateResult(sendOutcome{message: message})
 
@@ -607,16 +628,19 @@ func (eng *engine) handleMessage(message *protocol.Message) {
 	eng.sendToPipe(response)
 
 	m.taskMu.RLock()
-	_, exists := m.tasks[eng.ec.TaskID]
+	_, exists := m.tasks[newScopedID(eng.ec.Tenant, eng.ec.TaskID)]
 	m.taskMu.RUnlock()
 	if exists {
-		m.notifySubscribers(eng.ec.TaskID, response)
+		m.notifySubscribers(eng.ec.Tenant, eng.ec.TaskID, response)
 	}
 }
 
 // storeStatusMessage stores a stamped copy without mutating the processor's
 // message, which may still be visible in an earlier task snapshot or wire event.
-func (m *TaskManager) storeStatusMessage(taskID, contextID string, message *protocol.Message) {
+func (m *TaskManager) storeStatusMessage(
+	tenant, taskID, contextID string,
+	message *protocol.Message,
+) {
 	if message == nil {
 		return
 	}
@@ -627,7 +651,7 @@ func (m *TaskManager) storeStatusMessage(taskID, contextID string, message *prot
 	if stored.MessageID == "" {
 		stored.MessageID = protocol.GenerateMessageID()
 	}
-	m.storeMessage(stored)
+	m.storeMessage(tenant, stored)
 }
 
 // rollStatusMessage moves a superseded status message into conversation
@@ -642,7 +666,7 @@ func (eng *engine) rollStatusMessage(message *protocol.Message) {
 		return
 	}
 	eng.lastRolledStatusMessage = message
-	eng.manager.storeStatusMessage(eng.ec.TaskID, eng.ec.ContextID, message)
+	eng.manager.storeStatusMessage(eng.ec.Tenant, eng.ec.TaskID, eng.ec.ContextID, message)
 }
 
 // handleStatus persists a status update and then broadcasts it. The first task
@@ -669,17 +693,18 @@ func (eng *engine) handleStatus(event *protocol.TaskStatusUpdateEvent) {
 		// still be rejected as a concurrent execution. If cancellation claimed
 		// the slot first, keep this round active so its close rule can persist
 		// CANCELED rather than swallowing the accepted cancellation.
-		yielding = m.beginExecutionYield(eng.ec.TaskID, eng.exec)
+		yielding = m.beginExecutionYield(eng.ec.Tenant, eng.ec.TaskID, eng.exec)
 	}
 
 	// Persist first (§3.6), under the task lock.
 	m.taskMu.Lock()
-	task, exists := m.tasks[eng.ec.TaskID]
+	taskKey := newScopedID(eng.ec.Tenant, eng.ec.TaskID)
+	task, exists := m.tasks[taskKey]
 	if exists && isFinalState(task.Status.State) {
 		// Terminal states are immutable: never write over one, whoever set it.
 		m.taskMu.Unlock()
 		if yielding {
-			m.abortExecutionYield(eng.ec.TaskID, eng.exec)
+			m.abortExecutionYield(eng.ec.Tenant, eng.ec.TaskID, eng.exec)
 		}
 		log.Warnf("memory TaskManager: discarding status %s for task %s already in terminal state %s",
 			event.Status.State, eng.ec.TaskID, task.Status.State)
@@ -689,7 +714,7 @@ func (eng *engine) handleStatus(event *protocol.TaskStatusUpdateEvent) {
 	var previousStatusMessage *protocol.Message
 	if !exists {
 		task = eng.newTask(event.Status)
-		m.tasks[eng.ec.TaskID] = task
+		m.tasks[taskKey] = task
 	} else {
 		previousStatusMessage = task.Status.Message
 		task.Status = event.Status
@@ -706,7 +731,7 @@ func (eng *engine) handleStatus(event *protocol.TaskStatusUpdateEvent) {
 	m.taskMu.Unlock()
 	if err := eng.persistInlinePushConfig(); err != nil {
 		if yielding {
-			m.abortExecutionYield(eng.ec.TaskID, eng.exec)
+			m.abortExecutionYield(eng.ec.Tenant, eng.ec.TaskID, eng.exec)
 		}
 		eng.violate(err.Error())
 		return
@@ -725,10 +750,10 @@ func (eng *engine) handleStatus(event *protocol.TaskStatusUpdateEvent) {
 		// cannot yet continue. The handoff starts before enqueue so a client that
 		// polls the persisted task also waits instead of being rejected. It also
 		// serializes task-subscriber fan-out with a continuation round.
-		m.dispatchPush(eng.ec.TaskID, response)
+		m.dispatchPush(eng.ec.Tenant, eng.ec.TaskID, response)
 		eng.broadcastWithoutPush(response, snapshot)
 		eng.closePipe()
-		m.deregisterExecution(eng.ec.TaskID, eng.exec)
+		m.deregisterExecution(eng.ec.Tenant, eng.ec.TaskID, eng.exec)
 		return
 	}
 
@@ -738,7 +763,7 @@ func (eng *engine) handleStatus(event *protocol.TaskStatusUpdateEvent) {
 
 	if final {
 		eng.stopReason = engineStopTerminal
-		m.cleanSubscribers(eng.ec.TaskID)
+		m.cleanSubscribers(eng.ec.Tenant, eng.ec.TaskID)
 		// Nothing can follow a terminal frame: end the response stream here
 		// instead of trusting the MessageProcessor to close its channel promptly.
 		eng.closePipe()
@@ -752,7 +777,8 @@ func (eng *engine) handleArtifact(event *protocol.TaskArtifactUpdateEvent) {
 	m := eng.manager
 
 	m.taskMu.Lock()
-	task, exists := m.tasks[eng.ec.TaskID]
+	taskKey := newScopedID(eng.ec.Tenant, eng.ec.TaskID)
+	task, exists := m.tasks[taskKey]
 	if exists && isFinalState(task.Status.State) {
 		// Terminal states are immutable: no artifact may land after one.
 		m.taskMu.Unlock()
@@ -766,7 +792,7 @@ func (eng *engine) handleArtifact(event *protocol.TaskArtifactUpdateEvent) {
 			State:     protocol.TaskStateSubmitted,
 			Timestamp: nowTimestamp(),
 		})
-		m.tasks[eng.ec.TaskID] = task
+		m.tasks[taskKey] = task
 	}
 	var appendedAsNew bool
 	task.Artifacts, appendedAsNew = protocol.AppendArtifact(task.Artifacts, event.Artifact, event.Append != nil && *event.Append)
@@ -826,7 +852,7 @@ func (eng *engine) broadcast(response protocol.StreamResponse, snapshot *protoco
 		eng.offerImmediateResult(sendOutcome{task: snapshot})
 	}
 	eng.sendToPipe(response)
-	eng.manager.notifySubscribers(eng.ec.TaskID, response)
+	eng.manager.notifySubscribers(eng.ec.Tenant, eng.ec.TaskID, response)
 }
 
 // broadcastWithoutPush publishes an event whose automatic push delivery was
@@ -836,7 +862,7 @@ func (eng *engine) broadcastWithoutPush(response protocol.StreamResponse, snapsh
 		eng.offerImmediateResult(sendOutcome{task: snapshot})
 	}
 	eng.sendToPipe(response)
-	eng.manager.notifyLiveSubscribers(eng.ec.TaskID, response)
+	eng.manager.notifyLiveSubscribers(eng.ec.Tenant, eng.ec.TaskID, response)
 }
 
 // offerImmediateResult publishes the immediate result exactly once.
@@ -876,7 +902,7 @@ func (eng *engine) violate(reason string) {
 	m := eng.manager
 	event := eng.statusEvent(protocol.TaskStateFailed, eng.failureStatusMessage(reason))
 	m.taskMu.Lock()
-	task, exists := m.tasks[eng.ec.TaskID]
+	task, exists := m.tasks[newScopedID(eng.ec.Tenant, eng.ec.TaskID)]
 	if !exists || isFinalState(task.Status.State) {
 		m.taskMu.Unlock()
 		return
@@ -890,7 +916,7 @@ func (eng *engine) violate(reason string) {
 	m.taskMu.Unlock()
 
 	eng.broadcast(protocol.NewStreamResponseStatusUpdate(event), snapshot)
-	m.cleanSubscribers(eng.ec.TaskID)
+	m.cleanSubscribers(eng.ec.Tenant, eng.ec.TaskID)
 	eng.closePipe()
 }
 
@@ -913,7 +939,7 @@ func (eng *engine) finish() {
 	var closing *protocol.TaskStatusUpdateEvent
 
 	m.taskMu.Lock()
-	task, exists := m.tasks[eng.ec.TaskID]
+	task, exists := m.tasks[newScopedID(eng.ec.Tenant, eng.ec.TaskID)]
 	if exists && !isFinalState(task.Status.State) {
 		switch {
 		case eng.exec.cancelRequested.Load():
@@ -952,15 +978,15 @@ func (eng *engine) finish() {
 	if closing != nil {
 		response := protocol.NewStreamResponseStatusUpdate(closing)
 		eng.sendToPipe(response)
-		m.notifySubscribers(eng.ec.TaskID, response)
-		m.cleanSubscribers(eng.ec.TaskID)
+		m.notifySubscribers(eng.ec.Tenant, eng.ec.TaskID, response)
+		m.cleanSubscribers(eng.ec.Tenant, eng.ec.TaskID)
 	}
 
 	if eng.pipe != nil {
 		eng.pipe.Close()
 	}
 	eng.exec.cancel() // release the detached ctx resources
-	m.deregisterExecution(eng.ec.TaskID, eng.exec)
+	m.deregisterExecution(eng.ec.Tenant, eng.ec.TaskID, eng.exec)
 	close(eng.done)
 }
 
@@ -993,12 +1019,13 @@ func (eng *engine) failureStatusMessage(text string) *protocol.Message {
 // task exists (history trimmed per the request's historyLength), otherwise the
 // last message; an execution that produced neither is a MessageProcessor bug.
 func (m *TaskManager) buildSendResponse(
+	tenant string,
 	task *protocol.Task,
 	message *protocol.Message,
 	historyLength *int,
 ) (*protocol.SendMessageResponse, error) {
 	if task != nil {
-		m.fillTaskHistory(task, historyLength)
+		m.fillTaskHistory(tenant, task, historyLength)
 		return protocol.NewSendMessageResponseTask(task), nil
 	}
 	if message != nil {

--- a/taskmanager/memory/memory_engine_test.go
+++ b/taskmanager/memory/memory_engine_test.go
@@ -129,7 +129,7 @@ func statusMessageText(task *protocol.Task) string {
 func storedTaskState(m *TaskManager, taskID string) (protocol.TaskState, bool) {
 	m.taskMu.RLock()
 	defer m.taskMu.RUnlock()
-	task, ok := m.tasks[taskID]
+	task, ok := m.tasks[newScopedID("", taskID)]
 	if !ok {
 		return "", false
 	}
@@ -189,7 +189,7 @@ func seedTask(m *TaskManager, task protocol.Task) {
 		task.Status.Timestamp = nowTimestamp()
 	}
 	m.taskMu.Lock()
-	m.tasks[task.ID] = &task
+	m.tasks[newScopedID("", task.ID)] = &task
 	m.taskMu.Unlock()
 }
 
@@ -226,7 +226,7 @@ func TestOnSendMessage_PureMessageLeavesNoTask(t *testing.T) {
 
 	// The reply must be stored in the conversation.
 	manager.conversationMu.RLock()
-	_, stored := manager.messages[message.MessageID]
+	_, stored := manager.messages[newScopedID("", message.MessageID)]
 	manager.conversationMu.RUnlock()
 	if !stored {
 		t.Error("Reply message not found in storage")
@@ -707,7 +707,7 @@ func TestOnSendMessageStream_OrderAndPersistBeforeBroadcast(t *testing.T) {
 		t.Fatalf("Expected the artifact event second, got %+v", second)
 	}
 	manager.taskMu.RLock()
-	artifactCount := len(manager.tasks[working.TaskID].Artifacts)
+	artifactCount := len(manager.tasks[newScopedID("", working.TaskID)].Artifacts)
 	manager.taskMu.RUnlock()
 	if artifactCount != 1 {
 		t.Errorf("Expected 1 persisted artifact when the event is received, got %d", artifactCount)
@@ -1488,7 +1488,7 @@ func TestOnSendMessage_ContinuationContextMismatchRejected(t *testing.T) {
 		t.Fatalf("processor must not run for the rejected round, invocations=%d", got)
 	}
 	manager.conversationMu.RLock()
-	_, stored := manager.messages["mismatch-msg"]
+	_, stored := manager.messages[newScopedID("", "mismatch-msg")]
 	manager.conversationMu.RUnlock()
 	if stored {
 		t.Fatal("rejected continuation must not store the request message")
@@ -1631,7 +1631,7 @@ func TestConversationHistoryConcurrentAccess(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for j := 0; j < 200; j++ {
-				manager.getConversationHistory(contextID, 100)
+				manager.getConversationHistory("", contextID, 100)
 			}
 		}()
 	}

--- a/taskmanager/memory/memory_regression_test.go
+++ b/taskmanager/memory/memory_regression_test.go
@@ -181,23 +181,23 @@ func TestClaimCancelSlot_BlocksConcurrentRegistration(t *testing.T) {
 	manager := newTestManager(t, echoExecutor())
 	const taskID = "task-claim-slot"
 
-	live, sentinel, yieldDone := manager.claimCancelSlot(taskID)
+	live, sentinel, yieldDone := manager.claimCancelSlot("", taskID)
 	if live != nil || sentinel == nil {
 		t.Fatalf("expected to claim the free slot, got live=%v sentinel=%v", live, sentinel)
 	}
 	if yieldDone != nil {
 		t.Fatal("free slot unexpectedly reported a yield handoff")
 	}
-	if err := manager.registerExecution(context.Background(), taskID, &execution{cancel: func() {}}); err == nil {
+	if err := manager.registerExecution(context.Background(), "", taskID, &execution{cancel: func() {}}); err == nil {
 		t.Fatal("registration must be rejected while a cancel sentinel holds the slot")
 	}
-	manager.deregisterExecution(taskID, sentinel)
+	manager.deregisterExecution("", taskID, sentinel)
 
 	exec := &execution{cancel: func() {}}
-	if err := manager.registerExecution(context.Background(), taskID, exec); err != nil {
+	if err := manager.registerExecution(context.Background(), "", taskID, exec); err != nil {
 		t.Fatalf("registration after sentinel release failed: %v", err)
 	}
-	manager.releaseExecution(taskID, exec)
+	manager.releaseExecution("", taskID, exec)
 }
 
 // Cancellation and suspend handoff use execMu as their linearization point.
@@ -209,21 +209,21 @@ func TestCancelYieldLinearization(t *testing.T) {
 		const taskID = "task-cancel-wins-yield"
 		var cancelCalls atomic.Int32
 		exec := &execution{cancel: func() { cancelCalls.Add(1) }}
-		if err := manager.registerExecution(context.Background(), taskID, exec); err != nil {
+		if err := manager.registerExecution(context.Background(), "", taskID, exec); err != nil {
 			t.Fatalf("register execution: %v", err)
 		}
 		var releaseOnce sync.Once
-		release := func() { releaseOnce.Do(func() { manager.releaseExecution(taskID, exec) }) }
+		release := func() { releaseOnce.Do(func() { manager.releaseExecution("", taskID, exec) }) }
 		defer release()
 
-		yieldDone, accepted := manager.requestExecutionCancel(taskID, exec)
+		yieldDone, accepted := manager.requestExecutionCancel("", taskID, exec)
 		if !accepted || yieldDone != nil {
 			t.Fatalf("cancel result: accepted=%v yieldDone=%v, want accepted with no handoff", accepted, yieldDone)
 		}
 		if got := cancelCalls.Load(); got != 1 {
 			t.Fatalf("execution cancel calls = %d, want 1", got)
 		}
-		if manager.beginExecutionYield(taskID, exec) {
+		if manager.beginExecutionYield("", taskID, exec) {
 			t.Fatal("suspend handoff started after cancellation had already won")
 		}
 
@@ -235,18 +235,18 @@ func TestCancelYieldLinearization(t *testing.T) {
 		const taskID = "task-yield-wins-cancel"
 		var cancelCalls atomic.Int32
 		exec := &execution{cancel: func() { cancelCalls.Add(1) }}
-		if err := manager.registerExecution(context.Background(), taskID, exec); err != nil {
+		if err := manager.registerExecution(context.Background(), "", taskID, exec); err != nil {
 			t.Fatalf("register execution: %v", err)
 		}
 		var releaseOnce sync.Once
-		release := func() { releaseOnce.Do(func() { manager.releaseExecution(taskID, exec) }) }
+		release := func() { releaseOnce.Do(func() { manager.releaseExecution("", taskID, exec) }) }
 		defer release()
-		if !manager.beginExecutionYield(taskID, exec) {
+		if !manager.beginExecutionYield("", taskID, exec) {
 			t.Fatal("suspend handoff did not start")
 		}
 		handoff := exec.yieldDone
 
-		yieldDone, accepted := manager.requestExecutionCancel(taskID, exec)
+		yieldDone, accepted := manager.requestExecutionCancel("", taskID, exec)
 		if accepted || yieldDone != handoff {
 			t.Fatalf("cancel result: accepted=%v yieldDone=%v, want existing handoff %v",
 				accepted, yieldDone, handoff)
@@ -479,7 +479,7 @@ func TestResubscribe_ClientDisconnectDropsSubscriber(t *testing.T) {
 	eventually(t, func() bool {
 		manager.taskMu.RLock()
 		defer manager.taskMu.RUnlock()
-		return len(manager.subscribers[taskID]) == 0
+		return len(manager.subscribers[newScopedID("", taskID)]) == 0
 	}, "disconnected subscriber was not removed")
 }
 

--- a/taskmanager/memory/memory_test.go
+++ b/taskmanager/memory/memory_test.go
@@ -124,7 +124,7 @@ func TestTaskManager_OnSendMessage(t *testing.T) {
 
 			// Check that the reply message is in storage
 			manager.conversationMu.RLock()
-			_, exists := manager.messages[message.MessageID]
+			_, exists := manager.messages[newScopedID("", message.MessageID)]
 			manager.conversationMu.RUnlock()
 			if !exists {
 				t.Error("Message not found in storage")
@@ -414,10 +414,10 @@ func TestTaskManager_cleanupFailedSubscribersClosesRemovedSubscribers(t *testing
 	activeSub := newTaskSubscriber(taskID, 10, false)
 
 	manager.taskMu.Lock()
-	manager.subscribers[taskID] = []*taskSubscriber{failedSub, activeSub}
+	manager.subscribers[newScopedID("", taskID)] = []*taskSubscriber{failedSub, activeSub}
 	manager.taskMu.Unlock()
 
-	manager.cleanupFailedSubscribers(taskID, []*taskSubscriber{failedSub})
+	manager.cleanupFailedSubscribers("", taskID, []*taskSubscriber{failedSub})
 
 	if !failedSub.Closed() {
 		t.Error("Expected failed subscriber to be closed")
@@ -427,7 +427,7 @@ func TestTaskManager_cleanupFailedSubscribersClosesRemovedSubscribers(t *testing
 	}
 
 	manager.taskMu.RLock()
-	subs := manager.subscribers[taskID]
+	subs := manager.subscribers[newScopedID("", taskID)]
 	manager.taskMu.RUnlock()
 
 	if len(subs) != 1 || subs[0] != activeSub {
@@ -447,7 +447,7 @@ func TestTaskManager_cleanExpiredTasks(t *testing.T) {
 		},
 	})
 	manager.taskMu.Lock()
-	manager.subscribers["expired-task"] = []*taskSubscriber{
+	manager.subscribers[newScopedID("", "expired-task")] = []*taskSubscriber{
 		newTaskSubscriber("expired-task", 10, false),
 	}
 	manager.taskMu.Unlock()
@@ -476,7 +476,7 @@ func TestTaskManager_cleanExpiredTasks(t *testing.T) {
 		t.Errorf("Expected 0 cleaned tasks with TTL=0, got %d", skipped)
 	}
 	manager.taskMu.RLock()
-	if _, exists := manager.tasks["expired-task"]; !exists {
+	if _, exists := manager.tasks[newScopedID("", "expired-task")]; !exists {
 		t.Error("Expired task should still exist when TTL=0")
 	}
 	manager.taskMu.RUnlock()
@@ -491,16 +491,16 @@ func TestTaskManager_cleanExpiredTasks(t *testing.T) {
 	manager.taskMu.RLock()
 	defer manager.taskMu.RUnlock()
 
-	if _, exists := manager.tasks["expired-task"]; exists {
+	if _, exists := manager.tasks[newScopedID("", "expired-task")]; exists {
 		t.Error("Expected expired task to be removed")
 	}
-	if _, exists := manager.subscribers["expired-task"]; exists {
+	if _, exists := manager.subscribers[newScopedID("", "expired-task")]; exists {
 		t.Error("Expected expired task subscribers to be removed")
 	}
-	if _, exists := manager.tasks["active-task"]; !exists {
+	if _, exists := manager.tasks[newScopedID("", "active-task")]; !exists {
 		t.Error("Active task should not be removed")
 	}
-	if _, exists := manager.tasks["recent-task"]; !exists {
+	if _, exists := manager.tasks[newScopedID("", "recent-task")]; !exists {
 		t.Error("Recently completed task should not be removed")
 	}
 }
@@ -524,7 +524,7 @@ func TestTaskManager_TaskTTLCleanupGoroutine(t *testing.T) {
 	})
 
 	manager.taskMu.Lock()
-	manager.subscribers[taskID] = []*taskSubscriber{sub}
+	manager.subscribers[newScopedID("", taskID)] = []*taskSubscriber{sub}
 	manager.taskMu.Unlock()
 
 	if _, err := manager.pushStore.save(protocol.TaskPushNotificationConfig{TaskID: taskID}); err != nil {
@@ -537,11 +537,11 @@ func TestTaskManager_TaskTTLCleanupGoroutine(t *testing.T) {
 
 	for {
 		manager.taskMu.RLock()
-		_, taskExists := manager.tasks[taskID]
-		_, subsExists := manager.subscribers[taskID]
+		_, taskExists := manager.tasks[newScopedID("", taskID)]
+		_, subsExists := manager.subscribers[newScopedID("", taskID)]
 		manager.taskMu.RUnlock()
 
-		pushConfigs := manager.pushStore.list(taskID)
+		pushConfigs := manager.pushStore.list("", taskID)
 		pushExists := len(pushConfigs) > 0
 
 		if !taskExists && !subsExists && !pushExists && sub.Closed() {
@@ -579,7 +579,7 @@ func TestTaskManager_Close(t *testing.T) {
 	sub := newTaskSubscriber("close-test-task", 10, false)
 
 	manager.taskMu.Lock()
-	manager.subscribers["close-test-task"] = []*taskSubscriber{sub}
+	manager.subscribers[newScopedID("", "close-test-task")] = []*taskSubscriber{sub}
 	manager.taskMu.Unlock()
 
 	manager.Close()

--- a/taskmanager/memory/push_dispatch_test.go
+++ b/taskmanager/memory/push_dispatch_test.go
@@ -301,12 +301,12 @@ func TestInlinePushConfigRegistration(t *testing.T) {
 				len(suspended.History), len(after.History))
 		}
 		manager.conversationMu.RLock()
-		_, stored := manager.messages[followUp.Message.MessageID]
+		_, stored := manager.messages[newScopedID("", followUp.Message.MessageID)]
 		manager.conversationMu.RUnlock()
 		if stored {
 			t.Fatalf("rejected continuation stored incoming message %s", followUp.Message.MessageID)
 		}
-		if live := manager.liveExecution(suspended.ID); live != nil {
+		if live := manager.liveExecution("", suspended.ID); live != nil {
 			t.Fatal("rejected continuation did not release its execution slot")
 		}
 	})
@@ -460,7 +460,7 @@ func TestQueuedPushUsesRegistrationGeneration(t *testing.T) { //nolint:gocyclo /
 	}); err != nil {
 		t.Fatalf("set old config: %v", err)
 	}
-	oldRegistrations := manager.pushStore.registrations(taskID)
+	oldRegistrations := manager.pushStore.registrations("", taskID)
 	if len(oldRegistrations) != 1 {
 		t.Fatalf("old registrations = %d, want 1", len(oldRegistrations))
 	}
@@ -497,7 +497,7 @@ func TestQueuedPushUsesRegistrationGeneration(t *testing.T) { //nolint:gocyclo /
 	}); err != nil {
 		t.Fatalf("re-create config: %v", err)
 	}
-	newRegistrations := manager.pushStore.registrations(taskID)
+	newRegistrations := manager.pushStore.registrations("", taskID)
 	if len(newRegistrations) != 1 {
 		t.Fatalf("new registrations = %d, want 1", len(newRegistrations))
 	}
@@ -601,7 +601,7 @@ func TestSuspendWaitsForPushCapacityBeforeHandoff(t *testing.T) { //nolint:gocyc
 	}); err != nil {
 		t.Fatalf("set prefill config: %v", err)
 	}
-	prefillRegistrations := manager.pushStore.registrations(prefillTaskID)
+	prefillRegistrations := manager.pushStore.registrations("", prefillTaskID)
 	prefillEvent := protocol.NewStreamResponseStatusUpdate(&protocol.TaskStatusUpdateEvent{
 		TaskID: prefillTaskID,
 		Status: protocol.TaskStatus{State: protocol.TaskStateWorking},
@@ -642,7 +642,7 @@ func TestSuspendWaitsForPushCapacityBeforeHandoff(t *testing.T) { //nolint:gocyc
 		return ok && state == protocol.TaskStateInputRequired
 	}, "task must persist input-required before publication")
 	manager.execMu.Lock()
-	exec := manager.executions[taskID]
+	exec := manager.executions[newScopedID("", taskID)]
 	yielding := exec != nil && exec.yieldDone != nil
 	manager.execMu.Unlock()
 	if !yielding {

--- a/taskmanager/memory/push_store.go
+++ b/taskmanager/memory/push_store.go
@@ -28,14 +28,14 @@ type pushConfigStore struct {
 	mu sync.RWMutex
 	// closed prevents configs from being re-created after manager shutdown.
 	closed bool
-	// configs maps taskID -> configID -> internal registration. Generation is
+	// configs maps tenant+taskID -> configID -> internal registration. Generation is
 	// intentionally kept out of the public protocol type.
-	configs map[string]map[string]push.Registration
+	configs map[scopedID]map[string]push.Registration
 }
 
 func newPushConfigStore() *pushConfigStore {
 	return &pushConfigStore{
-		configs: make(map[string]map[string]push.Registration),
+		configs: make(map[scopedID]map[string]push.Registration),
 	}
 }
 
@@ -55,10 +55,11 @@ func (s *pushConfigStore) save(
 		cfg.ID = "push-" + uuid.New().String()
 	}
 	cfg = clonePushConfig(cfg)
-	if s.configs[cfg.TaskID] == nil {
-		s.configs[cfg.TaskID] = make(map[string]push.Registration)
+	taskKey := newScopedID(cfg.Tenant, cfg.TaskID)
+	if s.configs[taskKey] == nil {
+		s.configs[taskKey] = make(map[string]push.Registration)
 	}
-	s.configs[cfg.TaskID][cfg.ID] = push.Registration{
+	s.configs[taskKey][cfg.ID] = push.Registration{
 		Config:     cfg,
 		Generation: uuid.New().String(),
 	}
@@ -66,10 +67,10 @@ func (s *pushConfigStore) save(
 }
 
 // list returns all configs for taskID, ordered by ID for stable pagination.
-func (s *pushConfigStore) list(taskID string) []protocol.TaskPushNotificationConfig {
+func (s *pushConfigStore) list(tenant, taskID string) []protocol.TaskPushNotificationConfig {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	byID := s.configs[taskID]
+	byID := s.configs[newScopedID(tenant, taskID)]
 	out := make([]protocol.TaskPushNotificationConfig, 0, len(byID))
 	for _, registration := range byID {
 		out = append(out, clonePushConfig(registration.Config))
@@ -81,10 +82,12 @@ func (s *pushConfigStore) list(taskID string) []protocol.TaskPushNotificationCon
 }
 
 // get returns the config identified by taskID and configID.
-func (s *pushConfigStore) get(taskID, configID string) (protocol.TaskPushNotificationConfig, bool) {
+func (s *pushConfigStore) get(
+	tenant, taskID, configID string,
+) (protocol.TaskPushNotificationConfig, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	byID := s.configs[taskID]
+	byID := s.configs[newScopedID(tenant, taskID)]
 	registration, ok := byID[configID]
 	return clonePushConfig(registration.Config), ok
 }
@@ -92,10 +95,10 @@ func (s *pushConfigStore) get(taskID, configID string) (protocol.TaskPushNotific
 // registrations returns internal delivery snapshots, ordered by config ID.
 // Generation remains internal and lets the dispatcher discard queued work for
 // a config that was deleted or replaced after enqueue.
-func (s *pushConfigStore) registrations(taskID string) []push.Registration {
+func (s *pushConfigStore) registrations(tenant, taskID string) []push.Registration {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	byID := s.configs[taskID]
+	byID := s.configs[newScopedID(tenant, taskID)]
 	out := make([]push.Registration, 0, len(byID))
 	for _, registration := range byID {
 		registration.Config = clonePushConfig(registration.Config)
@@ -116,7 +119,7 @@ func (s *pushConfigStore) isCurrent(
 ) (bool, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	byID := s.configs[registration.Config.TaskID]
+	byID := s.configs[newScopedID(registration.Config.Tenant, registration.Config.TaskID)]
 	current, ok := byID[registration.Config.ID]
 	return ok && current.Generation == registration.Generation, nil
 }
@@ -132,27 +135,28 @@ func clonePushConfig(cfg protocol.TaskPushNotificationConfig) protocol.TaskPushN
 }
 
 // remove deletes a single config by ID; a missing config is a no-op.
-func (s *pushConfigStore) remove(taskID, configID string) {
+func (s *pushConfigStore) remove(tenant, taskID, configID string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if byID := s.configs[taskID]; byID != nil {
+	taskKey := newScopedID(tenant, taskID)
+	if byID := s.configs[taskKey]; byID != nil {
 		delete(byID, configID)
 		if len(byID) == 0 {
-			delete(s.configs, taskID)
+			delete(s.configs, taskKey)
 		}
 	}
 }
 
 // removeAll deletes every config for taskID.
-func (s *pushConfigStore) removeAll(taskID string) {
+func (s *pushConfigStore) removeAll(tenant, taskID string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	delete(s.configs, taskID)
+	delete(s.configs, newScopedID(tenant, taskID))
 }
 
 func (s *pushConfigStore) close() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.closed = true
-	s.configs = make(map[string]map[string]push.Registration)
+	s.configs = make(map[scopedID]map[string]push.Registration)
 }

--- a/taskmanager/memory/push_store_test.go
+++ b/taskmanager/memory/push_store_test.go
@@ -49,12 +49,12 @@ func TestPushConfigStore_ClonesAuthentication(t *testing.T) {
 	})
 	auth.Credentials = "mutated"
 
-	first, ok := s.get("t1", "c1")
+	first, ok := s.get("", "t1", "c1")
 	if !ok || first.Authentication.Credentials != "secret" {
 		t.Fatalf("caller mutation changed stored config: %+v", first)
 	}
 	first.Authentication.Credentials = "returned-mutation"
-	second, _ := s.get("t1", "c1")
+	second, _ := s.get("", "t1", "c1")
 	if second.Authentication.Credentials != "secret" {
 		t.Fatalf("returned value mutation changed stored config: %+v", second)
 	}
@@ -68,12 +68,12 @@ func TestPushConfigStore_MultipleConfigsPerTask(t *testing.T) {
 		t.Fatal("expected distinct config IDs")
 	}
 
-	if list := s.list("t1"); len(list) != 2 {
+	if list := s.list("", "t1"); len(list) != 2 {
 		t.Fatalf("expected 2 configs, got %d", len(list))
 	}
 
-	s.remove("t1", c1.ID)
-	list := s.list("t1")
+	s.remove("", "t1", c1.ID)
+	list := s.list("", "t1")
 	if len(list) != 1 || list[0].ID != c2.ID {
 		t.Fatalf("expected only c2 to remain, got %+v", list)
 	}
@@ -81,7 +81,7 @@ func TestPushConfigStore_MultipleConfigsPerTask(t *testing.T) {
 
 func TestPushConfigStore_ListEmptyIsNotNil(t *testing.T) {
 	s := newPushConfigStore()
-	list := s.list("nope")
+	list := s.list("", "nope")
 	if list == nil {
 		t.Error("expected a non-nil empty slice")
 	}
@@ -94,8 +94,8 @@ func TestPushConfigStore_RemoveAll(t *testing.T) {
 	s := newPushConfigStore()
 	_, _ = s.save(protocol.TaskPushNotificationConfig{TaskID: "t1", URL: "https://a"})
 	_, _ = s.save(protocol.TaskPushNotificationConfig{TaskID: "t1", URL: "https://b"})
-	s.removeAll("t1")
-	if list := s.list("t1"); len(list) != 0 {
+	s.removeAll("", "t1")
+	if list := s.list("", "t1"); len(list) != 0 {
 		t.Errorf("expected no configs after removeAll, got %d", len(list))
 	}
 }
@@ -108,7 +108,7 @@ func TestPushConfigStore_CloseClearsAndRejectsWrites(t *testing.T) {
 		t.Fatal(err)
 	}
 	store.close()
-	if got := store.list("task-1"); len(got) != 0 {
+	if got := store.list("", "task-1"); len(got) != 0 {
 		t.Fatalf("closed store retained configs: %+v", got)
 	}
 	if _, err := store.save(protocol.TaskPushNotificationConfig{

--- a/taskmanager/memory/tenant_isolation_test.go
+++ b/taskmanager/memory/tenant_isolation_test.go
@@ -1,0 +1,170 @@
+// Tencent is pleased to support the open source community by making trpc-a2a-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-a2a-go is licensed under the Apache License Version 2.0.
+
+package memory
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/push"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
+)
+
+func TestTaskManagerTenantDataIsolation(t *testing.T) {
+	manager := newTestManager(t, echoExecutor())
+	ctx := context.Background()
+	const taskID = "shared-task"
+	const contextID = "shared-context"
+	const messageID = "shared-message"
+
+	manager.taskMu.Lock()
+	manager.tasks[newScopedID("tenant-a", taskID)] = &protocol.Task{
+		ID: taskID, ContextID: contextID, Status: protocol.TaskStatus{State: protocol.TaskStateWorking},
+	}
+	manager.tasks[newScopedID("tenant-b", taskID)] = &protocol.Task{
+		ID: taskID, ContextID: contextID, Status: protocol.TaskStatus{State: protocol.TaskStateInputRequired},
+	}
+	manager.taskMu.Unlock()
+
+	contextA := contextID
+	manager.storeMessage("tenant-a", protocol.Message{
+		MessageID: messageID, ContextID: &contextA, Role: protocol.MessageRoleUser,
+	})
+	contextB := contextID
+	manager.storeMessage("tenant-b", protocol.Message{
+		MessageID: messageID, ContextID: &contextB, Role: protocol.MessageRoleAgent,
+	})
+
+	taskA, err := manager.OnGetTask(ctx, protocol.TaskQueryParams{Tenant: "tenant-a", ID: taskID})
+	if err != nil {
+		t.Fatalf("get tenant-a task: %v", err)
+	}
+	if taskA.Status.State != protocol.TaskStateWorking || len(taskA.History) != 1 ||
+		taskA.History[0].Role != protocol.MessageRoleUser {
+		t.Fatalf("tenant-a received foreign data: %+v", taskA)
+	}
+
+	taskB, err := manager.OnGetTask(ctx, protocol.TaskQueryParams{Tenant: "tenant-b", ID: taskID})
+	if err != nil {
+		t.Fatalf("get tenant-b task: %v", err)
+	}
+	if taskB.Status.State != protocol.TaskStateInputRequired || len(taskB.History) != 1 ||
+		taskB.History[0].Role != protocol.MessageRoleAgent {
+		t.Fatalf("tenant-b received foreign data: %+v", taskB)
+	}
+
+	if _, err := manager.OnGetTask(ctx, protocol.TaskQueryParams{Tenant: "tenant-c", ID: taskID}); !errors.Is(err, taskmanager.ErrTaskNotFoundSentinel) {
+		t.Fatalf("tenant-c must not see another tenant's task, got %v", err)
+	}
+	listA, err := manager.OnListTasks(ctx, protocol.ListTasksParams{Tenant: "tenant-a"})
+	if err != nil || len(listA.Tasks) != 1 || listA.Tasks[0].Status.State != protocol.TaskStateWorking {
+		t.Fatalf("tenant-a list leaked another tenant: result=%+v err=%v", listA, err)
+	}
+
+	if _, err := manager.OnCancelTask(ctx, protocol.TaskIDParams{Tenant: "tenant-a", ID: taskID}); err != nil {
+		t.Fatalf("cancel tenant-a task: %v", err)
+	}
+	taskB, err = manager.OnGetTask(ctx, protocol.TaskQueryParams{Tenant: "tenant-b", ID: taskID})
+	if err != nil || taskB.Status.State != protocol.TaskStateInputRequired {
+		t.Fatalf("canceling tenant-a changed tenant-b: task=%+v err=%v", taskB, err)
+	}
+
+	if _, err := manager.pushStore.save(protocol.TaskPushNotificationConfig{
+		Tenant: "tenant-a", TaskID: taskID, ID: "shared-config", URL: "https://a.example/push",
+	}); err != nil {
+		t.Fatalf("save tenant-a push config: %v", err)
+	}
+	if _, err := manager.pushStore.save(protocol.TaskPushNotificationConfig{
+		Tenant: "tenant-b", TaskID: taskID, ID: "shared-config", URL: "https://b.example/push",
+	}); err != nil {
+		t.Fatalf("save tenant-b push config: %v", err)
+	}
+	if got := manager.pushStore.list("tenant-a", taskID); len(got) != 1 || got[0].URL != "https://a.example/push" {
+		t.Fatalf("tenant-a push config leaked: %+v", got)
+	}
+
+	subscriberA := newTaskSubscriber(taskID, 1, false)
+	manager.taskMu.Lock()
+	manager.subscribers[newScopedID("tenant-a", taskID)] = []*taskSubscriber{subscriberA}
+	manager.taskMu.Unlock()
+	manager.notifySubscribers("tenant-b", taskID, protocol.NewStreamResponseTask(taskB))
+	select {
+	case <-subscriberA.Channel():
+		t.Fatal("tenant-b event reached tenant-a subscriber")
+	default:
+	}
+
+	liveA := &execution{cancel: func() {}}
+	liveB := &execution{cancel: func() {}}
+	if err := manager.registerExecution(ctx, "tenant-a", taskID, liveA); err != nil {
+		t.Fatalf("register tenant-a execution: %v", err)
+	}
+	if err := manager.registerExecution(ctx, "tenant-b", taskID, liveB); err != nil {
+		t.Fatalf("register tenant-b execution with the same task ID: %v", err)
+	}
+	manager.releaseExecution("tenant-a", taskID, liveA)
+	manager.releaseExecution("tenant-b", taskID, liveB)
+}
+
+func TestTaskManagerProcessorCannotMutateTenantScope(t *testing.T) {
+	manager := newTestManager(t, funcExecutor(func(
+		_ context.Context,
+		ec *taskmanager.ExecContext,
+	) (<-chan protocol.StreamEvent, error) {
+		ec.Tenant = "mutated-tenant"
+		ec.TaskID = "mutated-task"
+		ec.ContextID = "mutated-context"
+		if ec.PushConfig != nil {
+			ec.PushConfig.Tenant = "mutated-tenant"
+			ec.PushConfig.TaskID = "mutated-task"
+			if ec.PushConfig.Authentication != nil {
+				ec.PushConfig.Authentication.Credentials = "mutated-credentials"
+			}
+		}
+		events := make(chan protocol.StreamEvent, 1)
+		events <- statusUpdate(protocol.TaskStateCompleted, nil)
+		close(events)
+		return events, nil
+	}), WithPushNotifications(push.Config{ManualDelivery: true}))
+
+	message := protocol.NewMessage(protocol.MessageRoleUser, []*protocol.Part{protocol.NewTextPart("hello")})
+	result, err := manager.OnSendMessage(context.Background(), protocol.SendMessageParams{
+		Tenant: "tenant-a",
+		Configuration: &protocol.SendMessageConfiguration{PushConfig: &protocol.TaskPushNotificationConfig{
+			URL:            "https://example.com/push",
+			Authentication: &protocol.AuthenticationInfo{Scheme: "Bearer", Credentials: "original-credentials"},
+		}},
+		Message: message,
+	})
+	if err != nil {
+		t.Fatalf("send message: %v", err)
+	}
+	task := result.GetTask()
+	if task == nil || task.ID == "mutated-task" || task.ContextID == "mutated-context" {
+		t.Fatalf("processor mutation changed framework scope: %+v", task)
+	}
+	if _, err := manager.OnGetTask(context.Background(), protocol.TaskQueryParams{
+		Tenant: "tenant-a", ID: task.ID,
+	}); err != nil {
+		t.Fatalf("task was not stored in the request tenant: %v", err)
+	}
+	if _, err := manager.OnGetTask(context.Background(), protocol.TaskQueryParams{
+		Tenant: "mutated-tenant", ID: task.ID,
+	}); !errors.Is(err, taskmanager.ErrTaskNotFoundSentinel) {
+		t.Fatalf("processor moved task into another tenant: %v", err)
+	}
+	configs := manager.pushStore.list("tenant-a", task.ID)
+	if len(configs) != 1 || configs[0].TaskID != task.ID || configs[0].Authentication == nil ||
+		configs[0].Authentication.Credentials != "original-credentials" {
+		t.Fatalf("processor mutation changed stored push scope: %+v", configs)
+	}
+	if configs := manager.pushStore.list("mutated-tenant", "mutated-task"); len(configs) != 0 {
+		t.Fatalf("processor moved push config into another tenant: %+v", configs)
+	}
+}

--- a/taskmanager/redis/redis_cross_node_test.go
+++ b/taskmanager/redis/redis_cross_node_test.go
@@ -67,6 +67,7 @@ type nonBlockingEmptyTransport struct {
 
 func (*nonBlockingEmptyTransport) CommitTaskEvent(
 	context.Context,
+	string,
 	*protocol.Task,
 	protocol.StreamResponse,
 ) error {
@@ -76,6 +77,7 @@ func (*nonBlockingEmptyTransport) CommitTaskEvent(
 func (*nonBlockingEmptyTransport) AppendEvent(
 	context.Context,
 	string,
+	string,
 	protocol.StreamResponse,
 ) error {
 	return nil
@@ -83,6 +85,7 @@ func (*nonBlockingEmptyTransport) AppendEvent(
 
 func (*nonBlockingEmptyTransport) LoadTaskAndCursor(
 	context.Context,
+	string,
 	string,
 ) (*protocol.Task, string, error) {
 	return &protocol.Task{
@@ -95,6 +98,7 @@ func (*nonBlockingEmptyTransport) LoadTaskAndCursor(
 
 func (t *nonBlockingEmptyTransport) ReadAfter(
 	context.Context,
+	string,
 	string,
 	string,
 ) ([]protocol.StreamResponse, string, error) {
@@ -210,7 +214,7 @@ func TestCrossNode_ResubscribeReceivesSubsequentEvents(t *testing.T) {
 	if !drainForState(t, chB, protocol.TaskStateCompleted) {
 		t.Fatal("cross-node resubscriber never received the completed event before the stream closed")
 	}
-	if got, err := nodeA.client.XLen(context.Background(), streamKey(taskA.ID)).Result(); err != nil || got != 2 {
+	if got, err := nodeA.client.XLen(context.Background(), streamKey("", taskA.ID)).Result(); err != nil || got != 2 {
 		t.Fatalf("each status must be appended exactly once: xlen=%d err=%v", got, err)
 	}
 }
@@ -220,7 +224,7 @@ func TestCrossNode_ResubscribeReceivesSubsequentEvents(t *testing.T) {
 func TestCrossNode_DeliversEventPublishedRightAfterResubscribe(t *testing.T) {
 	nodeA, nodeB := twoNodeManagers(t, scriptedExecutor())
 	task := storedTask(t, nodeA, "task-gap", "ctx-gap", protocol.TaskStateWorking)
-	if err := nodeA.appendTaskEvent(context.Background(), task.ID, protocol.NewStreamResponseStatusUpdate(
+	if err := nodeA.appendTaskEvent(context.Background(), "", task.ID, protocol.NewStreamResponseStatusUpdate(
 		statusEvent(protocol.TaskStateWorking, agentReply("w1")))); err != nil {
 		t.Fatalf("append working event: %v", err)
 	}
@@ -230,7 +234,7 @@ func TestCrossNode_DeliversEventPublishedRightAfterResubscribe(t *testing.T) {
 		t.Fatalf("OnResubscribe: %v", err)
 	}
 	// Publish the terminal event immediately after resubscribe.
-	if err := nodeA.appendTaskEvent(context.Background(), task.ID, protocol.NewStreamResponseStatusUpdate(
+	if err := nodeA.appendTaskEvent(context.Background(), "", task.ID, protocol.NewStreamResponseStatusUpdate(
 		statusEvent(protocol.TaskStateCompleted, agentReply("done")))); err != nil {
 		t.Fatalf("append completed event: %v", err)
 	}
@@ -343,12 +347,12 @@ func TestCrossNode_AtomicSnapshotCursorHasNoOverlapOrGap(t *testing.T) {
 	first.ContextID = task.ContextID
 	task.Artifacts, _ = protocol.AppendArtifact(task.Artifacts, first.Artifact, false)
 	if err := nodeA.commitTaskEvent(
-		context.Background(), task, protocol.NewStreamResponseArtifactUpdate(first),
+		context.Background(), "", task, protocol.NewStreamResponseArtifactUpdate(first),
 	); err != nil {
 		t.Fatalf("store first task event: %v", err)
 	}
 
-	snapshot, cursor, err := nodeB.eventTransport.LoadTaskAndCursor(context.Background(), task.ID)
+	snapshot, cursor, err := nodeB.eventTransport.LoadTaskAndCursor(context.Background(), "", task.ID)
 	if err != nil {
 		t.Fatalf("loadTaskAndCursor: %v", err)
 	}
@@ -356,7 +360,7 @@ func TestCrossNode_AtomicSnapshotCursorHasNoOverlapOrGap(t *testing.T) {
 		t.Fatalf("snapshot must contain the committed artifact exactly once, got %+v", snapshot)
 	}
 	if duplicate, err := nodeB.client.XRead(context.Background(), &redis.XReadArgs{
-		Streams: []string{streamKey(task.ID), cursor},
+		Streams: []string{streamKey("", task.ID), cursor},
 		Count:   1,
 		Block:   -1,
 	}).Result(); !errors.Is(err, redis.Nil) {
@@ -370,12 +374,12 @@ func TestCrossNode_AtomicSnapshotCursorHasNoOverlapOrGap(t *testing.T) {
 	second.Append = &appendChunk
 	task.Artifacts, _ = protocol.AppendArtifact(task.Artifacts, second.Artifact, true)
 	if err := nodeA.commitTaskEvent(
-		context.Background(), task, protocol.NewStreamResponseArtifactUpdate(second),
+		context.Background(), "", task, protocol.NewStreamResponseArtifactUpdate(second),
 	); err != nil {
 		t.Fatalf("store second task event: %v", err)
 	}
 	streams, err := nodeB.client.XRead(context.Background(), &redis.XReadArgs{
-		Streams: []string{streamKey(task.ID), cursor},
+		Streams: []string{streamKey("", task.ID), cursor},
 		Count:   2,
 		Block:   -1,
 	}).Result()
@@ -405,7 +409,7 @@ func TestCrossNode_InputRequiredDoesNotCloseResubscribe(t *testing.T) {
 	input.ContextID = task.ContextID
 	task.Status = input.Status
 	if err := nodeA.commitTaskEvent(
-		context.Background(), task, protocol.NewStreamResponseStatusUpdate(input),
+		context.Background(), "", task, protocol.NewStreamResponseStatusUpdate(input),
 	); err != nil {
 		t.Fatalf("store input-required: %v", err)
 	}
@@ -418,7 +422,7 @@ func TestCrossNode_InputRequiredDoesNotCloseResubscribe(t *testing.T) {
 	completed.ContextID = task.ContextID
 	task.Status = completed.Status
 	if err := nodeA.commitTaskEvent(
-		context.Background(), task, protocol.NewStreamResponseStatusUpdate(completed),
+		context.Background(), "", task, protocol.NewStreamResponseStatusUpdate(completed),
 	); err != nil {
 		t.Fatalf("store completed: %v", err)
 	}
@@ -435,7 +439,7 @@ func TestCrossNode_ContinuationStatusMessageClearIsJournaled(t *testing.T) {
 	nodeA, nodeB := twoNodeManagers(t, scriptedExecutor(agentReply("clarification")))
 	task := storedTask(t, nodeA, "task-clear-status", "ctx-clear-status", protocol.TaskStateInputRequired)
 	task.Status.Message = agentReply("need input")
-	if err := nodeA.storeTask(context.Background(), task); err != nil {
+	if err := nodeA.storeTask(context.Background(), "", task); err != nil {
 		t.Fatalf("store task status message: %v", err)
 	}
 
@@ -493,7 +497,7 @@ func TestCrossNode_SlowConsumerDoesNotLoseStream(t *testing.T) {
 		update := protocol.NewStreamResponseStatusUpdate(
 			statusEvent(protocol.TaskStateWorking, agentReply("still working")),
 		)
-		if err := nodeA.appendTaskEvent(context.Background(), task.ID, update); err != nil {
+		if err := nodeA.appendTaskEvent(context.Background(), "", task.ID, update); err != nil {
 			t.Fatalf("append stream event %d: %v", i, err)
 		}
 	}
@@ -572,7 +576,7 @@ func TestCrossNode_IdleTailerDoesNotStarveTaskStoragePool(t *testing.T) {
 func TestCrossNode_WrongTypeStreamFailsAtomically(t *testing.T) {
 	nodeA, nodeB := twoNodeManagers(t, scriptedExecutor())
 	task := storedTask(t, nodeA, "task-wrongtype", "ctx-wrongtype", protocol.TaskStateWorking)
-	if err := nodeA.client.Set(context.Background(), streamKey(task.ID), "not-a-stream", 0).Err(); err != nil {
+	if err := nodeA.client.Set(context.Background(), streamKey("", task.ID), "not-a-stream", 0).Err(); err != nil {
 		t.Fatalf("seed wrong-type stream key: %v", err)
 	}
 
@@ -601,14 +605,14 @@ func TestCrossNode_MessageAppendFailureIsNotExposedAsSuccess(t *testing.T) {
 		WithCrossNodeResubscribe(true),
 	)
 	task := storedTask(t, manager, "task-message-fail", "ctx-message-fail", protocol.TaskStateWorking)
-	if err := manager.client.Set(context.Background(), streamKey(task.ID), "not-a-stream", 0).Err(); err != nil {
+	if err := manager.client.Set(context.Background(), streamKey("", task.ID), "not-a-stream", 0).Err(); err != nil {
 		t.Fatalf("seed wrong-type stream key: %v", err)
 	}
 	subscriber := newTaskSubscriber(task.ID, 1, false)
 	manager.subMu.Lock()
-	manager.subscribers[task.ID] = []*taskSubscriber{subscriber}
+	manager.subscribers[newScopedID("", task.ID)] = []*taskSubscriber{subscriber}
 	manager.subMu.Unlock()
-	defer manager.cleanupFailedSubscribers(task.ID, []*taskSubscriber{subscriber})
+	defer manager.cleanupFailedSubscribers("", task.ID, []*taskSubscriber{subscriber})
 
 	params := sendParams("continue", task.ContextID)
 	params.Message.TaskID = &task.ID
@@ -622,7 +626,7 @@ func TestCrossNode_MessageAppendFailureIsNotExposedAsSuccess(t *testing.T) {
 	if buffered := len(subscriber.Channel()); buffered != 0 {
 		t.Fatalf("message append failure reached local subscriber: buffered=%d", buffered)
 	}
-	history, err := manager.getConversationHistory(context.Background(), task.ContextID, 100)
+	history, err := manager.getConversationHistory(context.Background(), "", task.ContextID, 100)
 	if err != nil {
 		t.Fatalf("getConversationHistory: %v", err)
 	}
@@ -659,7 +663,7 @@ func TestCrossNode_TaskCommitFailureIsNotExposedAsSuccess(t *testing.T) {
 			taskID := "task-" + test.name + "-fail"
 			contextID := "ctx-" + test.name + "-fail"
 			task := storedTask(t, manager, taskID, contextID, protocol.TaskStateWorking)
-			if err := manager.client.Set(context.Background(), streamKey(task.ID), "not-a-stream", 0).Err(); err != nil {
+			if err := manager.client.Set(context.Background(), streamKey("", task.ID), "not-a-stream", 0).Err(); err != nil {
 				t.Fatalf("seed wrong-type stream key: %v", err)
 			}
 
@@ -708,7 +712,7 @@ func TestCrossNode_PersistenceFailureReturnsBeforeProcessorCloses(t *testing.T) 
 	})
 	manager, _ := setupTest(t, processor, WithCrossNodeResubscribe(true))
 	task := storedTask(t, manager, "task-fast-failure", "ctx-fast-failure", protocol.TaskStateWorking)
-	if err := manager.client.Set(context.Background(), streamKey(task.ID), "not-a-stream", 0).Err(); err != nil {
+	if err := manager.client.Set(context.Background(), streamKey("", task.ID), "not-a-stream", 0).Err(); err != nil {
 		t.Fatalf("seed wrong-type stream key: %v", err)
 	}
 
@@ -755,7 +759,7 @@ func TestCrossNode_PersistenceFailureClosesStreamBeforeProcessorCloses(t *testin
 	})
 	manager, _ := setupTest(t, processor, WithCrossNodeResubscribe(true))
 	task := storedTask(t, manager, "task-stream-failure", "ctx-stream-failure", protocol.TaskStateWorking)
-	if err := manager.client.Set(context.Background(), streamKey(task.ID), "not-a-stream", 0).Err(); err != nil {
+	if err := manager.client.Set(context.Background(), streamKey("", task.ID), "not-a-stream", 0).Err(); err != nil {
 		t.Fatalf("seed wrong-type stream key: %v", err)
 	}
 
@@ -811,7 +815,7 @@ func TestCrossNode_FailedStatusCommitDoesNotAdvanceHistory(t *testing.T) {
 
 	deadline := time.Now().Add(time.Second)
 	for {
-		stored, err := manager.getTaskInternal(context.Background(), id)
+		stored, err := manager.getTaskInternal(context.Background(), "", id)
 		if err == nil && stored.Status.Message != nil &&
 			stored.Status.Message.Parts[0].TextContent() == "first" {
 			break
@@ -821,7 +825,7 @@ func TestCrossNode_FailedStatusCommitDoesNotAdvanceHistory(t *testing.T) {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	if err := manager.client.Set(context.Background(), streamKey(id), "not-a-stream", 0).Err(); err != nil {
+	if err := manager.client.Set(context.Background(), streamKey("", id), "not-a-stream", 0).Err(); err != nil {
 		t.Fatalf("replace stream with wrong type: %v", err)
 	}
 	releaseProcessor()
@@ -829,7 +833,7 @@ func TestCrossNode_FailedStatusCommitDoesNotAdvanceHistory(t *testing.T) {
 		t.Fatalf("unexpected failed status result: %v", err)
 	}
 
-	stored, err := manager.getTaskInternal(context.Background(), id)
+	stored, err := manager.getTaskInternal(context.Background(), "", id)
 	if err != nil {
 		t.Fatalf("get stored task: %v", err)
 	}
@@ -837,7 +841,7 @@ func TestCrossNode_FailedStatusCommitDoesNotAdvanceHistory(t *testing.T) {
 		stored.Status.Message.Parts[0].TextContent() != "first" {
 		t.Fatalf("failed commit changed stored status: %+v", stored.Status)
 	}
-	history, err := manager.getConversationHistory(context.Background(), stored.ContextID, 100)
+	history, err := manager.getConversationHistory(context.Background(), "", stored.ContextID, 100)
 	if err != nil {
 		t.Fatalf("get conversation history: %v", err)
 	}
@@ -866,11 +870,11 @@ func TestCrossNode_SubMillisecondExpirationIsClamped(t *testing.T) {
 	update.ContextID = task.ContextID
 	task.Status = update.Status
 	if err := manager.commitTaskEvent(
-		context.Background(), task, protocol.NewStreamResponseStatusUpdate(update),
+		context.Background(), "", task, protocol.NewStreamResponseStatusUpdate(update),
 	); err != nil {
 		t.Fatalf("commitTaskEvent with sub-millisecond configured TTL: %v", err)
 	}
-	if got, err := manager.client.XLen(context.Background(), streamKey(task.ID)).Result(); err != nil || got != 1 {
+	if got, err := manager.client.XLen(context.Background(), streamKey("", task.ID)).Result(); err != nil || got != 1 {
 		t.Fatalf("stream event missing after clamped TTL: xlen=%d err=%v", got, err)
 	}
 }
@@ -892,7 +896,7 @@ func TestCrossNode_TaskCommitRefreshesPushConfigExpiration(t *testing.T) {
 	update.ContextID = task.ContextID
 	task.Status = update.Status
 	if err := manager.commitTaskEvent(
-		context.Background(), task, protocol.NewStreamResponseStatusUpdate(update),
+		context.Background(), "", task, protocol.NewStreamResponseStatusUpdate(update),
 	); err != nil {
 		t.Fatalf("commitTaskEvent: %v", err)
 	}
@@ -906,7 +910,7 @@ func TestCrossNode_TaskCommitRefreshesPushConfigExpiration(t *testing.T) {
 func TestCrossNode_CloseRejectsTailerAfterSnapshotRead(t *testing.T) {
 	nodeA, nodeB := twoNodeManagers(t, scriptedExecutor())
 	task := storedTask(t, nodeA, "task-close-admission", "ctx-close-admission", protocol.TaskStateWorking)
-	if _, _, err := nodeB.eventTransport.LoadTaskAndCursor(context.Background(), task.ID); err != nil {
+	if _, _, err := nodeB.eventTransport.LoadTaskAndCursor(context.Background(), "", task.ID); err != nil {
 		t.Fatalf("warm loadTaskAndCursor script: %v", err)
 	}
 	hook := &blockAfterCommandHook{

--- a/taskmanager/redis/redis_engine.go
+++ b/taskmanager/redis/redis_engine.go
@@ -145,6 +145,7 @@ type execution struct {
 // the caller registered the execution under (see prepareExecution).
 func (m *TaskManager) resolveContinuation(
 	ctx context.Context,
+	tenant string,
 	message *protocol.Message,
 ) (*protocol.Task, error) {
 	if message.TaskID == nil || *message.TaskID == "" {
@@ -152,7 +153,7 @@ func (m *TaskManager) resolveContinuation(
 	}
 	taskID := *message.TaskID
 
-	loaded, err := m.getTaskInternal(ctx, taskID)
+	loaded, err := m.getTaskInternal(ctx, tenant, taskID)
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +219,7 @@ func (m *TaskManager) prepareExecution(
 	// only after that write — so the working copy below can never be a stale
 	// pre-terminal snapshot that would smuggle writes past a terminal state.
 	// A rejected request never reaches the MessageProcessor and leaves no trace.
-	if err := m.registerExecution(ctx, taskID, ex.live); err != nil {
+	if err := m.registerExecution(ctx, request.Tenant, taskID, ex.live); err != nil {
 		cancel()
 		return nil, err
 	}
@@ -226,9 +227,9 @@ func (m *TaskManager) prepareExecution(
 	// Continuation: a request addressing an existing task loads it, rejects
 	// terminal tasks without invoking the MessageProcessor (the task is frozen), and
 	// hands the MessageProcessor the current snapshot via ec.Task.
-	task, err := m.resolveContinuation(ctx, message)
+	task, err := m.resolveContinuation(ctx, request.Tenant, message)
 	if err != nil {
-		m.releaseExecution(taskID, ex.live)
+		m.releaseExecution(request.Tenant, taskID, ex.live)
 		cancel()
 		return nil, err
 	}
@@ -241,9 +242,9 @@ func (m *TaskManager) prepareExecution(
 		}
 	}
 	acceptedOutputModes, inlinePushConfig := messageConfigurationValues(request.Configuration)
-	pushConfig, pending, err := m.prepareInlinePushConfig(taskID, task, inlinePushConfig)
+	pushConfig, pending, err := m.prepareInlinePushConfig(request.Tenant, taskID, task, inlinePushConfig)
 	if err != nil {
-		m.releaseExecution(taskID, ex.live)
+		m.releaseExecution(request.Tenant, taskID, ex.live)
 		cancel()
 		return nil, err
 	}
@@ -270,22 +271,22 @@ func (m *TaskManager) prepareExecution(
 				ContextID: task.ContextID,
 				Status:    task.Status,
 			}
-			if err := m.commitTaskEvent(ctx, task, protocol.NewStreamResponseStatusUpdate(event)); err != nil {
-				m.releaseExecution(taskID, ex.live)
+			if err := m.commitTaskEvent(ctx, request.Tenant, task, protocol.NewStreamResponseStatusUpdate(event)); err != nil {
+				m.releaseExecution(request.Tenant, taskID, ex.live)
 				cancel()
 				return nil, fmt.Errorf("failed to advance task status history: %w", err)
 			}
-			m.storeStatusMessage(taskID, contextID, statusMessage)
+			m.storeStatusMessage(request.Tenant, taskID, contextID, statusMessage)
 		}
 		// The engine's working copy must not alias ec.Task (the MessageProcessor's
 		// read-only snapshot).
 		ex.task = copyTask(task)
 	}
-	m.storeMessage(context.Background(), *message)
+	m.storeMessage(context.Background(), request.Tenant, *message)
 
 	// History is the conversation snapshot truncated per the manager
 	// configuration; the request's historyLength only shapes response tasks.
-	history, err := m.getConversationHistory(ctx, contextID, m.options.MaxHistoryLength)
+	history, err := m.getConversationHistory(ctx, request.Tenant, contextID, m.options.MaxHistoryLength)
 	if err != nil {
 		log.Warnf("RedisTaskManager: failed to load history for context %s: %v", contextID, err)
 	}
@@ -301,14 +302,23 @@ func (m *TaskManager) prepareExecution(
 	}
 	ex.inlinePushPending = pending
 
-	events, err := m.processor.ProcessMessage(execCtx, ex.ec)
+	processorEC := *ex.ec
+	if ex.ec.PushConfig != nil {
+		pushConfig := *ex.ec.PushConfig
+		if pushConfig.Authentication != nil {
+			auth := *pushConfig.Authentication
+			pushConfig.Authentication = &auth
+		}
+		processorEC.PushConfig = &pushConfig
+	}
+	events, err := m.processor.ProcessMessage(execCtx, &processorEC)
 	if err != nil {
-		m.releaseExecution(taskID, ex.live)
+		m.releaseExecution(request.Tenant, taskID, ex.live)
 		cancel()
 		return nil, err
 	}
 	if events == nil {
-		m.releaseExecution(taskID, ex.live)
+		m.releaseExecution(request.Tenant, taskID, ex.live)
 		cancel()
 		return nil, taskmanager.ErrInternalError("processor returned nil channel")
 	}
@@ -333,6 +343,7 @@ func messageConfigurationValues(
 // Existing tasks persist it immediately; fresh lazy tasks wait for their first
 // task event so a failed start or pure-Message reply cannot leave an orphan.
 func (m *TaskManager) prepareInlinePushConfig(
+	tenant string,
 	taskID string,
 	task *protocol.Task,
 	config *protocol.TaskPushNotificationConfig,
@@ -344,6 +355,7 @@ func (m *TaskManager) prepareInlinePushConfig(
 		return nil, false, taskmanager.ErrPushNotificationNotSupported()
 	}
 	pushConfig := *config
+	pushConfig.Tenant = tenant
 	pushConfig.TaskID = taskID
 	if pushConfig.ID == "" {
 		pushConfig.ID = taskID
@@ -500,7 +512,7 @@ func (ex *execution) finish() {
 	if ex.pipe != nil {
 		ex.pipe.Close()
 	}
-	ex.manager.deregisterExecution(ex.ec.TaskID, ex.live)
+	ex.manager.deregisterExecution(ex.ec.Tenant, ex.ec.TaskID, ex.live)
 	ex.live.cancel()
 	close(ex.done)
 }
@@ -578,7 +590,7 @@ func (ex *execution) processMessageEvent(msg *protocol.Message) {
 	ex.manager.stampReplyMessage(&contextID, msg)
 	response := protocol.NewStreamResponseMessage(msg)
 	if ex.task != nil {
-		if err := ex.manager.appendTaskEvent(context.Background(), ex.ec.TaskID, response); err != nil {
+		if err := ex.manager.appendTaskEvent(context.Background(), ex.ec.Tenant, ex.ec.TaskID, response); err != nil {
 			ex.failRun(fmt.Errorf("failed to store message event for task %s: %w", ex.ec.TaskID, err))
 			return
 		}
@@ -586,7 +598,7 @@ func (ex *execution) processMessageEvent(msg *protocol.Message) {
 	// The event journal is the success boundary for a reply attached to a Task.
 	// Store conversation history only after the append succeeds, so a failed
 	// request cannot leave behind an agent reply that no stream observed.
-	ex.manager.storeMessage(context.Background(), *msg)
+	ex.manager.storeMessage(context.Background(), ex.ec.Tenant, *msg)
 	ex.lastMessage = msg
 	ex.offerImmediateResult(sendOutcome{message: msg})
 	ex.broadcast(response)
@@ -594,7 +606,7 @@ func (ex *execution) processMessageEvent(msg *protocol.Message) {
 
 // storeStatusMessage stores a stamped copy without mutating the processor's
 // message, which may still be visible in an earlier task snapshot or wire event.
-func (m *TaskManager) storeStatusMessage(taskID, contextID string, message *protocol.Message) {
+func (m *TaskManager) storeStatusMessage(tenant, taskID, contextID string, message *protocol.Message) {
 	if message == nil {
 		return
 	}
@@ -605,7 +617,7 @@ func (m *TaskManager) storeStatusMessage(taskID, contextID string, message *prot
 	if stored.MessageID == "" {
 		stored.MessageID = protocol.GenerateMessageID()
 	}
-	m.storeMessage(context.Background(), stored)
+	m.storeMessage(context.Background(), tenant, stored)
 }
 
 // rollStatusMessage moves a superseded status message into conversation
@@ -618,7 +630,7 @@ func (ex *execution) rollStatusMessage(message *protocol.Message) {
 		return
 	}
 	ex.lastStatusMsg = message
-	ex.manager.storeStatusMessage(ex.ec.TaskID, ex.ec.ContextID, message)
+	ex.manager.storeStatusMessage(ex.ec.Tenant, ex.ec.TaskID, ex.ec.ContextID, message)
 }
 
 // processStatusEvent applies a status update to the task (lazily creating it
@@ -668,15 +680,15 @@ func (ex *execution) processStatusEvent(ev *protocol.TaskStatusUpdateEvent) {
 		// be rejected as a concurrent execution. If cancellation claimed the slot
 		// first, keep this round active so its close rule can persist CANCELED
 		// rather than swallowing the accepted cancellation.
-		yielding = ex.manager.beginExecutionYield(ex.ec.TaskID, ex.live)
+		yielding = ex.manager.beginExecutionYield(ex.ec.Tenant, ex.ec.TaskID, ex.live)
 	}
 	// Persist before broadcast (consistency order). A failure terminates the
 	// execution result: the mutated working copy is never returned as if it had
 	// committed successfully.
 	response := protocol.NewStreamResponseStatusUpdate(ev)
-	if err := ex.manager.commitTaskEvent(context.Background(), ex.task, response); err != nil {
+	if err := ex.manager.commitTaskEvent(context.Background(), ex.ec.Tenant, ex.task, response); err != nil {
 		if yielding {
-			ex.manager.abortExecutionYield(ex.ec.TaskID, ex.live)
+			ex.manager.abortExecutionYield(ex.ec.Tenant, ex.ec.TaskID, ex.live)
 		}
 		ex.failRun(fmt.Errorf("failed to store task %s status %s: %w", ev.TaskID, status.State, err))
 		return
@@ -687,7 +699,7 @@ func (ex *execution) processStatusEvent(ev *protocol.TaskStatusUpdateEvent) {
 	ex.rollStatusMessage(previousStatusMessage)
 	if err := ex.persistInlinePushConfig(); err != nil {
 		if yielding {
-			ex.manager.abortExecutionYield(ex.ec.TaskID, ex.live)
+			ex.manager.abortExecutionYield(ex.ec.Tenant, ex.ec.TaskID, ex.live)
 		}
 		log.Errorf("RedisTaskManager: failed to persist inline push config for task %s: %v", ex.ec.TaskID, err)
 		ex.failTask("failed to persist inline push config")
@@ -700,11 +712,11 @@ func (ex *execution) processStatusEvent(ev *protocol.TaskStatusUpdateEvent) {
 		// cannot yet continue. The handoff starts before enqueue so a client that
 		// polls the persisted task also waits instead of being rejected. It also
 		// serializes task-subscriber fan-out with a continuation round.
-		ex.manager.dispatchPush(ex.ec.TaskID, response)
+		ex.manager.dispatchPush(ex.ec.Tenant, ex.ec.TaskID, response)
 		ex.offerImmediateTask()
 		ex.broadcastWithoutPush(response)
 		ex.closePipe()
-		ex.manager.deregisterExecution(ex.ec.TaskID, ex.live)
+		ex.manager.deregisterExecution(ex.ec.Tenant, ex.ec.TaskID, ex.live)
 		return
 	}
 
@@ -713,7 +725,7 @@ func (ex *execution) processStatusEvent(ev *protocol.TaskStatusUpdateEvent) {
 	ex.offerImmediateTask()
 	ex.broadcast(response)
 	if final {
-		ex.manager.cleanSubscribers(ev.TaskID)
+		ex.manager.cleanSubscribers(ex.ec.Tenant, ev.TaskID)
 		// Nothing can follow a terminal frame: end the response stream here
 		// instead of trusting the MessageProcessor to close its channel promptly.
 		ex.closePipe()
@@ -745,7 +757,7 @@ func (ex *execution) processArtifactEvent(ev *protocol.TaskArtifactUpdateEvent) 
 	ex.taskTouched = true
 	// Persist before broadcast (consistency order).
 	response := protocol.NewStreamResponseArtifactUpdate(ev)
-	if err := ex.manager.commitTaskEvent(context.Background(), ex.task, response); err != nil {
+	if err := ex.manager.commitTaskEvent(context.Background(), ex.ec.Tenant, ex.task, response); err != nil {
 		ex.failRun(fmt.Errorf("failed to store task %s artifact: %w", ev.TaskID, err))
 		return
 	}
@@ -801,7 +813,7 @@ func (ex *execution) broadcast(event protocol.StreamResponse) {
 		}
 	}
 	if ex.task != nil {
-		ex.manager.notifySubscribers(ex.ec.TaskID, event)
+		ex.manager.notifySubscribers(ex.ec.Tenant, ex.ec.TaskID, event)
 	}
 }
 
@@ -814,7 +826,7 @@ func (ex *execution) broadcastWithoutPush(event protocol.StreamResponse) {
 		}
 	}
 	if ex.task != nil {
-		ex.manager.notifyLiveSubscribers(ex.ec.TaskID, event)
+		ex.manager.notifyLiveSubscribers(ex.ec.Tenant, ex.ec.TaskID, event)
 	}
 }
 

--- a/taskmanager/redis/redis_engine_test.go
+++ b/taskmanager/redis/redis_engine_test.go
@@ -172,13 +172,13 @@ func TestNotifySubscribers_EvictedSlowSubscriberChannelIsClosed(t *testing.T) {
 	// Register a non-blocking subscriber with a tiny buffer directly.
 	sub := newTaskSubscriber(taskID, 1, false)
 	m.subMu.Lock()
-	m.subscribers[taskID] = []*taskSubscriber{sub}
+	m.subscribers[newScopedID("", taskID)] = []*taskSubscriber{sub}
 	m.subMu.Unlock()
 
 	event := protocol.NewStreamResponseStatusUpdate(&protocol.TaskStatusUpdateEvent{TaskID: taskID})
 	// First fills the buffer, second overflows and evicts the subscriber.
-	m.notifySubscribers(taskID, event)
-	m.notifySubscribers(taskID, event)
+	m.notifySubscribers("", taskID, event)
+	m.notifySubscribers("", taskID, event)
 
 	// The evicted subscriber's channel must be closed: draining it must end.
 	done := make(chan struct{})
@@ -198,7 +198,7 @@ func TestNotifySubscribers_EvictedSlowSubscriberChannelIsClosed(t *testing.T) {
 
 	// It must also be gone from the map.
 	m.subMu.RLock()
-	_, exists := m.subscribers[taskID]
+	_, exists := m.subscribers[newScopedID("", taskID)]
 	m.subMu.RUnlock()
 	if exists {
 		t.Error("evicted subscriber must be removed from the map")

--- a/taskmanager/redis/redis_event_transport.go
+++ b/taskmanager/redis/redis_event_transport.go
@@ -31,12 +31,14 @@ type taskEventTransport interface {
 	// produced it.
 	CommitTaskEvent(
 		ctx context.Context,
+		tenant string,
 		task *protocol.Task,
 		event protocol.StreamResponse,
 	) error
 	// AppendEvent stores an event that does not modify the Task snapshot.
 	AppendEvent(
 		ctx context.Context,
+		tenant string,
 		taskID string,
 		event protocol.StreamResponse,
 	) error
@@ -44,6 +46,7 @@ type taskEventTransport interface {
 	// event cursor. A subscriber reads only events committed after that cursor.
 	LoadTaskAndCursor(
 		ctx context.Context,
+		tenant string,
 		taskID string,
 	) (*protocol.Task, string, error)
 	// ReadAfter returns an ordered batch strictly after cursor and the cursor for
@@ -51,6 +54,7 @@ type taskEventTransport interface {
 	// when the cursor also did not advance.
 	ReadAfter(
 		ctx context.Context,
+		tenant string,
 		taskID string,
 		cursor string,
 	) ([]protocol.StreamResponse, string, error)
@@ -142,12 +146,13 @@ func newRedisTaskEventTransport(
 // streamKey shares the task key's Redis Cluster slot without changing the
 // existing task key. Redis hashes the full task key and the {...} portion of
 // the stream key, which are the same bytes for manager-generated task IDs.
-func streamKey(taskID string) string {
-	return streamPrefix + "{" + taskPrefix + taskID + "}"
+func streamKey(tenant, taskID string) string {
+	return streamPrefix + "{" + taskKey(tenant, taskID) + "}"
 }
 
 func (t *redisTaskEventTransport) CommitTaskEvent(
 	ctx context.Context,
+	tenant string,
 	task *protocol.Task,
 	event protocol.StreamResponse,
 ) error {
@@ -162,7 +167,7 @@ func (t *redisTaskEventTransport) CommitTaskEvent(
 	if _, err := commitTaskEventScript.Run(
 		ctx,
 		t.client,
-		[]string{taskPrefix + task.ID, streamKey(task.ID)},
+		[]string{taskKey(tenant, task.ID), streamKey(tenant, task.ID)},
 		taskBytes,
 		eventBytes,
 		streamMaxLen,
@@ -176,6 +181,7 @@ func (t *redisTaskEventTransport) CommitTaskEvent(
 
 func (t *redisTaskEventTransport) AppendEvent(
 	ctx context.Context,
+	tenant string,
 	taskID string,
 	event protocol.StreamResponse,
 ) error {
@@ -186,7 +192,7 @@ func (t *redisTaskEventTransport) AppendEvent(
 	if _, err := appendEventScript.Run(
 		ctx,
 		t.client,
-		[]string{taskPrefix + taskID, streamKey(taskID)},
+		[]string{taskKey(tenant, taskID), streamKey(tenant, taskID)},
 		payload,
 		streamMaxLen,
 		streamField,
@@ -198,12 +204,13 @@ func (t *redisTaskEventTransport) AppendEvent(
 
 func (t *redisTaskEventTransport) LoadTaskAndCursor(
 	ctx context.Context,
+	tenant string,
 	taskID string,
 ) (*protocol.Task, string, error) {
 	values, err := loadTaskAndCursorScript.Run(
 		ctx,
 		t.client,
-		[]string{taskPrefix + taskID, streamKey(taskID)},
+		[]string{taskKey(tenant, taskID), streamKey(tenant, taskID)},
 	).Slice()
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to load task %s and stream cursor: %w", taskID, err)
@@ -235,11 +242,12 @@ func (t *redisTaskEventTransport) LoadTaskAndCursor(
 
 func (t *redisTaskEventTransport) ReadAfter(
 	ctx context.Context,
+	tenant string,
 	taskID string,
 	cursor string,
 ) ([]protocol.StreamResponse, string, error) {
 	res, err := t.client.XRead(ctx, &redisclient.XReadArgs{
-		Streams: []string{streamKey(taskID), cursor},
+		Streams: []string{streamKey(tenant, taskID), cursor},
 		// Do not pin the TaskManager's shared Redis connection pool while a
 		// subscription is idle. The manager applies a context-aware backoff when
 		// this non-blocking read has no event or cursor progress.

--- a/taskmanager/redis/redis_manager.go
+++ b/taskmanager/redis/redis_manager.go
@@ -9,11 +9,13 @@ package redis
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
 	"sort"
+	"strconv"
 	"sync"
 	"time"
 
@@ -30,7 +32,9 @@ const (
 	messagePrefix          = "msg:"
 	conversationPrefix     = "conv:"
 	taskPrefix             = "task:"
+	taskIndexPrefix        = "taskidx:"
 	pushNotificationPrefix = "push:"
+	tenantNamespacePrefix  = "tenant:"
 
 	// Default expiration time for Redis keys (1 hour).
 	defaultExpiration = 1 * time.Hour
@@ -41,6 +45,45 @@ const (
 	taskEventReadIdleInitialDelay   = 100 * time.Millisecond
 	taskEventReadIdleMaxDelay       = time.Second
 )
+
+// scopedID is the process-local identity of tenant-owned runtime state.
+type scopedID struct {
+	tenant string
+	id     string
+}
+
+func newScopedID(tenant, id string) scopedID {
+	return scopedID{tenant: tenant, id: id}
+}
+
+// tenantKeyPrefix namespaces Redis data without changing legacy empty-tenant
+// keys. Raw URL-safe base64 makes tenant values unambiguous key segments.
+func tenantKeyPrefix(tenant string) string {
+	if tenant == "" {
+		return ""
+	}
+	return tenantNamespacePrefix + base64.RawURLEncoding.EncodeToString([]byte(tenant)) + ":"
+}
+
+func messageKey(tenant, messageID string) string {
+	return tenantKeyPrefix(tenant) + messagePrefix + messageID
+}
+
+func conversationKey(tenant, contextID string) string {
+	return tenantKeyPrefix(tenant) + conversationPrefix + contextID
+}
+
+func taskKey(tenant, taskID string) string {
+	return tenantKeyPrefix(tenant) + taskPrefix + taskID
+}
+
+func taskIndexKey(tenant string) string {
+	return tenantKeyPrefix(tenant) + taskIndexPrefix + "all"
+}
+
+func pushNotificationKey(tenant, taskID string) string {
+	return tenantKeyPrefix(tenant) + pushNotificationPrefix + taskID
+}
 
 // appendConversationMessageScript appends a MessageID exactly once, trims the
 // history window, and refreshes its TTL as one atomic Redis operation. It uses
@@ -78,14 +121,14 @@ type TaskManager struct {
 
 	// subMu is a mutex for the subscribers map.
 	subMu sync.RWMutex
-	// subscribers is a map of task IDs to subscriber channels.
-	subscribers map[string][]*taskSubscriber
+	// subscribers is indexed by tenant and task ID.
+	subscribers map[scopedID][]*taskSubscriber
 
 	// cancelMu is a mutex for the executions map and the closed flag.
 	cancelMu sync.RWMutex
-	// executions maps task IDs to live execution handles so OnCancelTask can
+	// executions maps tenant-scoped task IDs to live execution handles so OnCancelTask can
 	// cancel the MessageProcessor's context.
-	executions map[string]*liveExecution
+	executions map[scopedID]*liveExecution
 	// closed rejects new runs once Close has begun tearing the manager down.
 	closed bool
 	// engineWg counts live drain engines so Close can wait for their final
@@ -155,8 +198,8 @@ func NewTaskManager(
 		processor:   processor,
 		client:      client,
 		expiration:  expiration,
-		subscribers: make(map[string][]*taskSubscriber),
-		executions:  make(map[string]*liveExecution),
+		subscribers: make(map[scopedID][]*taskSubscriber),
+		executions:  make(map[scopedID]*liveExecution),
 		pushEnabled: options.Push.Sender != nil || options.Push.ManualDelivery,
 		options:     options,
 	}
@@ -199,7 +242,7 @@ func (m *TaskManager) OnSendMessage(
 		// background and results stay retrievable via GetTask/subscriptions.
 		select {
 		case out := <-ex.immediateResult:
-			return m.buildSendResponse(out.task, out.message, historyLength)
+			return m.buildSendResponse(request.Tenant, out.task, out.message, historyLength)
 		case err := <-ex.runFailed:
 			return nil, err
 		case <-ex.done:
@@ -208,7 +251,7 @@ func (m *TaskManager) OnSendMessage(
 			if ex.runErr != nil {
 				return nil, ex.runErr
 			}
-			return m.buildSendResponse(ex.finalTask, ex.lastMessage, historyLength)
+			return m.buildSendResponse(request.Tenant, ex.finalTask, ex.lastMessage, historyLength)
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		}
@@ -221,7 +264,7 @@ func (m *TaskManager) OnSendMessage(
 		if ex.runErr != nil {
 			return nil, ex.runErr
 		}
-		return m.buildSendResponse(ex.finalTask, ex.lastMessage, historyLength)
+		return m.buildSendResponse(request.Tenant, ex.finalTask, ex.lastMessage, historyLength)
 	case <-ctx.Done():
 		// The request died first. The execution is detached: it keeps running
 		// and its results stay retrievable via GetTask/resubscribe.
@@ -263,7 +306,7 @@ func (m *TaskManager) OnGetTask(
 	ctx context.Context,
 	params protocol.TaskQueryParams,
 ) (*protocol.Task, error) {
-	task, err := m.getTaskInternal(ctx, params.ID)
+	task, err := m.getTaskInternal(ctx, params.Tenant, params.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -272,7 +315,7 @@ func (m *TaskManager) OnGetTask(
 	//   - historyLength unset -> no limit (full history)
 	//   - historyLength == 0  -> no messages
 	//   - historyLength > 0   -> the most recent N messages
-	m.fillTaskHistory(ctx, task, params.HistoryLength)
+	m.fillTaskHistory(ctx, params.Tenant, task, params.HistoryLength)
 
 	return task, nil
 }
@@ -280,7 +323,12 @@ func (m *TaskManager) OnGetTask(
 // fillTaskHistory shapes a response task's History per the v1.0 historyLength
 // semantics: unset means the full conversation history, 0 (or negative) means
 // none, N means the most recent N messages.
-func (m *TaskManager) fillTaskHistory(ctx context.Context, task *protocol.Task, historyLength *int) {
+func (m *TaskManager) fillTaskHistory(
+	ctx context.Context,
+	tenant string,
+	task *protocol.Task,
+	historyLength *int,
+) {
 	if task.ContextID == "" {
 		return
 	}
@@ -293,7 +341,7 @@ func (m *TaskManager) fillTaskHistory(ctx context.Context, task *protocol.Task, 
 		task.History = nil
 		return
 	}
-	history, err := m.getConversationHistory(ctx, task.ContextID, length)
+	history, err := m.getConversationHistory(ctx, tenant, task.ContextID, length)
 	if err != nil {
 		log.Warnf("Failed to retrieve message history for task %s: %v", task.ID, err)
 		// Continue without history rather than failing the whole request.
@@ -314,12 +362,13 @@ func historyLengthFromConfig(config *protocol.SendMessageConfiguration) *int {
 // exists (history shaped per the request's historyLength), otherwise the last
 // message; an execution that produced neither is an MessageProcessor bug.
 func (m *TaskManager) buildSendResponse(
+	tenant string,
 	task *protocol.Task,
 	message *protocol.Message,
 	historyLength *int,
 ) (*protocol.SendMessageResponse, error) {
 	if task != nil {
-		m.fillTaskHistory(context.Background(), task, historyLength)
+		m.fillTaskHistory(context.Background(), tenant, task, historyLength)
 		return protocol.NewSendMessageResponseTask(task), nil
 	}
 	if message != nil {
@@ -340,7 +389,7 @@ func (m *TaskManager) OnCancelTask(
 	params protocol.TaskIDParams,
 ) (*protocol.Task, error) {
 	for {
-		live, sentinel, yieldDone := m.claimCancelSlot(params.ID)
+		live, sentinel, yieldDone := m.claimCancelSlot(params.Tenant, params.ID)
 		if yieldDone != nil {
 			select {
 			case <-yieldDone:
@@ -350,13 +399,13 @@ func (m *TaskManager) OnCancelTask(
 			}
 		}
 		if live == nil {
-			defer m.deregisterExecution(params.ID, sentinel)
+			defer m.deregisterExecution(params.Tenant, params.ID, sentinel)
 			return m.cancelWithoutLiveRun(ctx, params)
 		}
 
 		// A stored terminal state is immutable even while the round is still
 		// draining: canceling it must fail like the no-live path does.
-		task, err := m.getTaskInternal(ctx, params.ID)
+		task, err := m.getTaskInternal(ctx, params.Tenant, params.ID)
 		if err != nil && !errors.Is(err, taskmanager.ErrTaskNotFoundSentinel) {
 			// Storage error, not a missing task: canceling is irreversible, so
 			// do not cancel a healthy run because the lookup blipped.
@@ -368,7 +417,7 @@ func (m *TaskManager) OnCancelTask(
 		// Linearize cancellation against a concurrent suspend handoff. If the
 		// handoff won, wait for it and retry as a no-live cancel; otherwise the
 		// close rule is guaranteed to observe cancelRequested.
-		yieldDone, accepted := m.requestExecutionCancel(params.ID, live)
+		yieldDone, accepted := m.requestExecutionCancel(params.Tenant, params.ID, live)
 		if yieldDone != nil {
 			select {
 			case <-yieldDone:
@@ -381,7 +430,7 @@ func (m *TaskManager) OnCancelTask(
 			continue
 		}
 
-		if m.liveRun(params.ID) != live {
+		if m.liveRun(params.Tenant, params.ID) != live {
 			// The run yielded (suspend) or finished while we were canceling, so
 			// its close rule will not persist CANCELED on our behalf. Reassess:
 			// the next pass either claims the free slot and persists CANCELED
@@ -405,7 +454,7 @@ func (m *TaskManager) cancelWithoutLiveRun(
 	ctx context.Context,
 	params protocol.TaskIDParams,
 ) (*protocol.Task, error) {
-	task, err := m.getTaskInternal(ctx, params.ID)
+	task, err := m.getTaskInternal(ctx, params.Tenant, params.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -428,12 +477,12 @@ func (m *TaskManager) cancelWithoutLiveRun(
 	response := protocol.NewStreamResponseStatusUpdate(event)
 	// Persist with a background context (like every engine write): the CANCELED
 	// state must land even if the cancel request's own context is already done.
-	if err := m.commitTaskEvent(context.Background(), task, response); err != nil {
+	if err := m.commitTaskEvent(context.Background(), params.Tenant, task, response); err != nil {
 		log.Errorf("Error storing cancelled task %s: %v", params.ID, err)
 		return nil, err
 	}
-	m.notifySubscribers(params.ID, response)
-	m.cleanSubscribers(params.ID)
+	m.notifySubscribers(params.Tenant, params.ID, response)
+	m.cleanSubscribers(params.Tenant, params.ID)
 
 	return task, nil
 }
@@ -449,7 +498,7 @@ func (m *TaskManager) OnPushNotificationSet(
 	if err := push.ValidateConfig(params); err != nil {
 		return nil, taskmanager.ErrInvalidParams(err.Error())
 	}
-	if _, err := m.getTaskInternal(ctx, params.TaskID); err != nil {
+	if _, err := m.getTaskInternal(ctx, params.Tenant, params.TaskID); err != nil {
 		return nil, err
 	}
 	stored, err := m.storePushConfig(ctx, params)
@@ -471,10 +520,10 @@ func (m *TaskManager) OnPushNotificationGet(
 	if params.ID == "" {
 		return nil, taskmanager.ErrInvalidParams("push notification config ID is required")
 	}
-	if _, err := m.getTaskInternal(ctx, params.TaskID); err != nil {
+	if _, err := m.getTaskInternal(ctx, params.Tenant, params.TaskID); err != nil {
 		return nil, err
 	}
-	configBytes, err := m.client.HGet(ctx, pushNotificationPrefix+params.TaskID, params.ID).Bytes()
+	configBytes, err := m.client.HGet(ctx, pushNotificationKey(params.Tenant, params.TaskID), params.ID).Bytes()
 	if err == nil {
 		registration, err := decodePushRegistration(configBytes)
 		if err != nil {
@@ -491,8 +540,8 @@ func (m *TaskManager) OnPushNotificationGet(
 // a v1.0 request leaves historyLength unset (spec: unset means no limit).
 const unlimitedHistoryLength = 1 << 30
 
-// OnListTasks handles the v1.0 ListTasks request by scanning stored tasks,
-// filtering, and applying offset-based pagination.
+// OnListTasks handles the v1.0 ListTasks request from the tenant-local task
+// index, filtering and applying offset-based pagination without a keyspace SCAN.
 func (m *TaskManager) OnListTasks(
 	ctx context.Context,
 	params protocol.ListTasksParams,
@@ -502,25 +551,53 @@ func (m *TaskManager) OnListTasks(
 		return nil, err
 	}
 
-	// Scan all task keys and collect matching tasks.
+	indexKey := taskIndexKey(params.Tenant)
+	nowMillis := time.Now().UnixMilli()
+	if err := m.client.ZRemRangeByScore(ctx, indexKey, "-inf", strconv.FormatInt(nowMillis, 10)).Err(); err != nil {
+		return nil, fmt.Errorf("failed to prune expired task index entries: %w", err)
+	}
+	taskIDs, err := m.client.ZRangeByScore(ctx, indexKey, &redis.ZRangeBy{
+		Min: "(" + strconv.FormatInt(nowMillis, 10),
+		Max: "+inf",
+	}).Result()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load task index: %w", err)
+	}
+
+	// Pipeline the task loads. ClusterClient splits the pipeline by node, so
+	// task records may stay distributed even though the tenant index is one key.
+	loads := make([]*redis.StringCmd, len(taskIDs))
+	_, pipelineErr := m.client.Pipelined(ctx, func(pipe redis.Pipeliner) error {
+		for i, taskID := range taskIDs {
+			loads[i] = pipe.Get(ctx, taskKey(params.Tenant, taskID))
+		}
+		return nil
+	})
+	if pipelineErr != nil && !errors.Is(pipelineErr, redis.Nil) {
+		return nil, fmt.Errorf("failed to load indexed tasks: %w", pipelineErr)
+	}
+
 	var filtered []*protocol.Task
-	iter := m.client.Scan(ctx, 0, taskPrefix+"*", 0).Iterator()
-	for iter.Next(ctx) {
-		taskBytes, err := m.client.Get(ctx, iter.Val()).Bytes()
+	for i, load := range loads {
+		taskBytes, err := load.Bytes()
+		if errors.Is(err, redis.Nil) {
+			// The index is written before the task. A failed or still-in-flight
+			// task write can therefore leave a temporary member; its score expires
+			// automatically. Do not ZREM here: the same task ID may have been
+			// concurrently recreated after this GET observed a miss.
+			continue
+		}
 		if err != nil {
-			continue // Key expired between SCAN and GET.
+			return nil, fmt.Errorf("failed to load task %s: %w", taskIDs[i], err)
 		}
 		var task protocol.Task
 		if err := json.Unmarshal(taskBytes, &task); err != nil {
-			log.Errorf("RedisTaskManager: skip malformed task at %s: %v", iter.Val(), err)
+			log.Errorf("RedisTaskManager: skip malformed indexed task %s: %v", taskIDs[i], err)
 			continue
 		}
 		if taskmanager.TaskMatchesListFilter(&task, params, afterTime) {
 			filtered = append(filtered, &task)
 		}
-	}
-	if err := iter.Err(); err != nil {
-		return nil, fmt.Errorf("failed to scan tasks: %w", err)
 	}
 	return taskmanager.PaginateTasks(filtered, params)
 }
@@ -534,11 +611,11 @@ func (m *TaskManager) OnPushNotificationList(
 	if !m.pushEnabled {
 		return nil, taskmanager.ErrPushNotificationNotSupported()
 	}
-	if _, err := m.getTaskInternal(ctx, params.TaskID); err != nil {
+	if _, err := m.getTaskInternal(ctx, params.Tenant, params.TaskID); err != nil {
 		return nil, err
 	}
 
-	configs, err := m.readPushConfigs(ctx, params.TaskID)
+	configs, err := m.readPushConfigs(ctx, params.Tenant, params.TaskID)
 	if err != nil {
 		return nil, err
 	}
@@ -557,10 +634,10 @@ func (m *TaskManager) OnPushNotificationDelete(
 	if params.ID == "" {
 		return taskmanager.ErrInvalidParams("push notification config ID is required")
 	}
-	if _, err := m.getTaskInternal(ctx, params.TaskID); err != nil {
+	if _, err := m.getTaskInternal(ctx, params.Tenant, params.TaskID); err != nil {
 		return err
 	}
-	pushKey := pushNotificationPrefix + params.TaskID
+	pushKey := pushNotificationKey(params.Tenant, params.TaskID)
 	if err := m.client.HDel(ctx, pushKey, params.ID).Err(); err != nil {
 		return fmt.Errorf("failed to delete push notification config: %w", err)
 	}
@@ -583,7 +660,7 @@ func (m *TaskManager) storePushConfig(
 	if cfg.ID == "" {
 		cfg.ID = "push-" + uuid.New().String()
 	}
-	pushKey := pushNotificationPrefix + cfg.TaskID
+	pushKey := pushNotificationKey(cfg.Tenant, cfg.TaskID)
 	registration := push.Registration{
 		Config:     cfg,
 		Generation: uuid.New().String(),
@@ -636,9 +713,9 @@ func decodePushRegistration(data []byte) (push.Registration, error) {
 
 // readPushConfigs returns all push configs registered for taskID, ordered by ID.
 func (m *TaskManager) readPushConfigs(
-	ctx context.Context, taskID string,
+	ctx context.Context, tenant, taskID string,
 ) ([]protocol.TaskPushNotificationConfig, error) {
-	registrations, err := m.readPushRegistrations(ctx, taskID)
+	registrations, err := m.readPushRegistrations(ctx, tenant, taskID)
 	if err != nil {
 		return nil, err
 	}
@@ -652,9 +729,9 @@ func (m *TaskManager) readPushConfigs(
 // readPushRegistrations returns all persisted push registration snapshots for
 // taskID, ordered by config ID.
 func (m *TaskManager) readPushRegistrations(
-	ctx context.Context, taskID string,
+	ctx context.Context, tenant, taskID string,
 ) ([]push.Registration, error) {
-	entries, err := m.client.HGetAll(ctx, pushNotificationPrefix+taskID).Result()
+	entries, err := m.client.HGetAll(ctx, pushNotificationKey(tenant, taskID)).Result()
 	if err != nil {
 		return nil, fmt.Errorf("failed to read push notification configs: %w", err)
 	}
@@ -679,7 +756,7 @@ func (m *TaskManager) isCurrentPushRegistration(
 	ctx context.Context, queued push.Registration,
 ) (bool, error) {
 	cfg := queued.Config
-	data, err := m.client.HGet(ctx, pushNotificationPrefix+cfg.TaskID, cfg.ID).Bytes()
+	data, err := m.client.HGet(ctx, pushNotificationKey(cfg.Tenant, cfg.TaskID), cfg.ID).Bytes()
 	if errors.Is(err, redis.Nil) {
 		return false, nil
 	}
@@ -697,7 +774,7 @@ func (m *TaskManager) isCurrentPushRegistration(
 // are read at event time before the event enters the bounded queue, so a later
 // registration change cannot retroactively change recipients. A full queue
 // applies backpressure rather than silently dropping an event.
-func (m *TaskManager) dispatchPush(taskID string, event protocol.StreamResponse) {
+func (m *TaskManager) dispatchPush(tenant, taskID string, event protocol.StreamResponse) {
 	if m.pushDispatcher == nil {
 		return
 	}
@@ -707,7 +784,7 @@ func (m *TaskManager) dispatchPush(taskID string, event protocol.StreamResponse)
 	if closed {
 		return
 	}
-	registrations, err := m.readPushRegistrations(m.pushCtx, taskID)
+	registrations, err := m.readPushRegistrations(m.pushCtx, tenant, taskID)
 	if err != nil {
 		if !errors.Is(err, context.Canceled) {
 			log.Warnf("RedisTaskManager: push dispatch: load config for task %s: %v", taskID, err)
@@ -730,7 +807,7 @@ func (m *TaskManager) OnResubscribe(
 	// The snapshot read happens OUTSIDE subMu: getTaskInternal is a network
 	// round-trip and subMu sits on every broadcast's fan-out path — holding it
 	// across a slow Redis call would stall every stream in the process.
-	task, err := m.getTaskInternal(ctx, params.ID)
+	task, err := m.getTaskInternal(ctx, params.Tenant, params.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -755,7 +832,8 @@ func (m *TaskManager) OnResubscribe(
 		return nil, err
 	}
 	m.subMu.Lock()
-	m.subscribers[params.ID] = append(m.subscribers[params.ID], subscriber)
+	key := newScopedID(params.Tenant, params.ID)
+	m.subscribers[key] = append(m.subscribers[key], subscriber)
 	m.subMu.Unlock()
 
 	// The snapshot predates the registration, so an update persisted between
@@ -764,14 +842,14 @@ func (m *TaskManager) OnResubscribe(
 	// guarantees the re-read covers every event broadcast before registration.
 	// (Boundary events may be delivered both in a snapshot and as themselves —
 	// at-least-once, as before.)
-	current, err := m.getTaskInternal(ctx, params.ID)
+	current, err := m.getTaskInternal(ctx, params.Tenant, params.ID)
 	if err == nil && taskChanged(task, current) {
 		if isFinalState(current.Status.State) {
 			// The task ended between the two reads: its terminal broadcast (and
 			// cleanSubscribers) may have run before the registration, which
 			// would leave this subscriber open forever. Reject like the
 			// up-front terminal check does; nothing was delivered to the caller.
-			m.cleanupFailedSubscribers(params.ID, []*taskSubscriber{subscriber})
+			m.cleanupFailedSubscribers(params.Tenant, params.ID, []*taskSubscriber{subscriber})
 			return nil, taskmanager.ErrUnsupportedOperation(
 				fmt.Sprintf("subscribe to task %s in terminal state %s", params.ID, current.Status.State))
 		}
@@ -787,7 +865,7 @@ func (m *TaskManager) OnResubscribe(
 	go func() {
 		select {
 		case <-ctx.Done():
-			m.cleanupFailedSubscribers(params.ID, []*taskSubscriber{subscriber})
+			m.cleanupFailedSubscribers(params.Tenant, params.ID, []*taskSubscriber{subscriber})
 		case <-subscriber.done:
 		}
 	}()
@@ -805,7 +883,7 @@ func (m *TaskManager) onCrossNodeResubscribe(
 	// The transport loads the Task and event cursor at one atomic boundary. A
 	// concurrent task-event commit is therefore either reflected by both values
 	// or by neither: the snapshot and subsequent read contain no gap or overlap.
-	task, startID, err := m.eventTransport.LoadTaskAndCursor(ctx, params.ID)
+	task, startID, err := m.eventTransport.LoadTaskAndCursor(ctx, params.Tenant, params.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -837,7 +915,7 @@ func (m *TaskManager) onCrossNodeResubscribe(
 	}
 	m.tailerWg.Add(1)
 	m.cancelMu.Unlock()
-	go m.tailTaskEvents(ctx, params.ID, startID, subscriber)
+	go m.tailTaskEvents(ctx, params.Tenant, params.ID, startID, subscriber)
 
 	return subscriber.Channel(), nil
 }
@@ -845,7 +923,11 @@ func (m *TaskManager) onCrossNodeResubscribe(
 // tailTaskEvents feeds a resubscriber from the configured event transport,
 // reading strictly after startID. It closes the subscriber and returns on the
 // terminal status frame, when the request ends, or when the manager closes.
-func (m *TaskManager) tailTaskEvents(ctx context.Context, taskID, startID string, sub *taskSubscriber) {
+func (m *TaskManager) tailTaskEvents(
+	ctx context.Context,
+	tenant, taskID, startID string,
+	sub *taskSubscriber,
+) {
 	defer m.tailerWg.Done()
 	defer sub.Close()
 
@@ -880,7 +962,7 @@ func (m *TaskManager) tailTaskEvents(ctx context.Context, taskID, startID string
 		default:
 		}
 		previousID := startID
-		events, nextID, err := m.eventTransport.ReadAfter(readCtx, taskID, startID)
+		events, nextID, err := m.eventTransport.ReadAfter(readCtx, tenant, taskID, startID)
 		if err != nil {
 			return // read context canceled, transport closed, or a storage error.
 		}
@@ -929,13 +1011,14 @@ func (m *TaskManager) tailTaskEvents(ctx context.Context, taskID, startID string
 // one atomic commit. It is a no-op when no event transport is configured.
 func (m *TaskManager) appendTaskEvent(
 	ctx context.Context,
+	tenant string,
 	taskID string,
 	event protocol.StreamResponse,
 ) error {
 	if m.eventTransport == nil {
 		return nil
 	}
-	return m.eventTransport.AppendEvent(ctx, taskID, event)
+	return m.eventTransport.AppendEvent(ctx, tenant, taskID, event)
 }
 
 // taskChanged reports whether two snapshots of the same task differ in what a
@@ -970,9 +1053,9 @@ func (m *TaskManager) stampReplyMessage(ctxID *string, message *protocol.Message
 }
 
 // storeMessage stores a message in Redis and updates conversation history.
-func (m *TaskManager) storeMessage(ctx context.Context, message protocol.Message) {
+func (m *TaskManager) storeMessage(ctx context.Context, tenant string, message protocol.Message) {
 	// Store the message.
-	msgKey := messagePrefix + message.MessageID
+	msgKey := messageKey(tenant, message.MessageID)
 	msgBytes, err := json.Marshal(message)
 	if err != nil {
 		log.Errorf("Failed to serialize message %s: %v", message.MessageID, err)
@@ -987,7 +1070,7 @@ func (m *TaskManager) storeMessage(ctx context.Context, message protocol.Message
 	// If the message has a contextID, add it to conversation history.
 	if message.ContextID != nil {
 		contextID := *message.ContextID
-		convKey := conversationPrefix + contextID
+		convKey := conversationKey(tenant, contextID)
 
 		// The same MessageID may reach this path concurrently from a reply and a
 		// superseded status. Keep the membership check, append, trim, and TTL
@@ -1009,6 +1092,7 @@ func (m *TaskManager) storeMessage(ctx context.Context, message protocol.Message
 // getConversationHistory retrieves conversation history for a context.
 func (m *TaskManager) getConversationHistory(
 	ctx context.Context,
+	tenant string,
 	contextID string,
 	length int,
 ) ([]protocol.Message, error) {
@@ -1016,7 +1100,7 @@ func (m *TaskManager) getConversationHistory(
 		return nil, nil
 	}
 
-	convKey := conversationPrefix + contextID
+	convKey := conversationKey(tenant, contextID)
 
 	// Get the message count.
 	count, err := m.client.LLen(ctx, convKey).Result()
@@ -1039,7 +1123,7 @@ func (m *TaskManager) getConversationHistory(
 	// Retrieve messages.
 	messages := make([]protocol.Message, 0, len(messageIDs))
 	for _, msgID := range messageIDs {
-		msgKey := messagePrefix + msgID
+		msgKey := messageKey(tenant, msgID)
 		msgBytes, err := m.client.Get(ctx, msgKey).Bytes()
 		if err != nil {
 			log.Warnf("Message %s not found in Redis", msgID)
@@ -1062,9 +1146,8 @@ func (m *TaskManager) getConversationHistory(
 // ErrTaskNotFound; any other failure is a storage error and is reported as
 // such — callers that take irreversible actions on not-found (cancel paths)
 // must be able to tell the two apart.
-func (m *TaskManager) getTaskInternal(ctx context.Context, taskID string) (*protocol.Task, error) {
-	taskKey := taskPrefix + taskID
-	taskBytes, err := m.client.Get(ctx, taskKey).Bytes()
+func (m *TaskManager) getTaskInternal(ctx context.Context, tenant, taskID string) (*protocol.Task, error) {
+	taskBytes, err := m.client.Get(ctx, taskKey(tenant, taskID)).Bytes()
 	if err != nil {
 		if errors.Is(err, redis.Nil) {
 			return nil, taskmanager.ErrTaskNotFound(taskID)
@@ -1080,26 +1163,33 @@ func (m *TaskManager) getTaskInternal(ctx context.Context, taskID string) (*prot
 	return &task, nil
 }
 
-// storeTask stores a task in Redis.
-func (m *TaskManager) storeTask(ctx context.Context, task *protocol.Task) error {
-	taskKey := taskPrefix + task.ID
-	taskBytes, err := json.Marshal(task)
-	if err != nil {
-		return fmt.Errorf("failed to serialize task: %w", err)
+// ensureTaskIndexed records taskID in the tenant-local listing index before
+// the Task write. A later Task-write failure may leave a stale member, which
+// ListTasks removes lazily; the reverse ordering could make a successfully
+// persisted task permanently invisible.
+func (m *TaskManager) ensureTaskIndexed(ctx context.Context, tenant, taskID string) error {
+	indexKey := taskIndexKey(tenant)
+	indexExpiration := m.expiration
+	if indexExpiration <= time.Duration(1<<63-1)/2 {
+		indexExpiration *= 2
 	}
-
-	_, err = m.client.Pipelined(ctx, func(pipe redis.Pipeliner) error {
-		pipe.Set(ctx, taskKey, taskBytes, m.expiration)
-		// A task continuation refreshes its registered push configs as well.
-		// Expire on a missing hash is intentionally a no-op.
-		pipe.Expire(ctx, pushNotificationPrefix+task.ID, m.expiration)
+	expiresAt := time.Now().Add(indexExpiration).UnixMilli()
+	if _, err := m.client.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+		pipe.ZAdd(ctx, indexKey, redis.Z{Score: float64(expiresAt), Member: taskID})
+		pipe.Expire(ctx, indexKey, indexExpiration)
 		return nil
-	})
-	if err != nil {
-		return fmt.Errorf("failed to store task: %w", err)
+	}); err != nil {
+		return fmt.Errorf("failed to index task %s: %w", taskID, err)
 	}
-
 	return nil
+}
+
+// storeTask stores a task in Redis.
+func (m *TaskManager) storeTask(ctx context.Context, tenant string, task *protocol.Task) error {
+	if err := m.ensureTaskIndexed(ctx, tenant, task.ID); err != nil {
+		return err
+	}
+	return m.storeTaskWithoutIndex(ctx, tenant, task)
 }
 
 // commitTaskEvent atomically persists a Task snapshot and distributes the event
@@ -1107,21 +1197,43 @@ func (m *TaskManager) storeTask(ctx context.Context, task *protocol.Task) error 
 // the original single-key Task persistence path.
 func (m *TaskManager) commitTaskEvent(
 	ctx context.Context,
+	tenant string,
 	task *protocol.Task,
 	event protocol.StreamResponse,
 ) error {
-	if m.eventTransport == nil {
-		return m.storeTask(ctx, task)
+	if err := m.ensureTaskIndexed(ctx, tenant, task.ID); err != nil {
+		return err
 	}
-	if err := m.eventTransport.CommitTaskEvent(ctx, task, event); err != nil {
+	if m.eventTransport == nil {
+		return m.storeTaskWithoutIndex(ctx, tenant, task)
+	}
+	if err := m.eventTransport.CommitTaskEvent(ctx, tenant, task, event); err != nil {
 		return err
 	}
 	// Keep the latest v2 storeTask behavior: every Task write refreshes its push
 	// registrations. This key cannot join the atomic script because the existing
 	// push key is in a different Redis Cluster slot; failure here must not turn an
 	// already-committed Task/event pair into a false negative result.
-	if err := m.client.Expire(ctx, pushNotificationPrefix+task.ID, m.expiration).Err(); err != nil {
+	if err := m.client.Expire(ctx, pushNotificationKey(tenant, task.ID), m.expiration).Err(); err != nil {
 		log.Warnf("RedisTaskManager: failed to refresh push config expiration for task %s: %v", task.ID, err)
+	}
+	return nil
+}
+
+// storeTaskWithoutIndex persists the Task after ensureTaskIndexed succeeded.
+func (m *TaskManager) storeTaskWithoutIndex(ctx context.Context, tenant string, task *protocol.Task) error {
+	key := taskKey(tenant, task.ID)
+	taskBytes, err := json.Marshal(task)
+	if err != nil {
+		return fmt.Errorf("failed to serialize task: %w", err)
+	}
+	_, err = m.client.Pipelined(ctx, func(pipe redis.Pipeliner) error {
+		pipe.Set(ctx, key, taskBytes, m.expiration)
+		pipe.Expire(ctx, pushNotificationKey(tenant, task.ID), m.expiration)
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to store task: %w", err)
 	}
 	return nil
 }
@@ -1147,18 +1259,20 @@ func isSuspendedState(state protocol.TaskState) bool {
 // round's short suspend handoff, while any other concurrent round is rejected.
 func (m *TaskManager) registerExecution(
 	ctx context.Context,
+	tenant string,
 	taskID string,
 	live *liveExecution,
 ) error {
+	key := newScopedID(tenant, taskID)
 	for {
 		m.cancelMu.Lock()
 		if m.closed {
 			m.cancelMu.Unlock()
 			return taskmanager.ErrInternalError("task manager is closed")
 		}
-		current, exists := m.executions[taskID]
+		current, exists := m.executions[key]
 		if !exists {
-			m.executions[taskID] = live
+			m.executions[key] = live
 			// Counted under the registry lock so Close (which flips m.closed first)
 			// can never begin waiting before a just-admitted run is counted.
 			m.engineWg.Add(1)
@@ -1182,8 +1296,8 @@ func (m *TaskManager) registerExecution(
 
 // releaseExecution aborts a registered run whose engine never started: it
 // undoes registerExecution's registration and engine count.
-func (m *TaskManager) releaseExecution(taskID string, live *liveExecution) {
-	m.deregisterExecution(taskID, live)
+func (m *TaskManager) releaseExecution(tenant, taskID string, live *liveExecution) {
+	m.deregisterExecution(tenant, taskID, live)
 	m.engineWg.Done()
 }
 
@@ -1192,18 +1306,20 @@ func (m *TaskManager) releaseExecution(taskID string, live *liveExecution) {
 // CANCELED write gets the same single-writer guarantee as a run: no
 // continuation can register (and then write) concurrently with it.
 func (m *TaskManager) claimCancelSlot(
+	tenant string,
 	taskID string,
 ) (live *liveExecution, sentinel *liveExecution, yieldDone <-chan struct{}) {
+	key := newScopedID(tenant, taskID)
 	m.cancelMu.Lock()
 	defer m.cancelMu.Unlock()
-	if exec, ok := m.executions[taskID]; ok {
+	if exec, ok := m.executions[key]; ok {
 		if exec.yieldDone != nil {
 			return nil, nil, exec.yieldDone
 		}
 		return exec, nil, nil
 	}
 	sentinel = &liveExecution{cancel: func() {}}
-	m.executions[taskID] = sentinel
+	m.executions[key] = sentinel
 	return nil, sentinel, nil
 }
 
@@ -1211,11 +1327,13 @@ func (m *TaskManager) claimCancelSlot(
 // suspend handoff. It returns the handoff channel when yield won, or accepted
 // after publishing cancelRequested under the registry lock.
 func (m *TaskManager) requestExecutionCancel(
+	tenant string,
 	taskID string,
 	live *liveExecution,
 ) (yieldDone <-chan struct{}, accepted bool) {
+	key := newScopedID(tenant, taskID)
 	m.cancelMu.Lock()
-	if m.executions[taskID] != live {
+	if m.executions[key] != live {
 		m.cancelMu.Unlock()
 		return nil, false
 	}
@@ -1231,19 +1349,20 @@ func (m *TaskManager) requestExecutionCancel(
 }
 
 // liveRun returns the task's currently registered execution handle, if any.
-func (m *TaskManager) liveRun(taskID string) *liveExecution {
+func (m *TaskManager) liveRun(tenant, taskID string) *liveExecution {
 	m.cancelMu.RLock()
 	defer m.cancelMu.RUnlock()
-	return m.executions[taskID]
+	return m.executions[newScopedID(tenant, taskID)]
 }
 
 // deregisterExecution removes the handle at engine end. It only removes its
 // own entry so a follow-up round on the same task is never evicted.
-func (m *TaskManager) deregisterExecution(taskID string, live *liveExecution) {
+func (m *TaskManager) deregisterExecution(tenant, taskID string, live *liveExecution) {
+	key := newScopedID(tenant, taskID)
 	m.cancelMu.Lock()
 	defer m.cancelMu.Unlock()
-	if current, ok := m.executions[taskID]; ok && current == live {
-		delete(m.executions, taskID)
+	if current, ok := m.executions[key]; ok && current == live {
+		delete(m.executions, key)
 		if live.yieldDone != nil {
 			close(live.yieldDone)
 			live.yieldDone = nil
@@ -1254,10 +1373,11 @@ func (m *TaskManager) deregisterExecution(taskID string, live *liveExecution) {
 // beginExecutionYield turns an active slot into a short handoff barrier. The
 // slot remains owned by live until its suspend frame has reached every local
 // observer, but continuations wait for the handoff instead of failing.
-func (m *TaskManager) beginExecutionYield(taskID string, live *liveExecution) bool {
+func (m *TaskManager) beginExecutionYield(tenant, taskID string, live *liveExecution) bool {
+	key := newScopedID(tenant, taskID)
 	m.cancelMu.Lock()
 	defer m.cancelMu.Unlock()
-	if m.executions[taskID] == live && live.yieldDone == nil && !live.cancelRequested.Load() {
+	if m.executions[key] == live && live.yieldDone == nil && !live.cancelRequested.Load() {
 		live.yieldDone = make(chan struct{})
 		return true
 	}
@@ -1266,10 +1386,11 @@ func (m *TaskManager) beginExecutionYield(taskID string, live *liveExecution) bo
 
 // abortExecutionYield restores an active slot when committing the suspended
 // state fails. Waiters wake and re-evaluate it as an ordinary active run.
-func (m *TaskManager) abortExecutionYield(taskID string, live *liveExecution) {
+func (m *TaskManager) abortExecutionYield(tenant, taskID string, live *liveExecution) {
+	key := newScopedID(tenant, taskID)
 	m.cancelMu.Lock()
 	defer m.cancelMu.Unlock()
-	if m.executions[taskID] == live && live.yieldDone != nil {
+	if m.executions[key] == live && live.yieldDone != nil {
 		close(live.yieldDone)
 		live.yieldDone = nil
 	}
@@ -1278,14 +1399,15 @@ func (m *TaskManager) abortExecutionYield(taskID string, live *liveExecution) {
 // cleanSubscribers closes and removes all subscribers for a task. Subscribers
 // are closed outside subMu so a stuck blocking send can never wedge the
 // manager-wide lock.
-func (m *TaskManager) cleanSubscribers(taskID string) {
+func (m *TaskManager) cleanSubscribers(tenant, taskID string) {
+	key := newScopedID(tenant, taskID)
 	m.subMu.Lock()
-	subs, exists := m.subscribers[taskID]
+	subs, exists := m.subscribers[key]
 	if !exists {
 		m.subMu.Unlock()
 		return
 	}
-	delete(m.subscribers, taskID)
+	delete(m.subscribers, key)
 	m.subMu.Unlock()
 
 	for _, sub := range subs {
@@ -1295,18 +1417,19 @@ func (m *TaskManager) cleanSubscribers(taskID string) {
 }
 
 // notifySubscribers notifies all subscribers of a task.
-func (m *TaskManager) notifySubscribers(taskID string, event protocol.StreamResponse) {
+func (m *TaskManager) notifySubscribers(tenant, taskID string, event protocol.StreamResponse) {
 	// Deliver push notifications independently of live SSE subscribers: reaching
 	// clients that are not currently streaming is the whole point of push.
-	m.dispatchPush(taskID, event)
-	m.notifyLiveSubscribers(taskID, event)
+	m.dispatchPush(tenant, taskID, event)
+	m.notifyLiveSubscribers(tenant, taskID, event)
 }
 
 // notifyLiveSubscribers fans out to process-local task subscribers without
 // dispatching push a second time.
-func (m *TaskManager) notifyLiveSubscribers(taskID string, event protocol.StreamResponse) {
+func (m *TaskManager) notifyLiveSubscribers(tenant, taskID string, event protocol.StreamResponse) {
+	key := newScopedID(tenant, taskID)
 	m.subMu.RLock()
-	subs, exists := m.subscribers[taskID]
+	subs, exists := m.subscribers[key]
 	if !exists || len(subs) == 0 {
 		m.subMu.RUnlock()
 		return
@@ -1336,7 +1459,7 @@ func (m *TaskManager) notifyLiveSubscribers(taskID string, event protocol.Stream
 
 	// Clean up failed or closed subscribers.
 	if len(failedSubscribers) > 0 {
-		m.cleanupFailedSubscribers(taskID, failedSubscribers)
+		m.cleanupFailedSubscribers(tenant, taskID, failedSubscribers)
 	}
 }
 
@@ -1344,10 +1467,14 @@ func (m *TaskManager) notifyLiveSubscribers(taskID string, event protocol.Stream
 // and closes them. Removed subscribers are closed outside subMu so a stuck
 // blocking send can never wedge the manager-wide lock; an evicted subscriber
 // must be closed or its consumer's range loop never ends.
-func (m *TaskManager) cleanupFailedSubscribers(taskID string, failedSubscribers []*taskSubscriber) {
+func (m *TaskManager) cleanupFailedSubscribers(
+	tenant, taskID string,
+	failedSubscribers []*taskSubscriber,
+) {
+	key := newScopedID(tenant, taskID)
 	m.subMu.Lock()
 
-	subs, exists := m.subscribers[taskID]
+	subs, exists := m.subscribers[key]
 	if !exists {
 		m.subMu.Unlock()
 		return
@@ -1372,12 +1499,12 @@ func (m *TaskManager) cleanupFailedSubscribers(taskID string, failedSubscribers 
 	}
 
 	if len(removedSubs) > 0 {
-		m.subscribers[taskID] = filteredSubs
+		m.subscribers[key] = filteredSubs
 		log.Debugf("Removed %d failed subscribers for task %s", len(removedSubs), taskID)
 
 		// If there are no subscribers left, delete the entire entry.
 		if len(filteredSubs) == 0 {
-			delete(m.subscribers, taskID)
+			delete(m.subscribers, key)
 		}
 	}
 	m.subMu.Unlock()
@@ -1424,7 +1551,7 @@ func (m *TaskManager) Close() error {
 		for _, subscribers := range m.subscribers {
 			subsToClose = append(subsToClose, subscribers...)
 		}
-		m.subscribers = make(map[string][]*taskSubscriber)
+		m.subscribers = make(map[scopedID][]*taskSubscriber)
 		m.subMu.Unlock()
 		for _, sub := range subsToClose {
 			sub.Close()

--- a/taskmanager/redis/redis_manager_test.go
+++ b/taskmanager/redis/redis_manager_test.go
@@ -100,7 +100,7 @@ func storedTask(t *testing.T, m *TaskManager, id, contextID string, state protoc
 			Timestamp: time.Now().UTC().Format(time.RFC3339),
 		},
 	}
-	if err := m.storeTask(context.Background(), task); err != nil {
+	if err := m.storeTask(context.Background(), "", task); err != nil {
 		t.Fatalf("storeTask failed: %v", err)
 	}
 	return task
@@ -110,7 +110,7 @@ func waitTaskState(t *testing.T, m *TaskManager, taskID string, state protocol.T
 	t.Helper()
 	deadline := time.Now().Add(3 * time.Second)
 	for time.Now().Before(deadline) {
-		task, err := m.getTaskInternal(context.Background(), taskID)
+		task, err := m.getTaskInternal(context.Background(), "", taskID)
 		if err == nil && task.Status.State == state {
 			return
 		}
@@ -173,7 +173,7 @@ func TestOnSendMessagePureMessage(t *testing.T) {
 	}
 
 	// Both the user message and the reply live in the conversation.
-	history, err := m.getConversationHistory(context.Background(), "ctx-pure", 10)
+	history, err := m.getConversationHistory(context.Background(), "", "ctx-pure", 10)
 	if err != nil {
 		t.Fatalf("getConversationHistory failed: %v", err)
 	}
@@ -262,7 +262,7 @@ func TestOnSendMessageHistoryLength(t *testing.T) {
 	for _, text := range []string{"m1", "m2"} {
 		msg := protocol.NewMessage(protocol.MessageRoleUser, []*protocol.Part{protocol.NewTextPart(text)})
 		msg.ContextID = &contextID
-		m.storeMessage(context.Background(), msg)
+		m.storeMessage(context.Background(), "", msg)
 	}
 
 	send := func(text string, historyLength *int) *protocol.Task {
@@ -699,7 +699,7 @@ func TestOnSendMessageStreamOrderAndPersistence(t *testing.T) {
 	if taskID == "" || statusUpdate.ContextID != "ctx-stream" {
 		t.Fatalf("frame 1: expected stamped IDs, got %+v", statusUpdate)
 	}
-	stored, err := m.getTaskInternal(context.Background(), taskID)
+	stored, err := m.getTaskInternal(context.Background(), "", taskID)
 	if err != nil {
 		t.Fatalf("task not persisted before broadcast: %v", err)
 	}
@@ -714,7 +714,7 @@ func TestOnSendMessageStreamOrderAndPersistence(t *testing.T) {
 	if artifactUpdate == nil || artifactUpdate.Artifact.ArtifactID != "artifact-1" {
 		t.Fatalf("frame 2: expected artifact update, got %+v", frame2.Result)
 	}
-	stored, err = m.getTaskInternal(context.Background(), taskID)
+	stored, err = m.getTaskInternal(context.Background(), "", taskID)
 	if err != nil {
 		t.Fatalf("getTaskInternal failed: %v", err)
 	}
@@ -729,7 +729,7 @@ func TestOnSendMessageStreamOrderAndPersistence(t *testing.T) {
 	if statusUpdate == nil || statusUpdate.Status.State != protocol.TaskStateCompleted {
 		t.Fatalf("frame 3: expected completed status, got %+v", frame3.Result)
 	}
-	stored, err = m.getTaskInternal(context.Background(), taskID)
+	stored, err = m.getTaskInternal(context.Background(), "", taskID)
 	if err != nil {
 		t.Fatalf("getTaskInternal failed: %v", err)
 	}
@@ -995,7 +995,7 @@ func TestOnCancelTaskWithoutLiveExecution(t *testing.T) {
 		t.Error("expected subscriber closed after terminal broadcast")
 	}
 
-	stored, err := m.getTaskInternal(context.Background(), "task-idle")
+	stored, err := m.getTaskInternal(context.Background(), "", "task-idle")
 	if err != nil {
 		t.Fatalf("getTaskInternal failed: %v", err)
 	}
@@ -1157,7 +1157,7 @@ func TestOnGetTaskHistoryLength(t *testing.T) {
 	for _, text := range []string{"m1", "m2", "m3"} {
 		msg := protocol.NewMessage(protocol.MessageRoleUser, []*protocol.Part{protocol.NewTextPart(text)})
 		msg.ContextID = &contextID
-		m.storeMessage(context.Background(), msg)
+		m.storeMessage(context.Background(), "", msg)
 	}
 	storedTask(t, m, "task-hist", contextID, protocol.TaskStateWorking)
 
@@ -1359,7 +1359,7 @@ func TestTaskWriteRefreshesPushConfigTTL(t *testing.T) {
 	if got := mr.TTL(pushNotificationPrefix + task.ID); got != 20*time.Minute {
 		t.Fatalf("push config TTL before refresh = %v, want 20m", got)
 	}
-	if err := m.storeTask(context.Background(), task); err != nil {
+	if err := m.storeTask(context.Background(), "", task); err != nil {
 		t.Fatal(err)
 	}
 	if got := mr.TTL(pushNotificationPrefix + task.ID); got != expire {
@@ -1442,12 +1442,12 @@ func TestStoreMessage_IdempotentByMessageID(t *testing.T) {
 	for i := 0; i < writers; i++ {
 		go func() {
 			defer wg.Done()
-			m.storeMessage(ctx, msg)
+			m.storeMessage(ctx, "", msg)
 		}()
 	}
 	wg.Wait()
 
-	hist, err := m.getConversationHistory(ctx, cid, 100)
+	hist, err := m.getConversationHistory(ctx, "", cid, 100)
 	if err != nil {
 		t.Fatalf("getConversationHistory: %v", err)
 	}

--- a/taskmanager/redis/redis_push_dispatch_test.go
+++ b/taskmanager/redis/redis_push_dispatch_test.go
@@ -286,13 +286,13 @@ func TestRedisPushQueuedGenerationInvalidatedAcrossManagers(t *testing.T) {
 
 	// Keep the first delivery in flight and leave the old-generation event in
 	// A's process-local queue.
-	managerA.dispatchPush(task.ID, response(protocol.TaskStateWorking))
+	managerA.dispatchPush("", task.ID, response(protocol.TaskStateWorking))
 	select {
 	case <-started:
 	case <-time.After(2 * time.Second):
 		t.Fatal("first push delivery did not start")
 	}
-	managerA.dispatchPush(task.ID, response(protocol.TaskStateInputRequired))
+	managerA.dispatchPush("", task.ID, response(protocol.TaskStateInputRequired))
 
 	// B deletes and recreates the same config ID. Existence and ID checks alone
 	// would revive the queued event; only the shared Redis generation rejects it.
@@ -307,7 +307,7 @@ func TestRedisPushQueuedGenerationInvalidatedAcrossManagers(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("manager B recreate: %v", err)
 	}
-	managerA.dispatchPush(task.ID, response(protocol.TaskStateCompleted))
+	managerA.dispatchPush("", task.ID, response(protocol.TaskStateCompleted))
 	releaseFirst()
 
 	deadline := time.Now().Add(2 * time.Second)
@@ -379,13 +379,13 @@ func TestRedisPushBackpressureSerializesSuspendContinuation(t *testing.T) { //no
 			Status: protocol.TaskStatus{State: state},
 		})
 	}
-	manager.dispatchPush(prefill.ID, prefillResponse(protocol.TaskStateWorking))
+	manager.dispatchPush("", prefill.ID, prefillResponse(protocol.TaskStateWorking))
 	select {
 	case <-started:
 	case <-time.After(2 * time.Second):
 		t.Fatal("prefill push delivery did not start")
 	}
-	manager.dispatchPush(prefill.ID, prefillResponse(protocol.TaskStateSubmitted))
+	manager.dispatchPush("", prefill.ID, prefillResponse(protocol.TaskStateSubmitted))
 
 	params := sendParams("start", "ctx-push-suspend")
 	params.Configuration = &protocol.SendMessageConfiguration{PushConfig: &protocol.TaskPushNotificationConfig{
@@ -407,7 +407,7 @@ func TestRedisPushBackpressureSerializesSuspendContinuation(t *testing.T) { //no
 	// Once INPUT_REQUIRED is visible in Redis, the yield barrier must already
 	// exist. This ordering makes a GetTask-driven continuation safe.
 	manager.cancelMu.RLock()
-	live := manager.executions[taskID]
+	live := manager.executions[newScopedID("", taskID)]
 	yielding := live != nil && live.yieldDone != nil
 	manager.cancelMu.RUnlock()
 	if !yielding {

--- a/taskmanager/redis/redis_regression_test.go
+++ b/taskmanager/redis/redis_regression_test.go
@@ -41,7 +41,7 @@ func pollTaskState(t *testing.T, m *TaskManager, taskID string, want protocol.Ta
 	deadline := time.Now().Add(2 * time.Second)
 	var last protocol.TaskState
 	for time.Now().Before(deadline) {
-		if task, err := m.getTaskInternal(context.Background(), taskID); err == nil {
+		if task, err := m.getTaskInternal(context.Background(), "", taskID); err == nil {
 			last = task.Status.State
 			if last == want {
 				return
@@ -100,7 +100,7 @@ func TestTerminal_NotResurrectedByYieldedRound(t *testing.T) {
 	openGate()
 	deadline := time.Now().Add(100 * time.Millisecond)
 	for time.Now().Before(deadline) {
-		stored, err := manager.getTaskInternal(context.Background(), taskID)
+		stored, err := manager.getTaskInternal(context.Background(), "", taskID)
 		if err != nil {
 			t.Fatalf("getTaskInternal failed: %v", err)
 		}
@@ -201,21 +201,21 @@ func TestRequestExecutionCancelReturnsWinningYieldHandoff(t *testing.T) {
 	const taskID = "task-yield-wins-cancel-race"
 	var canceled atomic.Bool
 	live := &liveExecution{cancel: func() { canceled.Store(true) }}
-	if err := manager.registerExecution(context.Background(), taskID, live); err != nil {
+	if err := manager.registerExecution(context.Background(), "", taskID, live); err != nil {
 		t.Fatalf("registerExecution: %v", err)
 	}
 	released := false
 	defer func() {
 		if !released {
-			manager.releaseExecution(taskID, live)
+			manager.releaseExecution("", taskID, live)
 		}
 	}()
 
-	if !manager.beginExecutionYield(taskID, live) {
+	if !manager.beginExecutionYield("", taskID, live) {
 		t.Fatal("beginExecutionYield did not claim the live execution")
 	}
 	wantHandoff := live.yieldDone
-	handoff, accepted := manager.requestExecutionCancel(taskID, live)
+	handoff, accepted := manager.requestExecutionCancel("", taskID, live)
 	if accepted {
 		t.Fatal("cancellation was accepted after yield won")
 	}
@@ -226,7 +226,7 @@ func TestRequestExecutionCancelReturnsWinningYieldHandoff(t *testing.T) {
 		t.Fatal("yield-winning execution was canceled")
 	}
 
-	manager.releaseExecution(taskID, live)
+	manager.releaseExecution("", taskID, live)
 	released = true
 	select {
 	case <-handoff:
@@ -377,7 +377,7 @@ func TestResubscribe_ClientDisconnectDropsSubscriber(t *testing.T) {
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		manager.subMu.RLock()
-		left := len(manager.subscribers[taskID])
+		left := len(manager.subscribers[newScopedID("", taskID)])
 		manager.subMu.RUnlock()
 		if left == 0 {
 			return

--- a/taskmanager/redis/tenant_isolation_test.go
+++ b/taskmanager/redis/tenant_isolation_test.go
@@ -1,0 +1,207 @@
+// Tencent is pleased to support the open source community by making trpc-a2a-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-a2a-go is licensed under the Apache License Version 2.0.
+
+package redis
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	redisc "github.com/redis/go-redis/v9"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/push"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
+)
+
+func TestTaskManagerTenantDataIsolationAndTaskIndex(t *testing.T) {
+	manager, mr := setupTest(t, scriptedExecutor())
+	ctx := context.Background()
+	const taskID = "shared-task"
+	const contextID = "shared-context"
+	const messageID = "shared-message"
+
+	if err := manager.storeTask(ctx, "tenant-a", &protocol.Task{
+		ID: taskID, ContextID: contextID, Status: protocol.TaskStatus{State: protocol.TaskStateWorking},
+	}); err != nil {
+		t.Fatalf("store tenant-a task: %v", err)
+	}
+	if err := manager.storeTask(ctx, "tenant-b", &protocol.Task{
+		ID: taskID, ContextID: contextID, Status: protocol.TaskStatus{State: protocol.TaskStateInputRequired},
+	}); err != nil {
+		t.Fatalf("store tenant-b task: %v", err)
+	}
+
+	contextA := contextID
+	manager.storeMessage(ctx, "tenant-a", protocol.Message{
+		MessageID: messageID, ContextID: &contextA, Role: protocol.MessageRoleUser,
+	})
+	contextB := contextID
+	manager.storeMessage(ctx, "tenant-b", protocol.Message{
+		MessageID: messageID, ContextID: &contextB, Role: protocol.MessageRoleAgent,
+	})
+
+	taskA, err := manager.OnGetTask(ctx, protocol.TaskQueryParams{Tenant: "tenant-a", ID: taskID})
+	if err != nil {
+		t.Fatalf("get tenant-a task: %v", err)
+	}
+	if taskA.Status.State != protocol.TaskStateWorking || len(taskA.History) != 1 ||
+		taskA.History[0].Role != protocol.MessageRoleUser {
+		t.Fatalf("tenant-a received foreign data: %+v", taskA)
+	}
+	taskB, err := manager.OnGetTask(ctx, protocol.TaskQueryParams{Tenant: "tenant-b", ID: taskID})
+	if err != nil {
+		t.Fatalf("get tenant-b task: %v", err)
+	}
+	if taskB.Status.State != protocol.TaskStateInputRequired || len(taskB.History) != 1 ||
+		taskB.History[0].Role != protocol.MessageRoleAgent {
+		t.Fatalf("tenant-b received foreign data: %+v", taskB)
+	}
+
+	if _, err := manager.OnGetTask(ctx, protocol.TaskQueryParams{Tenant: "tenant-c", ID: taskID}); !errors.Is(err, taskmanager.ErrTaskNotFoundSentinel) {
+		t.Fatalf("tenant-c must not see another tenant's task, got %v", err)
+	}
+	listA, err := manager.OnListTasks(ctx, protocol.ListTasksParams{Tenant: "tenant-a"})
+	if err != nil || len(listA.Tasks) != 1 || listA.Tasks[0].Status.State != protocol.TaskStateWorking {
+		t.Fatalf("tenant-a list leaked another tenant: result=%+v err=%v", listA, err)
+	}
+
+	indexed, err := manager.client.ZRange(ctx, taskIndexKey("tenant-a"), 0, -1).Result()
+	if err != nil || len(indexed) != 1 || indexed[0] != taskID {
+		t.Fatalf("tenant task index = %v, err=%v", indexed, err)
+	}
+	if err := manager.client.ZAdd(ctx, taskIndexKey("tenant-a"), redisc.Z{Member: "expired-task"}).Err(); err != nil {
+		t.Fatalf("seed stale index member: %v", err)
+	}
+	if _, err := manager.OnListTasks(ctx, protocol.ListTasksParams{Tenant: "tenant-a"}); err != nil {
+		t.Fatalf("list with stale member: %v", err)
+	}
+	if _, err := manager.client.ZScore(ctx, taskIndexKey("tenant-a"), "expired-task").Result(); !errors.Is(err, redisc.Nil) {
+		t.Fatalf("stale task index member was not pruned: %v", err)
+	}
+
+	// An unindexed legacy-looking task key proves ListTasks no longer discovers
+	// data through SCAN. Existing deployments must drain or explicitly migrate
+	// pre-index tasks before switching list traffic.
+	mr.Set(taskPrefix+"unindexed", `{"id":"unindexed"}`)
+	defaultList, err := manager.OnListTasks(ctx, protocol.ListTasksParams{})
+	if err != nil || len(defaultList.Tasks) != 0 {
+		t.Fatalf("ListTasks unexpectedly scanned unindexed keys: result=%+v err=%v", defaultList, err)
+	}
+
+	if _, err := manager.OnCancelTask(ctx, protocol.TaskIDParams{Tenant: "tenant-a", ID: taskID}); err != nil {
+		t.Fatalf("cancel tenant-a task: %v", err)
+	}
+	taskB, err = manager.OnGetTask(ctx, protocol.TaskQueryParams{Tenant: "tenant-b", ID: taskID})
+	if err != nil || taskB.Status.State != protocol.TaskStateInputRequired {
+		t.Fatalf("canceling tenant-a changed tenant-b: task=%+v err=%v", taskB, err)
+	}
+
+	if _, err := manager.storePushConfig(ctx, protocol.TaskPushNotificationConfig{
+		Tenant: "tenant-a", TaskID: taskID, ID: "shared-config", URL: "https://a.example/push",
+	}); err != nil {
+		t.Fatalf("store tenant-a push config: %v", err)
+	}
+	if _, err := manager.storePushConfig(ctx, protocol.TaskPushNotificationConfig{
+		Tenant: "tenant-b", TaskID: taskID, ID: "shared-config", URL: "https://b.example/push",
+	}); err != nil {
+		t.Fatalf("store tenant-b push config: %v", err)
+	}
+	configsA, err := manager.readPushConfigs(ctx, "tenant-a", taskID)
+	if err != nil || len(configsA) != 1 || configsA[0].URL != "https://a.example/push" {
+		t.Fatalf("tenant-a push config leaked: configs=%+v err=%v", configsA, err)
+	}
+
+	if taskKey("", taskID) != taskPrefix+taskID {
+		t.Fatalf("empty tenant must preserve legacy Redis keys, got %q", taskKey("", taskID))
+	}
+	if taskKey("tenant-a", taskID) == taskKey("tenant-b", taskID) {
+		t.Fatal("different tenants produced the same Redis task key")
+	}
+	if got, want := streamKey("tenant-a", taskID), "stream:{"+taskKey("tenant-a", taskID)+"}"; got != want {
+		t.Fatalf("tenant stream hash tag = %q, want %q", got, want)
+	}
+
+	subscriberA := newTaskSubscriber(taskID, 1, false)
+	manager.subMu.Lock()
+	manager.subscribers[newScopedID("tenant-a", taskID)] = []*taskSubscriber{subscriberA}
+	manager.subMu.Unlock()
+	manager.notifySubscribers("tenant-b", taskID, protocol.NewStreamResponseTask(taskB))
+	select {
+	case <-subscriberA.Channel():
+		t.Fatal("tenant-b event reached tenant-a subscriber")
+	default:
+	}
+
+	liveA := &liveExecution{cancel: func() {}}
+	liveB := &liveExecution{cancel: func() {}}
+	if err := manager.registerExecution(ctx, "tenant-a", taskID, liveA); err != nil {
+		t.Fatalf("register tenant-a execution: %v", err)
+	}
+	if err := manager.registerExecution(ctx, "tenant-b", taskID, liveB); err != nil {
+		t.Fatalf("register tenant-b execution with the same task ID: %v", err)
+	}
+	manager.releaseExecution("tenant-a", taskID, liveA)
+	manager.releaseExecution("tenant-b", taskID, liveB)
+}
+
+func TestTaskManagerProcessorCannotMutateTenantScope(t *testing.T) {
+	manager, _ := setupTest(t, executorFunc(func(
+		_ context.Context,
+		ec *taskmanager.ExecContext,
+	) (<-chan protocol.StreamEvent, error) {
+		ec.Tenant = "mutated-tenant"
+		ec.TaskID = "mutated-task"
+		ec.ContextID = "mutated-context"
+		if ec.PushConfig != nil {
+			ec.PushConfig.Tenant = "mutated-tenant"
+			ec.PushConfig.TaskID = "mutated-task"
+			if ec.PushConfig.Authentication != nil {
+				ec.PushConfig.Authentication.Credentials = "mutated-credentials"
+			}
+		}
+		events := make(chan protocol.StreamEvent, 1)
+		events <- statusEvent(protocol.TaskStateCompleted, nil)
+		close(events)
+		return events, nil
+	}), WithPushNotifications(push.Config{ManualDelivery: true}))
+
+	message := protocol.NewMessage(protocol.MessageRoleUser, []*protocol.Part{protocol.NewTextPart("hello")})
+	result, err := manager.OnSendMessage(context.Background(), protocol.SendMessageParams{
+		Tenant: "tenant-a",
+		Configuration: &protocol.SendMessageConfiguration{PushConfig: &protocol.TaskPushNotificationConfig{
+			URL:            "https://example.com/push",
+			Authentication: &protocol.AuthenticationInfo{Scheme: "Bearer", Credentials: "original-credentials"},
+		}},
+		Message: message,
+	})
+	if err != nil {
+		t.Fatalf("send message: %v", err)
+	}
+	task := result.GetTask()
+	if task == nil || task.ID == "mutated-task" || task.ContextID == "mutated-context" {
+		t.Fatalf("processor mutation changed framework scope: %+v", task)
+	}
+	if _, err := manager.OnGetTask(context.Background(), protocol.TaskQueryParams{
+		Tenant: "tenant-a", ID: task.ID,
+	}); err != nil {
+		t.Fatalf("task was not stored in the request tenant: %v", err)
+	}
+	if _, err := manager.OnGetTask(context.Background(), protocol.TaskQueryParams{
+		Tenant: "mutated-tenant", ID: task.ID,
+	}); !errors.Is(err, taskmanager.ErrTaskNotFoundSentinel) {
+		t.Fatalf("processor moved task into another tenant: %v", err)
+	}
+	configs, err := manager.readPushConfigs(context.Background(), "tenant-a", task.ID)
+	if err != nil || len(configs) != 1 || configs[0].TaskID != task.ID || configs[0].Authentication == nil ||
+		configs[0].Authentication.Credentials != "original-credentials" {
+		t.Fatalf("processor mutation changed stored push scope: configs=%+v err=%v", configs, err)
+	}
+	configs, err = manager.readPushConfigs(context.Background(), "mutated-tenant", "mutated-task")
+	if err != nil || len(configs) != 0 {
+		t.Fatalf("processor moved push config into another tenant: configs=%+v err=%v", configs, err)
+	}
+}


### PR DESCRIPTION
## Summary

- isolate memory and Redis task-manager data by tenant without changing the protocol Task shape
- scope messages, conversations, tasks, push configurations, subscribers, executions, and cross-node streams by tenant
- replace Redis `SCAN task:*` listing with a tenant-local sorted-set index and pipelined task loads
- prevent a MessageProcessor from mutating the framework-owned tenant/task scope through its ExecContext or inline push configuration snapshot

## Why

Tenant is already part of the v2 request scope, but the storage and process-local runtime maps were keyed only by task, context, or message ID. Identical IDs across tenants could therefore collide, and `ListTasks` could not enforce tenant isolation. Redis task listing also depended on a keyspace-wide `SCAN`.

The processor instance remains shared. This change isolates persisted data and task-local runtime state; binding a caller to an authorized tenant remains the server authentication and authorization layer's responsibility.

## Scope

This PR completes tenant isolation for the current retaining task managers. The broader high-cardinality `ListTasks` storage redesign, including versioned keys, compact catalogs, fixed partitioning, and cursor-native pagination, is intentionally deferred to a separate PR.

## Validation

- `go test ./...`
- `go test ./...` in `taskmanager/redis`
- `go test -race ./taskmanager/memory`
- `go test -race ./...` in `taskmanager/redis`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Data Isolation**
  * Task Manager data is now isolated by tenant across memory and Redis storage.
  * Prevents cross-tenant access to tasks, messages, conversations, executions, subscriptions, notifications, and push configurations.
  * Concurrent tasks with identical IDs can operate independently across tenants.

* **Reliability**
  * Improved tenant-aware cancellation, cleanup, history, notifications, and cross-node event handling.
  * Added coverage for tenant isolation, legacy compatibility, and stale task index cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->