### PR TITLE
trpc-a2a-go: close A2A v1.0 conformance gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### A2A v1.0 conformance fixes
+
+- **`securityRequirements` now uses the specified wire shape.** `SecurityRequirement.schemes` is `map<string, StringList>` in the proto, so scopes serialize as `{"schemes": {"google": {"list": ["openid"]}}}`. The previous form omitted the `StringList` level, which meant the specification's own sample Agent Card failed to parse and every card this SDK served declared its requirements in a shape no conformant peer could read. Cards written by earlier v2 prereleases (bare scope arrays) and v0 cards still parse.
+- `AgentSkill.securityRequirements` is now modelled, instead of being silently dropped when a card is read and re-served.
+- `ListTasks` returns tasks sorted by status timestamp descending as spec §3.1.4 requires, with the task ID breaking ties, and uses an opaque keyset cursor instead of an offset. Its required pagination fields are now always present, and out-of-range `pageSize` or negative `historyLength` values are rejected.
+- `GetExtendedAgentCard` distinguishes an unsupported capability from a declared-but-unconfigured extended card (spec §3.3.4, §13.3).
+- The JSON-RPC and HTTP+JSON bindings validate the `A2A-Version` service parameter, accepting it as a header or as a request parameter (spec §3.6.1), ignoring patch versions during negotiation, interpreting an absent value as 0.3, and answering `VersionNotSupportedError` for a version the interface does not speak.
+- `WithTenantCard` no longer stamps its tenant into the caller's Agent Card, so registering one card value for several tenants gives each its own tenant.
+
 ### Client endpoint handling
 
 - **The v2 JSON-RPC client now uses the URL passed to `NewA2AClient` as the exact endpoint instead of automatically appending `/`.** Root URLs and explicitly slash-terminated endpoints are unchanged; callers that require a trailing slash must now include it. HTTP+JSON operation-path construction and relative Agent Card discovery retain their path-joining behavior.

--- a/client/http_json_e2e_test.go
+++ b/client/http_json_e2e_test.go
@@ -65,7 +65,12 @@ func newHTTPJSONFixture(t *testing.T) (rest, rpc *A2AClient) {
 		Skills:             []protocol.AgentSkill{},
 	}
 	a2aServer, err := server.NewA2AServer(manager,
-		server.WithAgentCard(card), server.WithHTTPJSONEndpoint("/"))
+		server.WithAgentCard(card),
+		server.WithHTTPJSONEndpoint("/"),
+		server.WithAuthenticatedExtendedCardHandler(func(_ context.Context, base server.AgentCard) (server.AgentCard, error) {
+			return base, nil
+		}),
+	)
 	require.NoError(t, err)
 	testServer := httptest.NewServer(a2aServer.Handler())
 	t.Cleanup(testServer.Close)

--- a/protocol/agentcard.go
+++ b/protocol/agentcard.go
@@ -141,6 +141,9 @@ type AgentSkill struct {
 	Examples    []string `json:"examples,omitempty"`
 	InputModes  []string `json:"inputModes,omitempty"`
 	OutputModes []string `json:"outputModes,omitempty"`
+	// SecurityRequirements are the schemes needed for this skill specifically,
+	// overriding the card-level requirements.
+	SecurityRequirements SecurityRequirements `json:"securityRequirements,omitempty"`
 }
 
 // AgentExtension represents an agent extension.

--- a/protocol/security.go
+++ b/protocol/security.go
@@ -7,6 +7,7 @@
 package protocol
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -216,53 +217,126 @@ func (s *SecurityScheme) UnmarshalJSON(data []byte) error {
 // SecurityRequirements is a list of alternative security requirement sets. Each
 // entry maps a security-scheme name to the required scopes.
 //
-// The JSON wire form follows v1.0: each entry is wrapped as
-// {"schemes": {"name": ["scope"]}}. UnmarshalJSON also accepts the v0 flat form
-// ({"name": ["scope"]}). The deprecated v0 "security" key is mirrored separately
-// on AgentCard (see AgentCard.Security and NormalizeSecurity).
+// The JSON wire form is the ProtoJSON encoding of
+// SecurityRequirement.schemes (map<string, StringList>): each entry is
+// {"schemes": {"name": {"list": ["scope"]}}}. UnmarshalJSON also accepts the
+// scopes as a bare array — the shape earlier v2 prereleases emitted — and the
+// v0 flat form ({"name": ["scope"]}). The deprecated v0 "security" key is
+// mirrored separately on AgentCard (see AgentCard.Security and
+// NormalizeSecurity).
 type SecurityRequirements []map[string][]string
 
-type securityRequirementWire struct {
-	Schemes map[string][]string `json:"schemes"`
+// stringListWire is the ProtoJSON form of the StringList message that wraps a
+// requirement's scopes. It also decodes a bare array so cards written by
+// earlier v2 prereleases still parse.
+type stringListWire struct {
+	List []string `json:"list"`
 }
 
-// MarshalJSON emits the v1.0 wrapped form: [{"schemes": {...}}, ...].
+func (l stringListWire) MarshalJSON() ([]byte, error) {
+	list := l.List
+	if list == nil {
+		list = []string{}
+	}
+	return json.Marshal(struct {
+		List []string `json:"list"`
+	}{List: list})
+}
+
+func (l *stringListWire) UnmarshalJSON(data []byte) error {
+	var wrapped map[string]json.RawMessage
+	if err := json.Unmarshal(data, &wrapped); err == nil && wrapped != nil {
+		if len(wrapped) == 0 {
+			l.List = nil
+			return nil
+		}
+		list, ok := wrapped["list"]
+		if !ok {
+			// StringList.list is not required. After discarding unknown fields,
+			// an object without it is equivalent to an empty StringList.
+			l.List = nil
+			return nil
+		}
+		if err := json.Unmarshal(list, &l.List); err != nil {
+			return fmt.Errorf("invalid security requirement scopes: %w", err)
+		}
+		return nil
+	}
+	var bare []string
+	if err := json.Unmarshal(data, &bare); err != nil {
+		return fmt.Errorf("invalid security requirement scopes: %w", err)
+	}
+	l.List = bare
+	return nil
+}
+
+type securityRequirementWire struct {
+	Schemes map[string]stringListWire `json:"schemes"`
+}
+
+// MarshalJSON emits the v1.0 wrapped form: [{"schemes": {"name": {"list": [...]}}}, ...].
 func (r SecurityRequirements) MarshalJSON() ([]byte, error) {
 	out := make([]securityRequirementWire, 0, len(r))
 	for _, req := range r {
-		out = append(out, securityRequirementWire{Schemes: req})
+		schemes := make(map[string]stringListWire, len(req))
+		for name, scopes := range req {
+			schemes[name] = stringListWire{List: scopes}
+		}
+		out = append(out, securityRequirementWire{Schemes: schemes})
 	}
 	return json.Marshal(out)
 }
 
-// UnmarshalJSON accepts both the v1.0 wrapped form and the v0 flat form.
+// UnmarshalJSON accepts the v1.0 wrapped form, the wrapped form with bare
+// arrays emitted by earlier v2 prereleases, and the v0 flat form. Each entry
+// is decoded independently so a mixed compatibility document cannot silently
+// lose one of its security alternatives.
 func (r *SecurityRequirements) UnmarshalJSON(data []byte) error {
-	var wrapped []securityRequirementWire
-	if err := json.Unmarshal(data, &wrapped); err == nil && hasSchemesKey(wrapped) {
-		result := make(SecurityRequirements, 0, len(wrapped))
-		for _, w := range wrapped {
-			result = append(result, w.Schemes)
-		}
-		*r = result
-		return nil
-	}
-	// Fall back to the v0 flat form.
-	var flat []map[string][]string
-	if err := json.Unmarshal(data, &flat); err != nil {
+	var entries []json.RawMessage
+	if err := json.Unmarshal(data, &entries); err != nil {
 		return fmt.Errorf("invalid security requirements: %w", err)
 	}
-	*r = flat
-	return nil
-}
-
-// hasSchemesKey reports whether at least one entry decoded a non-nil schemes
-// map, distinguishing the wrapped form from the flat form (whose objects have
-// no "schemes" key and therefore decode to a nil map).
-func hasSchemesKey(wrapped []securityRequirementWire) bool {
-	for _, w := range wrapped {
-		if w.Schemes != nil {
-			return true
+	result := make(SecurityRequirements, 0, len(entries))
+	for i, entry := range entries {
+		var object map[string]json.RawMessage
+		if err := json.Unmarshal(entry, &object); err != nil || object == nil {
+			return fmt.Errorf("invalid security requirement at index %d", i)
 		}
+		if schemesJSON, ok := object["schemes"]; ok {
+			trimmed := bytes.TrimSpace(schemesJSON)
+			var wrappedObject map[string]json.RawMessage
+			if string(trimmed) == "null" {
+				result = append(result, map[string][]string{})
+				continue
+			}
+			if err := json.Unmarshal(schemesJSON, &wrappedObject); err == nil && wrappedObject != nil {
+				var wire map[string]stringListWire
+				if err := json.Unmarshal(schemesJSON, &wire); err != nil {
+					return fmt.Errorf("invalid security requirement at index %d: %w", i, err)
+				}
+				schemes := make(map[string][]string, len(wire))
+				for name, scopes := range wire {
+					schemes[name] = scopes.List
+				}
+				result = append(result, schemes)
+				continue
+			}
+			if len(trimmed) == 0 || trimmed[0] != '[' {
+				return fmt.Errorf("invalid security requirement at index %d", i)
+			}
+		}
+		flat := make(map[string][]string)
+		for name, scopesJSON := range object {
+			var scopes []string
+			if err := json.Unmarshal(scopesJSON, &scopes); err != nil {
+				// Unknown v1 fields are discarded. Array-valued properties remain
+				// accepted as the legacy flat security-requirement form.
+				continue
+			}
+			flat[name] = scopes
+		}
+		result = append(result, flat)
 	}
-	return len(wrapped) == 0
+	*r = result
+	return nil
 }

--- a/protocol/security_test.go
+++ b/protocol/security_test.go
@@ -52,21 +52,95 @@ func TestSecurityScheme_UnmarshalBothShapes(t *testing.T) {
 }
 
 func TestSecurityRequirements_WrappedWire(t *testing.T) {
+	// SecurityRequirement.schemes is map<string, StringList> in the proto, so
+	// the ProtoJSON form wraps the scopes in {"list": [...]}.
 	r := SecurityRequirements{{"apiKey": {"read"}}}
 	b, err := json.Marshal(r)
 	require.NoError(t, err)
-	assert.JSONEq(t, `[{"schemes":{"apiKey":["read"]}}]`, string(b))
+	assert.JSONEq(t, `[{"schemes":{"apiKey":{"list":["read"]}}}]`, string(b))
 
-	// Unmarshal both shapes.
-	var fromV1 SecurityRequirements
-	require.NoError(t, json.Unmarshal([]byte(`[{"schemes":{"k":["s"]}}]`), &fromV1))
-	require.Len(t, fromV1, 1)
-	assert.Equal(t, []string{"s"}, fromV1[0]["k"])
+	// The spec's own sample Agent Card must round-trip.
+	var fromSpec SecurityRequirements
+	require.NoError(t, json.Unmarshal(
+		[]byte(`[{"schemes":{"google":{"list":["openid","profile","email"]}}}]`), &fromSpec))
+	require.Len(t, fromSpec, 1)
+	assert.Equal(t, []string{"openid", "profile", "email"}, fromSpec[0]["google"])
+
+	// Bare scopes inside "schemes" — what earlier v2 prereleases emitted.
+	var fromPrerelease SecurityRequirements
+	require.NoError(t, json.Unmarshal([]byte(`[{"schemes":{"k":["s"]}}]`), &fromPrerelease))
+	require.Len(t, fromPrerelease, 1)
+	assert.Equal(t, []string{"s"}, fromPrerelease[0]["k"])
 
 	var fromV0 SecurityRequirements
 	require.NoError(t, json.Unmarshal([]byte(`[{"k":["s"]}]`), &fromV0))
 	require.Len(t, fromV0, 1)
 	assert.Equal(t, []string{"s"}, fromV0[0]["k"])
+
+	// "schemes" is also a valid v0 scheme name. An array value distinguishes
+	// it from the v1.0 wrapper object.
+	var namedSchemes SecurityRequirements
+	require.NoError(t, json.Unmarshal(
+		[]byte(`[{"schemes":["read"]},{"schemes":[],"oauth":["openid"]}]`), &namedSchemes))
+	require.Len(t, namedSchemes, 2)
+	assert.Equal(t, []string{"read"}, namedSchemes[0]["schemes"])
+	assert.Empty(t, namedSchemes[1]["schemes"])
+	assert.Equal(t, []string{"openid"}, namedSchemes[1]["oauth"])
+}
+
+func TestSecurityRequirements_MixedCompatibilityWire(t *testing.T) {
+	var got SecurityRequirements
+	require.NoError(t, json.Unmarshal([]byte(`[
+		{"schemes":{"oauth":{"list":["openid"]}}},
+		{"schemes":{"apiKey":["read"]}},
+		{"mtls":[]}
+	]`), &got))
+	require.Len(t, got, 3)
+	assert.Equal(t, []string{"openid"}, got[0]["oauth"])
+	assert.Equal(t, []string{"read"}, got[1]["apiKey"])
+	assert.Empty(t, got[2]["mtls"])
+}
+
+func TestSecurityRequirements_IgnoresUnknownFields(t *testing.T) {
+	var got SecurityRequirements
+	require.NoError(t, json.Unmarshal([]byte(`[
+		{"schemes":{"oauth":{"list":["openid"],"future":true}},"future":"ignored"},
+		{"schemes":{"apiKey":["read"]},"future":"ignored"},
+		{"mtls":[]},
+		{"schemes":{"futureOnly":{"future":true}}},
+		{"future":true},
+		{"schemes":null,"future":true}
+	]`), &got))
+	require.Len(t, got, 6)
+	assert.Equal(t, []string{"openid"}, got[0]["oauth"])
+	assert.Equal(t, []string{"read"}, got[1]["apiKey"])
+	assert.Empty(t, got[2]["mtls"])
+	assert.Empty(t, got[3]["futureOnly"])
+	assert.Empty(t, got[4])
+	assert.Empty(t, got[5])
+}
+
+func TestSecurityRequirements_RejectsMalformedScopes(t *testing.T) {
+	for _, input := range []string{
+		`[{"schemes":{"oauth":{"list":"openid"}}}]`,
+		`[{"schemes":"oauth"}]`,
+	} {
+		var got SecurityRequirements
+		assert.Error(t, json.Unmarshal([]byte(input), &got), input)
+	}
+}
+
+func TestAgentSkill_SecurityRequirementsRoundTrip(t *testing.T) {
+	want := AgentSkill{
+		ID: "skill", Name: "Skill", Tags: []string{"test"},
+		SecurityRequirements: SecurityRequirements{{"oauth": {"openid"}}},
+	}
+	payload, err := json.Marshal(want)
+	require.NoError(t, err)
+	assert.Contains(t, string(payload), `"securityRequirements":[{"schemes":{"oauth":{"list":["openid"]}}}]`)
+	var got AgentSkill
+	require.NoError(t, json.Unmarshal(payload, &got))
+	assert.Equal(t, want.SecurityRequirements, got.SecurityRequirements)
 }
 
 func TestAgentInterface_DualKeyWire(t *testing.T) {

--- a/protocol/types.go
+++ b/protocol/types.go
@@ -332,9 +332,9 @@ type ListTasksParams struct {
 // ListTasksResult is the result of the ListTasks method.
 type ListTasksResult struct {
 	Tasks         []*Task `json:"tasks"`
-	NextPageToken string  `json:"nextPageToken,omitempty"`
-	PageSize      int     `json:"pageSize,omitempty"`
-	TotalSize     int     `json:"totalSize,omitempty"`
+	NextPageToken string  `json:"nextPageToken"`
+	PageSize      int     `json:"pageSize"`
+	TotalSize     int     `json:"totalSize"`
 }
 
 // ListTaskPushNotificationConfigsParams defines the parameters for the

--- a/protocol/types_test.go
+++ b/protocol/types_test.go
@@ -19,6 +19,17 @@ import (
 func boolPtr(b bool) *bool       { return &b }
 func stringPtr(s string) *string { return &s }
 
+func TestListTasksResultRequiredFields(t *testing.T) {
+	payload, err := json.Marshal(ListTasksResult{Tasks: []*Task{}})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"tasks": [],
+		"nextPageToken": "",
+		"pageSize": 0,
+		"totalSize": 0
+	}`, string(payload))
+}
+
 func TestTaskState(t *testing.T) {
 	tests := []struct {
 		state    TaskState

--- a/server/http_json.go
+++ b/server/http_json.go
@@ -220,12 +220,8 @@ func (s *A2AServer) handleHTTPJSON(w http.ResponseWriter, r *http.Request) {
 		s.writeHTTPJSONStatus(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "HTTP method not allowed")
 		return
 	}
-	requestedVersion := r.Header.Get("A2A-Version")
-	if requestedVersion == "" {
-		requestedVersion = r.URL.Query().Get("A2A-Version")
-	}
-	if requestedVersion != "" && requestedVersion != protocol.ProtocolVersionV1 {
-		s.writeHTTPJSONError(w, taskmanager.ErrVersionNotSupported(requestedVersion), route.taskID)
+	if versionErr := validateA2AVersion(r); versionErr != nil {
+		s.writeHTTPJSONError(w, versionErr, route.taskID)
 		return
 	}
 	if err := validateHTTPJSONContentType(r); err != nil {
@@ -660,10 +656,10 @@ func (s *A2AServer) resolveExtendedAgentCard(ctx context.Context, tenant string)
 		return AgentCard{}, taskmanager.ErrInvalidParams("unknown tenant")
 	}
 	if !baseCard.ExtendedAgentCardEnabled() {
-		return AgentCard{}, taskmanager.ErrAuthenticatedExtendedCardNotConfigured()
+		return AgentCard{}, taskmanager.ErrUnsupportedOperation(protocol.MethodAgentAuthenticatedExtendedCard)
 	}
 	if s.authenticatedCardHandler == nil {
-		return s.finalizePushCapability(baseCard), nil
+		return AgentCard{}, taskmanager.ErrAuthenticatedExtendedCardNotConfigured()
 	}
 	card, err := s.authenticatedCardHandler(ctx, baseCard)
 	if err != nil {

--- a/server/http_json_test.go
+++ b/server/http_json_test.go
@@ -8,8 +8,10 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"mime"
 	"net/http"
 	"net/http/httptest"
@@ -22,6 +24,12 @@ import (
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
 )
+
+func newV1HTTPRequest(method, target string, body io.Reader) *http.Request {
+	req := httptest.NewRequest(method, target, body)
+	req.Header.Set("A2A-Version", protocol.ProtocolVersionV1)
+	return req
+}
 
 func TestParseHTTPJSONRoute(t *testing.T) {
 	tests := []struct {
@@ -111,7 +119,7 @@ func TestHTTPJSONMediaTypesAndRawResponse(t *testing.T) {
 		protocol.MediaTypeJSON,
 	} {
 		t.Run(contentType, func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodPost, "/message:send", bytes.NewReader(body))
+			req := newV1HTTPRequest(http.MethodPost, "/message:send", bytes.NewReader(body))
 			req.Header.Set("Content-Type", contentType)
 			recorder := httptest.NewRecorder()
 			srv.Handler().ServeHTTP(recorder, req)
@@ -129,14 +137,14 @@ func TestHTTPJSONMediaTypesAndRawResponse(t *testing.T) {
 		})
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/message:send", bytes.NewReader(body))
+	req := newV1HTTPRequest(http.MethodPost, "/message:send", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/xml")
 	recorder := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(recorder, req)
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
 	assert.Contains(t, recorder.Body.String(), "CONTENT_TYPE_NOT_SUPPORTED")
 
-	req = httptest.NewRequest(http.MethodPost, "/message:send", bytes.NewReader(body))
+	req = newV1HTTPRequest(http.MethodPost, "/message:send", bytes.NewReader(body))
 	req.Header.Set("Content-Type", protocol.MediaTypeA2AJSON)
 	req.Header.Set("A2A-Version", "2.0")
 	recorder = httptest.NewRecorder()
@@ -144,12 +152,31 @@ func TestHTTPJSONMediaTypesAndRawResponse(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
 	assert.Contains(t, recorder.Body.String(), "VERSION_NOT_SUPPORTED")
 
-	req = httptest.NewRequest(http.MethodPost, "/message:send?A2A-Version=2.0", bytes.NewReader(body))
+	req = newV1HTTPRequest(http.MethodPost, "/message:send?A2A-Version=2.0", bytes.NewReader(body))
+	req.Header.Set("Content-Type", protocol.MediaTypeA2AJSON)
+	req.Header.Del("A2A-Version")
+	recorder = httptest.NewRecorder()
+	srv.Handler().ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "VERSION_NOT_SUPPORTED")
+
+	// An absent version is interpreted as 0.3, which this v1-only interface
+	// does not support.
+	req = httptest.NewRequest(http.MethodPost, "/message:send", bytes.NewReader(body))
 	req.Header.Set("Content-Type", protocol.MediaTypeA2AJSON)
 	recorder = httptest.NewRecorder()
 	srv.Handler().ServeHTTP(recorder, req)
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
 	assert.Contains(t, recorder.Body.String(), "VERSION_NOT_SUPPORTED")
+
+	for _, version := range []string{"1.0.0", "1.0.7"} {
+		req = newV1HTTPRequest(http.MethodPost, "/message:send", bytes.NewReader(body))
+		req.Header.Set("Content-Type", protocol.MediaTypeA2AJSON)
+		req.Header.Set("A2A-Version", version)
+		recorder = httptest.NewRecorder()
+		srv.Handler().ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusOK, recorder.Code, version)
+	}
 }
 
 func TestHTTPJSONTaskNotFoundError(t *testing.T) {
@@ -160,7 +187,7 @@ func TestHTTPJSONTaskNotFoundError(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	req := httptest.NewRequest(http.MethodGet, "/tasks/missing-task", nil)
+	req := newV1HTTPRequest(http.MethodGet, "/tasks/missing-task", nil)
 	recorder := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(recorder, req)
 
@@ -197,7 +224,7 @@ func TestHTTPJSONErrorBodyCarriesDetail(t *testing.T) {
 	}}
 	body, err := json.Marshal(params)
 	require.NoError(t, err)
-	req := httptest.NewRequest(http.MethodPost, "/message:send", bytes.NewReader(body))
+	req := newV1HTTPRequest(http.MethodPost, "/message:send", bytes.NewReader(body))
 	req.Header.Set("Content-Type", protocol.MediaTypeA2AJSON)
 	recorder := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(recorder, req)
@@ -214,7 +241,7 @@ func TestHTTPJSONErrorBodyCarriesDetail(t *testing.T) {
 	assert.Equal(t, "message role must be ROLE_USER", response.Error.Message)
 
 	// A tenant conflict is likewise reported by cause, not as bare "Invalid params".
-	req = httptest.NewRequest(http.MethodPost, "/tenant-a/message:send", bytes.NewReader(
+	req = newV1HTTPRequest(http.MethodPost, "/tenant-a/message:send", bytes.NewReader(
 		[]byte(`{"tenant":"tenant-b","message":{"messageId":"m","role":"ROLE_USER","parts":[{"text":"hi"}]}}`)))
 	req.Header.Set("Content-Type", protocol.MediaTypeA2AJSON)
 	recorder = httptest.NewRecorder()
@@ -240,7 +267,7 @@ func TestHTTPJSONRequiresExplicitEndpointOption(t *testing.T) {
 	assert.False(t, srv.httpJSONEnabled)
 
 	rpcBody := []byte(`{"jsonrpc":"2.0","id":"1","method":"` + protocol.MethodTasksGet + `","params":{"id":"missing-task"}}`)
-	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(rpcBody))
+	req := newV1HTTPRequest(http.MethodPost, "/", bytes.NewReader(rpcBody))
 	req.Header.Set("Content-Type", protocol.MediaTypeJSON)
 	recorder := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(recorder, req)
@@ -251,7 +278,7 @@ func TestHTTPJSONRequiresExplicitEndpointOption(t *testing.T) {
 	assert.True(t, srv.httpJSONEnabled)
 	assert.Equal(t, "/agent", srv.httpJSONBasePath)
 
-	req = httptest.NewRequest(http.MethodGet, "/agent/tasks/missing-task", nil)
+	req = newV1HTTPRequest(http.MethodGet, "/agent/tasks/missing-task", nil)
 	recorder = httptest.NewRecorder()
 	srv.Handler().ServeHTTP(recorder, req)
 	assert.Equal(t, http.StatusNotFound, recorder.Code)
@@ -270,7 +297,7 @@ func TestHTTPJSONTenantShadowingRouteKeyword(t *testing.T) {
 	require.NoError(t, err)
 
 	body := []byte(`{"message":{"messageId":"m","role":"ROLE_USER","parts":[{"text":"hi"}]}}`)
-	req := httptest.NewRequest(http.MethodPost, "/tasks/message:send", bytes.NewReader(body))
+	req := newV1HTTPRequest(http.MethodPost, "/tasks/message:send", bytes.NewReader(body))
 	req.Header.Set("Content-Type", protocol.MediaTypeA2AJSON)
 	recorder := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(recorder, req)
@@ -295,7 +322,7 @@ func TestHTTPJSONStreamUsesRawSSEData(t *testing.T) {
 	}}
 	body, err := json.Marshal(params)
 	require.NoError(t, err)
-	req := httptest.NewRequest(http.MethodPost, "/message:stream", bytes.NewReader(body))
+	req := newV1HTTPRequest(http.MethodPost, "/message:stream", bytes.NewReader(body))
 	req.Header.Set("Content-Type", protocol.MediaTypeA2AJSON)
 	recorder := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(recorder, req)
@@ -323,7 +350,14 @@ func TestHTTPJSONTaskPushAndExtendedCardRoutes(t *testing.T) {
 	extended := true
 	card := defaultAgentCard()
 	card.Capabilities.ExtendedAgentCard = &extended
-	srv, err := NewA2AServer(manager, WithAgentCard(card), WithHTTPJSONEndpoint("/"))
+	srv, err := NewA2AServer(
+		manager,
+		WithAgentCard(card),
+		WithHTTPJSONEndpoint("/"),
+		WithAuthenticatedExtendedCardHandler(func(_ context.Context, base AgentCard) (AgentCard, error) {
+			return base, nil
+		}),
+	)
 	require.NoError(t, err)
 
 	request := func(method, target string, body any) *httptest.ResponseRecorder {
@@ -333,7 +367,7 @@ func TestHTTPJSONTaskPushAndExtendedCardRoutes(t *testing.T) {
 			encoded, err = json.Marshal(body)
 			require.NoError(t, err)
 		}
-		req := httptest.NewRequest(method, target, bytes.NewReader(encoded))
+		req := newV1HTTPRequest(method, target, bytes.NewReader(encoded))
 		if body != nil {
 			req.Header.Set("Content-Type", protocol.MediaTypeA2AJSON)
 		}
@@ -403,7 +437,7 @@ func TestHTTPJSONValidationAndCapabilityErrors(t *testing.T) {
 	require.NoError(t, err)
 
 	request := func(method, target, body string) *httptest.ResponseRecorder {
-		req := httptest.NewRequest(method, target, bytes.NewBufferString(body))
+		req := newV1HTTPRequest(method, target, bytes.NewBufferString(body))
 		if body != "" {
 			req.Header.Set("Content-Type", protocol.MediaTypeA2AJSON)
 		}
@@ -442,7 +476,7 @@ func TestHTTPJSONValidationAndCapabilityErrors(t *testing.T) {
 
 	recorder = request(http.MethodGet, "/extendedAgentCard", "")
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
-	assert.Contains(t, recorder.Body.String(), "EXTENDED_AGENT_CARD_NOT_CONFIGURED")
+	assert.Contains(t, recorder.Body.String(), "UNSUPPORTED_OPERATION")
 
 	limited, err := NewA2AServer(
 		manager,
@@ -451,7 +485,7 @@ func TestHTTPJSONValidationAndCapabilityErrors(t *testing.T) {
 		WithHTTPJSONMaxBodyBytes(32),
 	)
 	require.NoError(t, err)
-	req := httptest.NewRequest(http.MethodPost, "/message:send", strings.NewReader(strings.Repeat(" ", 33)))
+	req := newV1HTTPRequest(http.MethodPost, "/message:send", strings.NewReader(strings.Repeat(" ", 33)))
 	req.Header.Set("Content-Type", protocol.MediaTypeA2AJSON)
 	recorder = httptest.NewRecorder()
 	limited.Handler().ServeHTTP(recorder, req)
@@ -462,7 +496,7 @@ func TestHTTPJSONValidationAndCapabilityErrors(t *testing.T) {
 func TestDecodeHTTPJSONBodyLimitCanBeDisabled(t *testing.T) {
 	srv := &A2AServer{httpJSONMaxBody: defaultHTTPJSONMaxBodyBytes}
 	WithHTTPJSONMaxBodyBytes(0)(srv)
-	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"value":"accepted"}`))
+	req := newV1HTTPRequest(http.MethodPost, "/", strings.NewReader(`{"value":"accepted"}`))
 
 	var body map[string]string
 	err := srv.decodeHTTPJSONBody(httptest.NewRecorder(), req, &body, true)
@@ -519,7 +553,7 @@ func TestHTTPJSONInternalErrorDetailIsNotLeaked(t *testing.T) {
 		Parts:     []*protocol.Part{protocol.NewTextPart("hello")},
 	}})
 	require.NoError(t, err)
-	req := httptest.NewRequest(http.MethodPost, "/message:send", bytes.NewReader(body))
+	req := newV1HTTPRequest(http.MethodPost, "/message:send", bytes.NewReader(body))
 	req.Header.Set("Content-Type", protocol.MediaTypeA2AJSON)
 	recorder := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(recorder, req)

--- a/server/options.go
+++ b/server/options.go
@@ -139,10 +139,17 @@ func WithTenantCard(tenant string, card AgentCard) Option {
 			s.tenantCards = make(map[string]AgentCard)
 		}
 		card.NormalizeInterfaces()
-		// Stamp the tenant onto the card's interfaces so clients see who to address.
-		for i := range card.SupportedInterfaces {
-			card.SupportedInterfaces[i].Tenant = tenant
+		// Stamp the tenant onto the card's interfaces so clients see who to
+		// address. Copy the slice first: card is passed by value but its
+		// backing array is still the caller's, so registering one card value
+		// for several tenants would otherwise leave them all advertising the
+		// tenant that was registered last.
+		interfaces := make([]protocol.AgentInterface, len(card.SupportedInterfaces))
+		copy(interfaces, card.SupportedInterfaces)
+		for i := range interfaces {
+			interfaces[i].Tenant = tenant
 		}
+		card.SupportedInterfaces = interfaces
 		s.tenantCards[tenant] = card
 	}
 }

--- a/server/options_test.go
+++ b/server/options_test.go
@@ -454,3 +454,24 @@ func TestWithBasePathPriority(t *testing.T) {
 		})
 	}
 }
+
+// WithTenantCard must not stamp its tenant into the caller's card: the same
+// card value is a natural thing to register for several tenants.
+func TestWithTenantCardDoesNotAliasCallerInterfaces(t *testing.T) {
+	card := defaultAgentCard()
+	card.SupportedInterfaces = []protocol.AgentInterface{{
+		URL:             "https://host.example/a2a",
+		ProtocolBinding: "JSONRPC",
+		ProtocolVersion: protocol.ProtocolVersionV1,
+	}}
+
+	srv, err := NewA2AServer(newMockTaskManager(),
+		WithTenantCard("alpha", card),
+		WithTenantCard("beta", card),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "alpha", srv.tenantCards["alpha"].SupportedInterfaces[0].Tenant)
+	assert.Equal(t, "beta", srv.tenantCards["beta"].SupportedInterfaces[0].Tenant)
+	assert.Empty(t, card.SupportedInterfaces[0].Tenant, "caller's card must be left untouched")
+}

--- a/server/server.go
+++ b/server/server.go
@@ -17,6 +17,7 @@ import (
 	"mime"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -433,10 +434,10 @@ func (s *A2AServer) withMiddleware(h http.Handler) http.Handler {
 }
 
 // dispatchByProtocol returns a handler that routes a JSON-RPC POST to the
-// legacy handler when its "method" is a legacy (slash-delimited) name and to
-// the v1 handler otherwise. The v1.0 PascalCase method names never contain a
-// slash, so the two sets are disjoint. Non-POST requests and unreadable
-// bodies fall through to the v1 handler.
+// legacy handler when its "method" is a legacy (slash-delimited) name and no
+// protocol version was supplied. An explicit version must be validated by the
+// v1 handler and cannot bypass negotiation merely by using a legacy method.
+// Non-POST requests and unreadable bodies fall through to the v1 handler.
 func (s *A2AServer) dispatchByProtocol(v1Handler, legacyHandler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.Body == nil {
@@ -457,7 +458,8 @@ func (s *A2AServer) dispatchByProtocol(v1Handler, legacyHandler http.Handler) ht
 		var probe struct {
 			Method string `json:"method"`
 		}
-		if json.Unmarshal(body, &probe) == nil && strings.Contains(probe.Method, "/") {
+		if json.Unmarshal(body, &probe) == nil &&
+			strings.Contains(probe.Method, "/") && requestedA2AVersion(r) == "" {
 			legacyHandler.ServeHTTP(w, r)
 			return
 		}
@@ -595,7 +597,63 @@ func (s *A2AServer) validateJSONRPCRequest(w http.ResponseWriter, r *http.Reques
 		return false
 	}
 
+	// Spec §9.2 routes the A2A service parameters through HTTP headers on this
+	// binding too, so an unsupported version must be rejected here.
+	if versionErr := validateA2AVersion(r); versionErr != nil {
+		s.writeJSONRPCError(w, nil, jsonrpc.FromTaskManagerError(versionErr))
+		return false
+	}
+
 	return true
+}
+
+// validateA2AVersion rejects a request that asks for a protocol version this
+// build does not speak. Per spec §3.6.1 the version may travel as the
+// A2A-Version header or as a request parameter. Per §3.6.2 an absent value is
+// interpreted as 0.3, and patch versions do not participate in negotiation.
+func validateA2AVersion(r *http.Request) *taskmanager.Error {
+	requested := requestedA2AVersion(r)
+	if requested == "" {
+		requested = "0.3"
+	}
+	parts := strings.Split(requested, ".")
+	if len(parts) != 2 && len(parts) != 3 {
+		return taskmanager.ErrVersionNotSupported(requested)
+	}
+	values := make([]uint64, len(parts))
+	for i, part := range parts {
+		if part == "" {
+			return taskmanager.ErrVersionNotSupported(requested)
+		}
+		value, err := strconv.ParseUint(part, 10, 32)
+		if err != nil {
+			return taskmanager.ErrVersionNotSupported(requested)
+		}
+		values[i] = value
+	}
+	supported := strings.Split(protocol.ProtocolVersionV1, ".")
+	if len(supported) != 2 ||
+		strconv.FormatUint(values[0], 10) != supported[0] ||
+		strconv.FormatUint(values[1], 10) != supported[1] {
+		return taskmanager.ErrVersionNotSupported(requested)
+	}
+	return nil
+}
+
+func requestedA2AVersion(r *http.Request) string {
+	requested := r.Header.Get("A2A-Version")
+	if requested == "" {
+		requested = r.URL.Query().Get("A2A-Version")
+		if requested == "" {
+			for name, values := range r.URL.Query() {
+				if strings.EqualFold(name, "A2A-Version") && len(values) > 0 {
+					requested = values[0]
+					break
+				}
+			}
+		}
+	}
+	return requested
 }
 
 // parseJSONRPCRequest reads the request body and parses it into a JSON-RPC request.

--- a/server/server_handlers_test.go
+++ b/server/server_handlers_test.go
@@ -63,6 +63,7 @@ func createJSONRPCRequest(t *testing.T, method string, params interface{}, id st
 	req, err := http.NewRequest(http.MethodPost, "http://test", bytes.NewReader(reqBytes))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("A2A-Version", protocol.ProtocolVersionV1)
 
 	return req, reqBytes
 }
@@ -98,6 +99,7 @@ func testJSONRPCErrorResponse(t *testing.T, server *httptest.Server, method stri
 	if contentType != "" {
 		req.Header.Set("Content-Type", contentType)
 	}
+	req.Header.Set("A2A-Version", protocol.ProtocolVersionV1)
 
 	resp, err := server.Client().Do(req)
 	require.NoError(t, err)
@@ -438,6 +440,7 @@ func TestA2AServer_Resubscribe(t *testing.T) {
 		require.NoError(t, err)
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Accept", "text/event-stream") // Request SSE
+		req.Header.Set("A2A-Version", protocol.ProtocolVersionV1)
 
 		resp, err := testServer.Client().Do(req)
 		require.NoError(t, err)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -78,6 +78,7 @@ func performJSONRPCRequest(
 	require.NoError(t, err)
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Accept", "application/json")
+	httpReq.Header.Set("A2A-Version", protocol.ProtocolVersionV1)
 
 	resp, err := server.Client().Do(httpReq)
 	require.NoError(t, err, "HTTP request failed")
@@ -499,6 +500,7 @@ func TestA2ASrv_HandleMessageStream_SSE(t *testing.T) {
 	require.NoError(t, err)
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Accept", "text/event-stream") // Critical for SSE
+	httpReq.Header.Set("A2A-Version", protocol.ProtocolVersionV1)
 
 	// Perform request
 	resp, err := testServer.Client().Do(httpReq)
@@ -976,22 +978,25 @@ func TestA2AServer_HandleAgentGetAuthenticatedExtendedCard(t *testing.T) {
 		expectedError            bool
 		expectedErrorCode        int
 	}{
+		// Spec §3.3.4 / §13.3: an undeclared capability is UnsupportedOperation,
+		// not ExtendedAgentCardNotConfigured.
 		{
-			name:                 "not_configured",
+			name:                 "capability_absent",
 			supportsExtendedCard: nil,
 			expectedError:        true,
-			expectedErrorCode:    jsonrpc.CodeAuthenticatedExtendedCardNotConfigured,
+			expectedErrorCode:    jsonrpc.CodeUnsupportedOperation,
 		},
 		{
-			name:                 "disabled",
+			name:                 "capability_false",
 			supportsExtendedCard: func() *bool { b := false; return &b }(),
 			expectedError:        true,
-			expectedErrorCode:    jsonrpc.CodeAuthenticatedExtendedCardNotConfigured,
+			expectedErrorCode:    jsonrpc.CodeUnsupportedOperation,
 		},
 		{
 			name:                 "enabled_no_handler",
 			supportsExtendedCard: func() *bool { b := true; return &b }(),
-			expectedError:        false,
+			expectedError:        true,
+			expectedErrorCode:    jsonrpc.CodeAuthenticatedExtendedCardNotConfigured,
 		},
 		{
 			name:                 "enabled_with_handler",
@@ -1061,6 +1066,37 @@ func TestA2AServer_HandleAgentGetAuthenticatedExtendedCard(t *testing.T) {
 	}
 }
 
+func TestA2AServer_HandleTenantExtendedAgentCard(t *testing.T) {
+	enabled := true
+	card := defaultAgentCard()
+	card.Name = "Tenant Agent"
+	card.Capabilities.ExtendedAgentCard = &enabled
+
+	srv, err := NewA2AServer(
+		newMockTaskManager(),
+		WithTenantCard("tenant-a", card),
+		WithAuthenticatedExtendedCardHandler(func(_ context.Context, base AgentCard) (AgentCard, error) {
+			base.Description = "extended tenant card"
+			return base, nil
+		}),
+	)
+	require.NoError(t, err)
+	testServer := httptest.NewServer(http.HandlerFunc(srv.handleJSONRPC))
+	defer testServer.Close()
+
+	resp := performJSONRPCRequest(t, testServer, protocol.MethodAgentAuthenticatedExtendedCard,
+		map[string]string{"tenant": "tenant-a"}, "tenant-extended-card")
+	require.Nil(t, resp.Error)
+	payload, err := json.Marshal(resp.Result)
+	require.NoError(t, err)
+	var got AgentCard
+	require.NoError(t, json.Unmarshal(payload, &got))
+	assert.Equal(t, "Tenant Agent", got.Name)
+	assert.Equal(t, "extended tenant card", got.Description)
+	require.NotEmpty(t, got.SupportedInterfaces)
+	assert.Equal(t, "tenant-a", got.SupportedInterfaces[0].Tenant)
+}
+
 // blockMiddleware rejects every request with 401, used to prove the compat
 // path is covered by the middleware chain.
 type blockMiddleware struct{}
@@ -1107,6 +1143,44 @@ func TestCompatHandler_CoveredByMiddleware(t *testing.T) {
 	require.NoError(t, err)
 	defer resp2.Body.Close()
 	assert.Equal(t, http.StatusUnauthorized, resp2.StatusCode)
+}
+
+func TestCompatDispatchRespectsA2AVersion(t *testing.T) {
+	compatHits := 0
+	compat := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		compatHits++
+		w.WriteHeader(http.StatusNoContent)
+	})
+	srv, err := NewA2AServer(
+		newMockTaskManager(),
+		WithAgentCard(defaultAgentCard()),
+		WithCompatHandler(compat),
+	)
+	require.NoError(t, err)
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(
+		`{"jsonrpc":"2.0","id":"1","method":"message/send","params":{}}`,
+	)))
+	request.Header.Set("Content-Type", protocol.MediaTypeJSON)
+	srv.Handler().ServeHTTP(recorder, request)
+	assert.Equal(t, http.StatusNoContent, recorder.Code)
+	assert.Equal(t, 1, compatHits)
+
+	for _, version := range []string{"1.0", "2.0"} {
+		recorder = httptest.NewRecorder()
+		request = httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(
+			`{"jsonrpc":"2.0","id":"2","method":"message/send","params":{}}`,
+		)))
+		request.Header.Set("Content-Type", protocol.MediaTypeJSON)
+		request.Header.Set("A2A-Version", version)
+		srv.Handler().ServeHTTP(recorder, request)
+		assert.Contains(t, recorder.Body.String(), map[string]string{
+			"1.0": "Method not found",
+			"2.0": "Version not supported",
+		}[version])
+		assert.Equal(t, 1, compatHits)
+	}
 }
 
 // TestServer_ServingPathsIndependentOfSupportedInterfaces verifies mount paths
@@ -1166,6 +1240,7 @@ func TestHTTPJSONTenantCanMatchJSONRPCEndpointPrefix(t *testing.T) {
 	// The REST tenant "rpc" must not be swallowed by the /rpc/ JSON-RPC pattern.
 	recorder := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/rpc/tasks/missing-task", nil)
+	req.Header.Set("A2A-Version", protocol.ProtocolVersionV1)
 	srv.Handler().ServeHTTP(recorder, req)
 	assert.Equal(t, protocol.MediaTypeA2AJSON, recorder.Header().Get("Content-Type"))
 	assert.Contains(t, recorder.Body.String(), "TASK_NOT_FOUND")
@@ -1176,6 +1251,7 @@ func TestHTTPJSONTenantCanMatchJSONRPCEndpointPrefix(t *testing.T) {
 		`{"jsonrpc":"2.0","id":"1","method":"GetTask","params":{"id":"missing-task"}}`,
 	)))
 	req.Header.Set("Content-Type", protocol.MediaTypeJSON)
+	req.Header.Set("A2A-Version", protocol.ProtocolVersionV1)
 	srv.Handler().ServeHTTP(recorder, req)
 	assert.Contains(t, recorder.Body.String(), `"jsonrpc":"2.0"`)
 
@@ -1193,6 +1269,7 @@ func TestHTTPJSONTenantCanMatchJSONRPCEndpointPrefix(t *testing.T) {
 		`{"jsonrpc":"2.0","id":"1","method":"GetTask","params":{"id":"missing-task"}}`,
 	)))
 	req.Header.Set("Content-Type", protocol.MediaTypeJSON)
+	req.Header.Set("A2A-Version", protocol.ProtocolVersionV1)
 	escapedSrv.Handler().ServeHTTP(recorder, req)
 	assert.Contains(t, recorder.Body.String(), `"jsonrpc":"2.0"`)
 }
@@ -1314,5 +1391,82 @@ func TestHandleSSEStreamDrainsAfterClientDisconnect(t *testing.T) {
 	case <-producerDone:
 	case <-time.After(time.Second):
 		t.Fatal("event producer remained blocked after SSE client disconnect")
+	}
+}
+
+// Version negotiation uses Major.Minor, ignores a numeric patch component and
+// treats an absent value as 0.3 as required by spec §3.6.
+func TestValidateA2AVersion(t *testing.T) {
+	for _, tc := range []struct {
+		name, target, header string
+		wantErr              bool
+	}{
+		{name: "supported header", target: "/", header: "1.0"},
+		{name: "supported query", target: "/?A2A-Version=1.0"},
+		{name: "case-insensitive query", target: "/?a2a-version=1.0"},
+		{name: "patch zero", target: "/", header: "1.0.0"},
+		{name: "patch ignored", target: "/", header: "1.0.7"},
+		{name: "header wins", target: "/?A2A-Version=2.0", header: "1.0.1"},
+		{name: "absent means 0.3", target: "/", wantErr: true},
+		{name: "unsupported minor", target: "/", header: "1.1", wantErr: true},
+		{name: "unsupported major", target: "/", header: "2.0", wantErr: true},
+		{name: "unsupported old version", target: "/", header: "0.3", wantErr: true},
+		{name: "malformed short", target: "/", header: "1", wantErr: true},
+		{name: "malformed patch", target: "/", header: "1.0.x", wantErr: true},
+		{name: "too many components", target: "/", header: "1.0.0.0", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, tc.target, nil)
+			if tc.header != "" {
+				req.Header.Set("A2A-Version", tc.header)
+			}
+			assert.Equal(t, tc.wantErr, validateA2AVersion(req) != nil)
+		})
+	}
+}
+
+func TestJSONRPCA2AVersionNegotiation(t *testing.T) {
+	srv, err := NewA2AServer(newMockTaskManager(), WithAgentCard(defaultAgentCard()))
+	require.NoError(t, err)
+	testServer := httptest.NewServer(http.HandlerFunc(srv.handleJSONRPC))
+	defer testServer.Close()
+
+	body := `{"jsonrpc":"2.0","id":"1","method":"` + protocol.MethodTasksGet + `","params":{"id":"t1"}}`
+	post := func(t *testing.T, target string, header string) *http.Response {
+		t.Helper()
+		req, err := http.NewRequest(http.MethodPost, testServer.URL+target, strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		if header != "" {
+			req.Header.Set("A2A-Version", header)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		return resp
+	}
+
+	for _, tc := range []struct{ name, target, header string }{
+		{"missing version", "/", ""},
+		{"header", "/", "0.3"},
+		{"query parameter", "/?A2A-Version=0.3", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := post(t, tc.target, tc.header)
+			defer resp.Body.Close()
+			payload, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			assert.Contains(t, string(payload), "Version not supported")
+		})
+	}
+
+	for _, version := range []string{protocol.ProtocolVersionV1, "1.0.0", "1.0.7"} {
+		t.Run("supported "+version, func(t *testing.T) {
+			resp := post(t, "/", version)
+			defer resp.Body.Close()
+			payload, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			assert.NotContains(t, string(payload), "Version not supported")
+		})
 	}
 }

--- a/taskmanager/list_tasks.go
+++ b/taskmanager/list_tasks.go
@@ -7,9 +7,10 @@
 package taskmanager
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"sort"
-	"strconv"
 	"time"
 
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
@@ -55,44 +56,112 @@ func TaskMatchesListFilter(task *protocol.Task, params protocol.ListTasksParams,
 	return true
 }
 
-// PaginateTasks sorts the filtered tasks by ID for stable pagination, applies
-// offset-based pagination from params.PageToken/PageSize, trims each returned
+type listTasksCursor struct {
+	Timestamp string `json:"t"`
+	ID        string `json:"i"`
+}
+
+func listTaskSortTime(timestamp string) time.Time {
+	if timestamp == "" {
+		return time.Time{}
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, timestamp)
+	if err != nil {
+		// Retained tasks created by an application may contain a malformed
+		// timestamp. Keep ListTasks available and put those tasks in the stable
+		// zero-time bucket rather than failing the entire result set.
+		return time.Time{}
+	}
+	return parsed
+}
+
+func encodeListTasksCursor(task *protocol.Task) (string, error) {
+	timestamp := ""
+	if parsed := listTaskSortTime(task.Status.Timestamp); !parsed.IsZero() {
+		timestamp = parsed.UTC().Format(time.RFC3339Nano)
+	}
+	payload, err := json.Marshal(listTasksCursor{Timestamp: timestamp, ID: task.ID})
+	if err != nil {
+		return "", fmt.Errorf("encode ListTasks pageToken: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(payload), nil
+}
+
+func decodeListTasksCursor(token string) (listTasksCursor, time.Time, error) {
+	payload, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return listTasksCursor{}, time.Time{}, ErrInvalidParams("invalid pageToken")
+	}
+	var cursor listTasksCursor
+	if err := json.Unmarshal(payload, &cursor); err != nil || cursor.ID == "" {
+		return listTasksCursor{}, time.Time{}, ErrInvalidParams("invalid pageToken")
+	}
+	if cursor.Timestamp == "" {
+		return cursor, time.Time{}, nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, cursor.Timestamp)
+	if err != nil {
+		return listTasksCursor{}, time.Time{}, ErrInvalidParams("invalid pageToken")
+	}
+	return cursor, parsed, nil
+}
+
+// PaginateTasks sorts the filtered tasks most-recently-updated first, applies
+// keyset pagination from params.PageToken/PageSize, trims each returned
 // task's history per params.HistoryLength and strips artifacts unless
 // params.IncludeArtifacts is set. Returned tasks are copies, so the caller's
 // stored tasks are never mutated. It is shared by the in-memory and Redis
 // task managers.
 func PaginateTasks(filtered []*protocol.Task, params protocol.ListTasksParams) (*protocol.ListTasksResult, error) {
-	sort.Slice(filtered, func(i, j int) bool { return filtered[i].ID < filtered[j].ID })
+	if params.PageSize != nil && (*params.PageSize < 1 || *params.PageSize > ListTasksMaxPageSize) {
+		return nil, ErrInvalidParams("pageSize must be between 1 and 100")
+	}
+	if params.HistoryLength != nil && *params.HistoryLength < 0 {
+		return nil, ErrInvalidParams("historyLength must be non-negative")
+	}
+
+	// Spec §3.1.4: "Implementations MUST return tasks sorted by their status
+	// timestamp time in descending order". Parse the timestamps because valid
+	// RFC3339 representations with different fractional precision do not compare
+	// correctly as strings. The task ID breaks ties.
+	sort.Slice(filtered, func(i, j int) bool {
+		iTime := listTaskSortTime(filtered[i].Status.Timestamp)
+		jTime := listTaskSortTime(filtered[j].Status.Timestamp)
+		if !iTime.Equal(jTime) {
+			return iTime.After(jTime)
+		}
+		return filtered[i].ID < filtered[j].ID
+	})
 
 	pageSize := ListTasksDefaultPageSize
-	if params.PageSize != nil && *params.PageSize > 0 {
+	if params.PageSize != nil {
 		pageSize = *params.PageSize
-		if pageSize > ListTasksMaxPageSize {
-			pageSize = ListTasksMaxPageSize
-		}
 	}
-	offset := 0
+	start := 0
 	if params.PageToken != "" {
-		o, err := strconv.Atoi(params.PageToken)
-		if err != nil || o < 0 {
-			return nil, fmt.Errorf("invalid pageToken %q", params.PageToken)
+		cursor, cursorTime, err := decodeListTasksCursor(params.PageToken)
+		if err != nil {
+			return nil, err
 		}
-		offset = o
+		// Find the first task strictly after the cursor in the sorted order.
+		// This remains valid when the cursor task has since been deleted.
+		start = sort.Search(len(filtered), func(i int) bool {
+			taskTime := listTaskSortTime(filtered[i].Status.Timestamp)
+			return taskTime.Before(cursorTime) ||
+				(taskTime.Equal(cursorTime) && filtered[i].ID > cursor.ID)
+		})
 	}
 
 	totalSize := len(filtered)
-	if offset > totalSize {
-		offset = totalSize
-	}
-	end := offset + pageSize
+	end := start + pageSize
 	if end > totalSize {
 		end = totalSize
 	}
 
-	tasks := make([]*protocol.Task, 0, end-offset)
-	for _, task := range filtered[offset:end] {
+	tasks := make([]*protocol.Task, 0, end-start)
+	for _, task := range filtered[start:end] {
 		cp := *task // copy so trimming never mutates stored tasks
-		if params.HistoryLength != nil && *params.HistoryLength >= 0 && len(cp.History) > *params.HistoryLength {
+		if params.HistoryLength != nil && len(cp.History) > *params.HistoryLength {
 			cp.History = cp.History[len(cp.History)-*params.HistoryLength:]
 		}
 		if params.IncludeArtifacts == nil || !*params.IncludeArtifacts {
@@ -107,7 +176,11 @@ func PaginateTasks(filtered []*protocol.Task, params protocol.ListTasksParams) (
 		TotalSize: totalSize,
 	}
 	if end < totalSize {
-		result.NextPageToken = strconv.Itoa(end)
+		token, err := encodeListTasksCursor(filtered[end-1])
+		if err != nil {
+			return nil, err
+		}
+		result.NextPageToken = token
 	}
 	return result, nil
 }

--- a/taskmanager/list_tasks_test.go
+++ b/taskmanager/list_tasks_test.go
@@ -7,6 +7,8 @@
 package taskmanager
 
 import (
+	"encoding/base64"
+	"errors"
 	"testing"
 	"time"
 
@@ -76,8 +78,41 @@ func ltSampleTasks() []*protocol.Task {
 	return []*protocol.Task{mk("t3"), mk("t1"), mk("t5"), mk("t2"), mk("t4")}
 }
 
+// Spec §3.1.4: "Implementations MUST return tasks sorted by their status
+// timestamp time in descending order (most recently updated tasks first)."
+func TestPaginateTasksOrdersByStatusTimestampDescending(t *testing.T) {
+	mk := func(id, timestamp string) *protocol.Task {
+		return &protocol.Task{ID: id, Status: protocol.TaskStatus{Timestamp: timestamp}}
+	}
+	tasks := []*protocol.Task{
+		mk("t-whole", "2024-01-01T00:00:00Z"),
+		mk("t-b", "2024-01-01T00:00:00.100Z"),
+		mk("t-a", "2024-01-01T00:00:00.100Z"),
+		mk("t-empty", ""),
+	}
+	res, err := PaginateTasks(tasks, protocol.ListTasksParams{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"t-a", "t-b", "t-whole", "t-empty"}
+	for i, id := range want {
+		if res.Tasks[i].ID != id {
+			t.Fatalf("position %d: want %s, got %s (full order %v)", i, id, res.Tasks[i].ID, res.Tasks)
+		}
+	}
+
+	// Paging must walk the same descending order.
+	page, err := PaginateTasks(tasks, protocol.ListTasksParams{PageSize: ltIntPtr(1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Tasks) != 1 || page.Tasks[0].ID != "t-a" {
+		t.Errorf("first page should hold the most recent task, got %v", page.Tasks)
+	}
+}
+
 func TestPaginateTasks(t *testing.T) {
-	t.Run("default page: sorted by ID, artifacts stripped, no next page", func(t *testing.T) {
+	t.Run("equal timestamps fall back to the ID tiebreak", func(t *testing.T) {
 		res, err := PaginateTasks(ltSampleTasks(), protocol.ListTasksParams{})
 		if err != nil {
 			t.Fatal(err)
@@ -97,48 +132,124 @@ func TestPaginateTasks(t *testing.T) {
 	})
 
 	t.Run("pageSize + pageToken walk pages", func(t *testing.T) {
-		p1, err := PaginateTasks(ltSampleTasks(), protocol.ListTasksParams{PageSize: ltIntPtr(2)})
-		if err != nil {
-			t.Fatal(err)
+		var got []string
+		token := ""
+		for {
+			page, err := PaginateTasks(ltSampleTasks(), protocol.ListTasksParams{
+				PageSize: ltIntPtr(2), PageToken: token,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, task := range page.Tasks {
+				got = append(got, task.ID)
+			}
+			if page.NextPageToken == "" {
+				break
+			}
+			if page.NextPageToken == "2" || page.NextPageToken == "4" {
+				t.Fatalf("page token must be opaque, got %q", page.NextPageToken)
+			}
+			token = page.NextPageToken
 		}
-		if len(p1.Tasks) != 2 || p1.Tasks[0].ID != "t1" || p1.Tasks[1].ID != "t2" || p1.NextPageToken != "2" {
-			t.Errorf("page1 wrong: ids=%s,%s next=%q", p1.Tasks[0].ID, p1.Tasks[1].ID, p1.NextPageToken)
+		want := []string{"t1", "t2", "t3", "t4", "t5"}
+		if len(got) != len(want) {
+			t.Fatalf("got %v, want %v", got, want)
 		}
-		p2, err := PaginateTasks(ltSampleTasks(), protocol.ListTasksParams{PageSize: ltIntPtr(2), PageToken: p1.NextPageToken})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if p2.Tasks[0].ID != "t3" || p2.NextPageToken != "4" {
-			t.Errorf("page2 wrong: id=%s next=%q", p2.Tasks[0].ID, p2.NextPageToken)
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("got %v, want %v", got, want)
+			}
 		}
 	})
 
 	t.Run("invalid pageToken errors", func(t *testing.T) {
-		if _, err := PaginateTasks(ltSampleTasks(), protocol.ListTasksParams{PageToken: "abc"}); err == nil {
-			t.Error("non-numeric pageToken should error")
+		tokens := []string{
+			"not-base64!",
+			base64.RawURLEncoding.EncodeToString([]byte(`not-json`)),
+			base64.RawURLEncoding.EncodeToString([]byte(`{"t":"2024-01-01T00:00:00Z"}`)),
+			base64.RawURLEncoding.EncodeToString([]byte(`{"t":"not-a-time","i":"task"}`)),
 		}
-		if _, err := PaginateTasks(ltSampleTasks(), protocol.ListTasksParams{PageToken: "-1"}); err == nil {
-			t.Error("negative pageToken should error")
-		}
-	})
-
-	t.Run("offset past end -> empty page", func(t *testing.T) {
-		res, err := PaginateTasks(ltSampleTasks(), protocol.ListTasksParams{PageToken: "100"})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(res.Tasks) != 0 || res.NextPageToken != "" {
-			t.Errorf("expected empty final page, got %d tasks next=%q", len(res.Tasks), res.NextPageToken)
+		for _, token := range tokens {
+			_, err := PaginateTasks(ltSampleTasks(), protocol.ListTasksParams{PageToken: token})
+			if !errors.Is(err, ErrInvalidParamsSentinel) {
+				t.Errorf("pageToken %q: got %v, want invalid params", token, err)
+			}
 		}
 	})
 
-	t.Run("pageSize capped at max", func(t *testing.T) {
-		res, err := PaginateTasks(ltSampleTasks(), protocol.ListTasksParams{PageSize: ltIntPtr(99999)})
+	t.Run("cursor continues after its task is deleted", func(t *testing.T) {
+		input := ltSampleTasks()
+		first, err := PaginateTasks(input, protocol.ListTasksParams{PageSize: ltIntPtr(1)})
 		if err != nil {
 			t.Fatal(err)
 		}
-		if res.PageSize != ListTasksMaxPageSize {
-			t.Errorf("pageSize=%d want %d", res.PageSize, ListTasksMaxPageSize)
+		var remaining []*protocol.Task
+		for _, task := range input {
+			if task.ID != first.Tasks[0].ID {
+				remaining = append(remaining, task)
+			}
+		}
+		next, err := PaginateTasks(remaining, protocol.ListTasksParams{
+			PageSize: ltIntPtr(1), PageToken: first.NextPageToken,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(next.Tasks) != 1 || next.Tasks[0].ID != "t2" {
+			t.Fatalf("next page = %v, want t2", next.Tasks)
+		}
+	})
+
+	t.Run("updates before the cursor do not repeat earlier results", func(t *testing.T) {
+		mk := func(id, timestamp string) *protocol.Task {
+			return &protocol.Task{ID: id, Status: protocol.TaskStatus{Timestamp: timestamp}}
+		}
+		input := []*protocol.Task{
+			mk("a", "2024-01-01T00:00:01Z"),
+			mk("b", "2024-01-01T00:00:02Z"),
+			mk("c", "2024-01-01T00:00:03Z"),
+			mk("d", "2024-01-01T00:00:00Z"),
+		}
+		first, err := PaginateTasks(input, protocol.ListTasksParams{PageSize: ltIntPtr(2)})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, task := range input {
+			if task.ID == "a" {
+				task.Status.Timestamp = "2024-01-01T00:00:04Z"
+			}
+		}
+		next, err := PaginateTasks(input, protocol.ListTasksParams{
+			PageSize: ltIntPtr(2), PageToken: first.NextPageToken,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(next.Tasks) != 1 || next.Tasks[0].ID != "d" {
+			t.Fatalf("next page = %v, want only d", next.Tasks)
+		}
+	})
+
+	t.Run("pageSize validates range", func(t *testing.T) {
+		for _, pageSize := range []int{-1, 0, ListTasksMaxPageSize + 1} {
+			_, err := PaginateTasks(ltSampleTasks(), protocol.ListTasksParams{PageSize: ltIntPtr(pageSize)})
+			if !errors.Is(err, ErrInvalidParamsSentinel) {
+				t.Errorf("pageSize %d: got %v, want invalid params", pageSize, err)
+			}
+		}
+		for _, pageSize := range []int{1, ListTasksMaxPageSize} {
+			res, err := PaginateTasks(ltSampleTasks(), protocol.ListTasksParams{PageSize: ltIntPtr(pageSize)})
+			if err != nil || res.PageSize != pageSize {
+				t.Errorf("pageSize %d: result=%+v err=%v", pageSize, res, err)
+			}
+		}
+	})
+
+	t.Run("negative historyLength errors", func(t *testing.T) {
+		_, err := PaginateTasks(ltSampleTasks(), protocol.ListTasksParams{HistoryLength: ltIntPtr(-1)})
+		if !errors.Is(err, ErrInvalidParamsSentinel) {
+			t.Errorf("got %v, want invalid params", err)
 		}
 	})
 

--- a/taskmanager/memory/memory.go
+++ b/taskmanager/memory/memory.go
@@ -526,7 +526,7 @@ func (m *TaskManager) OnPushNotificationGet(
 	return &config, nil
 }
 
-// OnListTasks handles the v1.0 ListTasks request with filtering and offset-based pagination.
+// OnListTasks handles the v1.0 ListTasks request with filtering and keyset pagination.
 func (m *TaskManager) OnListTasks(
 	ctx context.Context,
 	params protocol.ListTasksParams,

--- a/taskmanager/memory/memory_test.go
+++ b/taskmanager/memory/memory_test.go
@@ -669,7 +669,8 @@ func TestTaskManager_OnListTasks(t *testing.T) {
 		seedTask(manager, seed[i])
 	}
 
-	// No filter: all tasks, sorted by ID.
+	// No filter: all tasks, most recently updated first (spec §3.1.4), with the
+	// task ID breaking timestamp ties.
 	result, err := manager.OnListTasks(ctx, protocol.ListTasksParams{})
 	if err != nil {
 		t.Fatalf("OnListTasks failed: %v", err)
@@ -677,11 +678,16 @@ func TestTaskManager_OnListTasks(t *testing.T) {
 	if result.TotalSize != 3 || len(result.Tasks) != 3 {
 		t.Fatalf("Expected 3 tasks, got total=%d len=%d", result.TotalSize, len(result.Tasks))
 	}
-	if result.Tasks[0].ID != "task-a" || result.Tasks[2].ID != "task-c" {
-		t.Errorf("Expected ID-sorted order, got %s..%s", result.Tasks[0].ID, result.Tasks[2].ID)
+	gotOrder := []string{result.Tasks[0].ID, result.Tasks[1].ID, result.Tasks[2].ID}
+	wantOrder := []string{"task-b", "task-c", "task-a"}
+	for i := range wantOrder {
+		if gotOrder[i] != wantOrder[i] {
+			t.Errorf("Expected status-timestamp-descending order %v, got %v", wantOrder, gotOrder)
+			break
+		}
 	}
-	// Artifacts stripped by default.
-	if result.Tasks[2].Artifacts != nil {
+	// Artifacts stripped by default (task-c carries the only artifact).
+	if result.Tasks[1].Artifacts != nil {
 		t.Errorf("Expected artifacts stripped by default")
 	}
 
@@ -707,13 +713,13 @@ func TestTaskManager_OnListTasks(t *testing.T) {
 		t.Fatalf("Expected task-c with artifact, got %+v", result.Tasks)
 	}
 
-	// Pagination: page size 2 -> next page token "2", second page has 1 task.
+	// Pagination: page size 2 yields an opaque cursor, then one final task.
 	result, err = manager.OnListTasks(ctx, protocol.ListTasksParams{PageSize: intPtr(2)})
 	if err != nil {
 		t.Fatalf("OnListTasks paged failed: %v", err)
 	}
-	if len(result.Tasks) != 2 || result.NextPageToken != "2" {
-		t.Fatalf("Expected 2 tasks + token \"2\", got len=%d token=%q", len(result.Tasks), result.NextPageToken)
+	if len(result.Tasks) != 2 || result.NextPageToken == "" {
+		t.Fatalf("Expected 2 tasks + cursor, got len=%d token=%q", len(result.Tasks), result.NextPageToken)
 	}
 	result, err = manager.OnListTasks(ctx, protocol.ListTasksParams{
 		PageSize: intPtr(2), PageToken: result.NextPageToken,
@@ -723,6 +729,16 @@ func TestTaskManager_OnListTasks(t *testing.T) {
 	}
 	if len(result.Tasks) != 1 || result.NextPageToken != "" {
 		t.Fatalf("Expected final page with 1 task, got len=%d token=%q", len(result.Tasks), result.NextPageToken)
+	}
+
+	for _, params := range []protocol.ListTasksParams{
+		{PageSize: intPtr(0)},
+		{PageSize: intPtr(taskmanager.ListTasksMaxPageSize + 1)},
+		{HistoryLength: intPtr(-1)},
+	} {
+		if _, err := manager.OnListTasks(ctx, params); !errors.Is(err, taskmanager.ErrInvalidParamsSentinel) {
+			t.Errorf("OnListTasks(%+v) error = %v, want invalid params", params, err)
+		}
 	}
 }
 

--- a/taskmanager/redis/redis_manager.go
+++ b/taskmanager/redis/redis_manager.go
@@ -576,7 +576,7 @@ func (m *TaskManager) OnPushNotificationGet(
 const unlimitedHistoryLength = 1 << 30
 
 // OnListTasks handles the v1.0 ListTasks request from the tenant-and-owner-local task
-// index, filtering and applying offset-based pagination without a keyspace SCAN.
+// index, filtering and applying keyset pagination without a keyspace SCAN.
 func (m *TaskManager) OnListTasks(
 	ctx context.Context,
 	params protocol.ListTasksParams,

--- a/taskmanager/redis/redis_manager_test.go
+++ b/taskmanager/redis/redis_manager_test.go
@@ -1416,6 +1416,17 @@ func TestOnListTasks(t *testing.T) {
 		}
 		seen[task.ID] = true
 	}
+
+	intPointer := func(value int) *int { return &value }
+	for _, params := range []protocol.ListTasksParams{
+		{PageSize: intPointer(0)},
+		{PageSize: intPointer(taskmanager.ListTasksMaxPageSize + 1)},
+		{HistoryLength: intPointer(-1)},
+	} {
+		if _, err := m.OnListTasks(context.Background(), params); !errors.Is(err, taskmanager.ErrInvalidParamsSentinel) {
+			t.Errorf("OnListTasks(%+v) error = %v, want invalid params", params, err)
+		}
+	}
 }
 
 // =============================================================================

--- a/taskmanager/stateless/stateless.go
+++ b/taskmanager/stateless/stateless.go
@@ -184,10 +184,10 @@ func (*TaskManager) OnCancelTask(
 
 // OnListTasks returns an empty page because the manager retains no Tasks.
 func (*TaskManager) OnListTasks(
-	context.Context,
-	protocol.ListTasksParams,
+	_ context.Context,
+	params protocol.ListTasksParams,
 ) (*protocol.ListTasksResult, error) {
-	return &protocol.ListTasksResult{Tasks: make([]*protocol.Task, 0)}, nil
+	return taskmanager.PaginateTasks(nil, params)
 }
 
 // OnPushNotificationSet rejects push registration.

--- a/taskmanager/stateless/stateless_test.go
+++ b/taskmanager/stateless/stateless_test.go
@@ -21,6 +21,8 @@ type processorFunc func(
 	*taskmanager.ExecContext,
 ) (<-chan protocol.StreamEvent, error)
 
+func intPtr(i int) *int { return &i }
+
 func (f processorFunc) ProcessMessage(
 	ctx context.Context,
 	ec *taskmanager.ExecContext,
@@ -708,8 +710,18 @@ func TestTaskAndPushMethods(t *testing.T) {
 		t.Errorf("OnCancelTask error = %v", err)
 	}
 	list, err := manager.OnListTasks(ctx, protocol.ListTasksParams{})
-	if err != nil || list == nil || list.Tasks == nil || len(list.Tasks) != 0 {
+	if err != nil || list == nil || list.Tasks == nil || len(list.Tasks) != 0 ||
+		list.PageSize != taskmanager.ListTasksDefaultPageSize || list.TotalSize != 0 || list.NextPageToken != "" {
 		t.Errorf("OnListTasks = %+v, %v", list, err)
+	}
+	for _, params := range []protocol.ListTasksParams{
+		{PageSize: intPtr(0)},
+		{PageSize: intPtr(taskmanager.ListTasksMaxPageSize + 1)},
+		{HistoryLength: intPtr(-1)},
+	} {
+		if _, err := manager.OnListTasks(ctx, params); !errors.Is(err, taskmanager.ErrInvalidParamsSentinel) {
+			t.Errorf("OnListTasks(%+v) error = %v, want invalid params", params, err)
+		}
 	}
 	if _, err := manager.OnResubscribe(ctx, protocol.TaskIDParams{ID: "task-1"}); !errors.Is(
 		err, taskmanager.ErrTaskNotFoundSentinel,


### PR DESCRIPTION
Base: `v2`

## Summary

This closes conformance gaps found by auditing the v2 implementation against the A2A v1.0.0 specification and its normative `a2a.proto`.

- **`securityRequirements` used the wrong wire shape.** `SecurityRequirement.schemes` is `map<string, StringList>`, so scopes now serialize as `{"schemes": {"google": {"list": ["openid"]}}}`. Reading remains compatible with earlier v2 prereleases and v0 cards, while unknown ProtoJSON fields are ignored for forward compatibility.
- **`AgentSkill.securityRequirements` was missing** (proto field 8), so per-skill schemes could not be declared and were silently dropped whenever a card was read and re-served.
- **`ListTasks` did not fully implement §3.1.4.** Results are now sorted by status timestamp descending with an opaque keyset cursor, required result fields are always serialized, and explicit `pageSize`/`historyLength` values are validated.
- **`GetExtendedAgentCard` returned the wrong error.** §3.3.4 and §13.3 require `UnsupportedOperationError` when `capabilities.extendedAgentCard` is absent or false; `ExtendedAgentCardNotConfiguredError` is reserved for an agent that declares the capability but cannot produce a card.
- **Version negotiation was incomplete.** Both JSON-RPC and HTTP+JSON now read `A2A-Version` from the header or request parameter, compare Major.Minor while ignoring a numeric patch component, interpret an absent value as `0.3`, and return `VersionNotSupportedError` when the selected interface cannot speak it. Explicit versions cannot bypass validation through a legacy slash-delimited method.
- **`WithTenantCard` stamped its tenant into the caller's Agent Card.** The card is passed by value but its `SupportedInterfaces` backing array was shared, so registering one card value for several tenants left them all advertising the tenant registered last.

## Compatibility

- The `securityRequirements` output changes from the earlier non-conformant shape; compatible readers still accept earlier prerelease and v0 inputs.
- `ListTasks` result ordering changes, older page tokens are invalidated, and explicitly invalid `pageSize` or `historyLength` values now return `InvalidParams` instead of being clamped or ignored.
- `GetExtendedAgentCard` returns `-32004` instead of `-32007` when the capability is not declared.
- A request without `A2A-Version` is interpreted as `0.3` as required by §3.6.2, so a v1-only interface rejects it. Legacy slash-delimited JSON-RPC requests remain compatible when the legacy handler is configured and the version is omitted.

## Not in scope

Other gaps from the same audit remain follow-up design work:

- `capabilities.streaming` is not enforced; an agent that declares `streaming: false` still accepts `message:stream` and `tasks:subscribe` (§3.3.4).
- A task-lifecycle stream does not begin with the `Task` object (§3.1.2).
- No authorization scoping for multi-tenant deployments: `Task` carries no tenant, so `ListTasks` is not tenant-filtered (§3.1.4, §13.1).
- The `A2A-Extensions` service parameter is not read, so a required extension cannot be enforced (§3.2.6, §3.3.4).
- Agent Card JWS signatures are neither produced nor verified (§8.4, SHOULD).

## Validation

- `GOWORK=off go test -count=1 ./...`
- `GOWORK=off go test -race -count=1 ./...`
- `GOWORK=off go vet ./...`
- `GOWORK=off go build ./...`
- Root and Redis `golangci-lint`
- Redis module test, race, vet, and build with the same root-module workspace replacement used by CI
- `go mod tidy -diff` for root, Redis, examples, and examples/multi
- Tests for examples and examples/multi
- `typos`

The Redis nested module still pins the latest published root prerelease (`v2.0.0-alpha.3`); its standalone dependency bump must follow the next root prerelease rather than pinning an unmerged commit here.
