### PR TITLE
taskmanager/redis: use Redis Streams for task resubscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@
 - HTTP+JSON validation errors report the specific client-correctable cause in `error.message` (spec §11.6), while internal and invalid-agent-response details are logged and replaced by a generic heading. The REST client rebuilds errors from the wire values instead of re-running the server-side constructors.
 - HTTP+JSON request bodies are limited to 4 MiB by default to bound decoder memory use; `server.WithHTTPJSONMaxBodyBytes` changes or explicitly disables the limit.
 
+### Redis TaskManager
+
+- **`SubscribeToTask` now uses Redis Streams on every Redis TaskManager.** Task events are journaled by default so a reconnect may land on any replica sharing Redis without configuration. `WithCrossNodeResubscribe` remains as a deprecated no-op for source compatibility.
+- **Redis 5.0 or newer is required.** Deployments must allow the Stream commands (`XADD`, `XRANGE`, and `XREVRANGE`), sorted-set commands (`ZADD`, `ZSCORE`, `ZINCRBY`, `ZCARD`, and `ZREMRANGEBYRANK`), and Lua commands used by the TaskManager. Upgrade all replicas together because older nodes do not write the event journal required by Stream-only subscribers.
+- Stream subscriptions use a size-one local response pipe, stop when their Task expires, and retry transient Redis read failures with bounded backoff instead of retaining stale subscribers indefinitely. Live executions renew their Task lease while silent, and event writes are idempotent across ambiguous Redis command retries.
+
 ## 2.0.0-alpha.3 (2026-07-22)
 
 This prerelease adds request-scoped stateless execution and restores Redis

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ the native channel style recommended for new code.
 | `TaskHandler.GetTask(taskID)` | `TaskHandle.GetTask()` — this round's continuation snapshot only, `nil` on a fresh round; arbitrary-task reads and `CancellableTask.Cancel` are gone |
 | `TaskHandler.GetMetadata` | removed (it always returned an error in v0.x); message metadata is `ExecContext.Message.Metadata` |
 | `taskmanager.TaskSubscriber` / `CancellableTask` | removed with the callback design |
-| redis `NewTaskSubscriber` / `WithSubscriberSendHook` / `WithSubscriberBlockingSend` | removed — the manager owns fan-out; Redis cross-node `SubscribeToTask` is opt-in with `redis.WithCrossNodeResubscribe(true)` |
+| redis `NewTaskSubscriber` / `WithSubscriberSendHook` / `WithSubscriberBlockingSend` | removed — the manager owns streaming; Redis `SubscribeToTask` uses a cross-node Redis Stream by default |
 
 ### Behavior changes to check
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -362,7 +362,7 @@ func (p *myProcessor) ProcessMessage(
 | `TaskHandler.GetTask(taskID)` | `TaskHandle.GetTask()` —— 仅本轮的续跑快照，全新一轮时为 `nil`；任意 task 读取与 `CancellableTask.Cancel` 均已移除 |
 | `TaskHandler.GetMetadata` | 已移除（它在 v0.x 中总是返回 error）；message 的 metadata 为 `ExecContext.Message.Metadata` |
 | `taskmanager.TaskSubscriber` / `CancellableTask` | 随回调式设计一并移除 |
-| redis `NewTaskSubscriber` / `WithSubscriberSendHook` / `WithSubscriberBlockingSend` | 已移除——fan-out 由 manager 管理；Redis 跨节点 `SubscribeToTask` 可通过 `redis.WithCrossNodeResubscribe(true)` 显式开启 |
+| redis `NewTaskSubscriber` / `WithSubscriberSendHook` / `WithSubscriberBlockingSend` | 已移除——streaming 由 manager 管理；Redis `SubscribeToTask` 默认使用跨节点 Redis Stream |
 
 ### 需要注意的行为变化
 

--- a/docs/mkdocs/en/migration.md
+++ b/docs/mkdocs/en/migration.md
@@ -190,7 +190,7 @@ channel underneath is the actual contract, shown in
 | `taskmanager.CancellableTask` (and `CancellableTask.Cancel`) | removed — cancellation is `CancelTask` cancelling the processor's `ctx` |
 | `memory.NewTaskManager(processor, opts...)` | unchanged shape |
 | `redis.NewTaskManager(...)` | `redis.NewTaskManager(processor, rdb, opts...)` — **note the argument order** `(processor, rdb)` |
-| redis `NewTaskSubscriber` / `WithSubscriberSendHook` / `WithSubscriberBlockingSend` | removed — the manager owns fan-out; Redis cross-node `SubscribeToTask` is opt-in with `redis.WithCrossNodeResubscribe(true)` |
+| redis `NewTaskSubscriber` / `WithSubscriberSendHook` / `WithSubscriberBlockingSend` | removed — the manager owns streaming; Redis `SubscribeToTask` uses a cross-node Redis Stream by default |
 
 ### Wire method names
 

--- a/docs/mkdocs/en/overview.md
+++ b/docs/mkdocs/en/overview.md
@@ -27,7 +27,7 @@ the runtime contract see [Server](server.md) and [Client](client.md).
 | Multi-tenant hosting with per-tenant agent cards | ✅ | One process, many agents, routed by tenant. |
 | Legacy v0.2.x wire compatibility | ✅ | `compat/v0` on the same endpoint and auth chain. |
 | Telemetry: OpenTelemetry metrics, TTFT tracking | ✅ | Pluggable meter provider and first-token policy. |
-| Cross-node `SubscribeToTask` on Redis | ✅ Opt-in | Enable `WithCrossNodeResubscribe(true)` on every replica sharing Redis. |
+| Cross-node `SubscribeToTask` on Redis | ✅ | Redis TaskManager journals Task events by default; Redis 5.0+ is required. |
 
 ## Architecture
 
@@ -120,9 +120,7 @@ retention semantics — lives with the agent-author guide in
 ## Roadmap
 
 - **gRPC transport binding** — the spec defines it alongside JSON-RPC and HTTP+JSON; this framework does not serve gRPC yet.
-- **Redis execution coordination** — cross-node `SubscribeToTask` is available,
-  but continuation, live cancel, and single-writer execution routing remain
-  node-local concerns rather than a distributed work queue.
+- **Redis execution coordination** — cross-node `SubscribeToTask` is available by default, but continuation, live cancel, and single-writer execution routing remain node-local concerns rather than a distributed work queue.
 
 ## Where to go next
 

--- a/docs/mkdocs/en/server.md
+++ b/docs/mkdocs/en/server.md
@@ -296,12 +296,7 @@ tm, _ := redistm.NewTaskManager(proc, redisClient,   // note: (processor, client
 )
 ```
 
-For a multi-replica service, add `redistm.WithCrossNodeResubscribe(true)` on
-**every** replica sharing Redis. It lets `SubscribeToTask` reconnect through a
-different node by atomically storing Task updates with a per-task Redis Stream.
-It does not route continuation, live-cancel, or execution requests between
-nodes. Each task stream retains approximately the latest 10,000 events; clients
-that lag beyond that bound may miss intermediate events.
+The Redis TaskManager requires Redis 5.0 or newer and atomically stores Task updates with a per-task Redis Stream by default. This lets `SubscribeToTask` reconnect through a different replica sharing Redis without extra configuration. It does not route continuation, live-cancel, or execution requests between nodes. Each Task Stream retains approximately the latest 10,000 events; clients that lag beyond that bound may miss intermediate events. Upgrade every replica together: older TaskManager versions do not write the journal consumed by Stream-only subscribers.
 
 → [examples/redis](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples/redis).
 Implement the `taskmanager.TaskManager` interface for a custom backend.
@@ -312,11 +307,9 @@ Retention for the stateful managers:
 | --- | --- | --- |
 | Conversations | cleaned after `ConversationTTL` idle (default 1h); capped at `MaxHistoryLength` | key TTL (default 1h), refreshed on writes |
 | Terminal tasks | **kept forever by default** (`TaskTTL` = 0) — set `memory.WithTaskTTL` in production | key TTL (default 1h, `WithExpireTime`) |
-| Suspended tasks | never collected (cleaner is terminal-only) — have clients resume or cancel them | expire with the key TTL |
+| Suspended tasks | never collected (cleaner is terminal-only) — have clients resume or cancel them | expire with the key TTL; a live execution renews its lease until it finishes or yields |
 
-There is no per-task delete API; A2A defines none. Redis live event fan-out is
-per-process by default; `WithCrossNodeResubscribe(true)` moves resubscribe
-observation to Redis when enabled consistently across replicas.
+There is no per-task delete API; A2A defines none. Redis `SubscribeToTask` observation is backed by the per-task Redis Stream; active local response pipes close when the client disconnects, the Task becomes terminal, or its Redis key expires.
 
 ## Authentication
 

--- a/docs/mkdocs/zh/migration.md
+++ b/docs/mkdocs/zh/migration.md
@@ -169,7 +169,7 @@ func (p *myProcessor) ProcessMessage(
 | `taskmanager.CancellableTask`（及 `CancellableTask.Cancel`） | 移除——取消即 `CancelTask` 取消 processor 的 `ctx` |
 | `memory.NewTaskManager(processor, opts...)` | 形状不变 |
 | `redis.NewTaskManager(...)` | `redis.NewTaskManager(processor, rdb, opts...)`——**注意参数顺序**为 `(processor, rdb)` |
-| redis `NewTaskSubscriber` / `WithSubscriberSendHook` / `WithSubscriberBlockingSend` | 移除——fan-out 由 manager 管理；Redis 跨节点 `SubscribeToTask` 可通过 `redis.WithCrossNodeResubscribe(true)` 显式开启 |
+| redis `NewTaskSubscriber` / `WithSubscriberSendHook` / `WithSubscriberBlockingSend` | 移除——streaming 由 manager 管理；Redis `SubscribeToTask` 默认使用跨节点 Redis Stream |
 
 ### wire 方法名
 

--- a/docs/mkdocs/zh/overview.md
+++ b/docs/mkdocs/zh/overview.md
@@ -32,7 +32,7 @@ tRPC-A2A-Go 是 A2A（Agent-to-Agent）协议 v1.0 的 Go 实现。它同时提�
 | 子路径部署 | 支持 | `WithBasePath` 适配网关或统一前缀。 |
 | legacy v0.2.x wire 兼容 | 支持 | `compat/v0` 挂到同一端点、同一鉴权链，保留 v0 默认行为。 |
 | OpenTelemetry 指标 | 支持 | 请求数、耗时、TTFT；可注入 meter provider 或让 server 创建 OTLP provider。 |
-| Redis 跨节点 `SubscribeToTask` | 可选支持 | 共享 Redis 的所有副本都需开启 `WithCrossNodeResubscribe(true)`。 |
+| Redis 跨节点 `SubscribeToTask` | 支持 | Redis TaskManager 默认记录 Task 事件；要求 Redis 5.0+。 |
 
 ## 架构
 
@@ -103,7 +103,7 @@ sequenceDiagram
 ## 当前边界
 
 - 当前实现 JSON-RPC 与 HTTP+JSON（REST）传输绑定；gRPC 尚未落地。
-- Redis 后端可选择把 Task 事件写入 Redis Stream，使 `SubscribeToTask` 能跨节点接回；continuation、live cancel 和执行 single-writer 仍是节点本地能力，并非分布式工作队列。
+- Redis 后端默认把 Task 事件写入 Redis Stream，使 `SubscribeToTask` 能跨节点接回；continuation、live cancel 和执行 single-writer 仍是节点本地能力，并非分布式工作队列。
 - A2A 没有定义“删除任务”API；生产环境需要通过 TTL 控制终态任务留存。
 
 ## 下一步

--- a/docs/mkdocs/zh/server.md
+++ b/docs/mkdocs/zh/server.md
@@ -236,11 +236,7 @@ tm, _ := redistm.NewTaskManager(proc, redisClient,   // 注意参数序:(process
 )
 ```
 
-多副本部署时，请在共享 Redis 的**每个**副本上增加
-`redistm.WithCrossNodeResubscribe(true)`。它把 Task 更新与每任务 Redis Stream
-事件原子写入，使 `SubscribeToTask` 可经其他节点接回；它不负责跨节点路由
-continuation、live cancel 或执行请求。每个 Task Stream 约保留最新 10,000 个事件；
-落后超过该窗口的客户端可能错过中间事件。
+Redis TaskManager 要求 Redis 5.0 或更高版本，并默认将 Task 更新与每任务 Redis Stream 事件原子写入，使 `SubscribeToTask` 无需额外配置即可经其他共享 Redis 的节点接回；它不负责跨节点路由 continuation、live cancel 或执行请求。每个 Task Stream 约保留最新 10,000 个事件，落后超过该窗口的客户端可能错过中间事件。升级时必须同步更新所有副本，因为旧版 TaskManager 不会写入 Stream-only subscriber 所依赖的事件日志。
 
 → [examples/redis](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples/redis)。实现 `taskmanager.TaskManager` 接口即可自带后端。
 
@@ -250,10 +246,9 @@ continuation、live cancel 或执行请求。每个 Task Stream 约保留最新 
 | --- | --- | --- |
 | 会话 | 闲置超 `ConversationTTL`(默认 1h)即清理;单会话上限 `MaxHistoryLength` | key TTL(默认 1h),写时续期 |
 | 终态任务 | **默认永久保留**(`TaskTTL`=0)——生产环境请设置 `memory.WithTaskTTL` | key TTL(默认 1h,`WithExpireTime`) |
-| 挂起任务 | 永不回收(清理器只收终态)——请让 client 恢复或取消它们 | 随 key TTL 过期 |
+| 挂起任务 | 永不回收(清理器只收终态)——请让 client 恢复或取消它们 | 随 key TTL 过期；活跃执行在结束或让出前会持续续租 |
 
-没有按任务的删除 API；A2A 未定义此类接口。Redis 实时事件扇出默认仍在进程内；所有副本一致开启
-`WithCrossNodeResubscribe(true)` 后，`SubscribeToTask` 的观察面由 Redis 承担。
+没有按任务的删除 API；A2A 未定义此类接口。Redis `SubscribeToTask` 的观察面由每任务 Redis Stream 承担；客户端断开、Task 进入终态或 Redis Task key 过期时，本地响应 pipe 会关闭。
 
 ## 鉴权
 
@@ -400,7 +395,7 @@ srv, _ := server.NewA2AServer(tm, server.WithAgentCard(card),
 | 需求 | 推荐配置 | 注意事项 |
 | --- | --- | --- |
 | 本地开发、单进程 demo | `taskmanager/memory` | 默认终态任务永久保留；生产请设置 `memory.WithTaskTTL`。 |
-| 重启后保留任务、跨节点接回订阅 | `taskmanager/redis` + `WithCrossNodeResubscribe(true)` | 所有共享 Redis 的副本都要开启；只覆盖 `SubscribeToTask`，不路由 continuation/cancel/执行。 |
+| 重启后保留任务、跨节点接回订阅 | `taskmanager/redis` | 要求 Redis 5.0+；只覆盖 `SubscribeToTask`，不路由 continuation/cancel/执行。 |
 | 用户在线等结果 | `SendMessage` 或 `SendStreamingMessage` | v1.0 `SendMessage` 默认阻塞。 |
 | 用户离线等待回调 | push notification + JWKS | 需要 agent card 声明 push 能力，服务端负责发送 webhook。 |
 | 一个 agent 一个进程 | `WithAgentCard` | 最简单，card 直接代表该 agent。 |

--- a/examples/redis/README.md
+++ b/examples/redis/README.md
@@ -160,20 +160,7 @@ Test 2: Streaming conversion with task updates
 
 ### Multiple Server Replicas
 
-When several server replicas share Redis, enable cross-node resubscribe on
-every replica:
-
-```go
-taskManager, err := redisTaskManager.NewTaskManager(
-    processor,
-    rdb,
-    redisTaskManager.WithCrossNodeResubscribe(true),
-)
-```
-
-This lets a reconnecting `SubscribeToTask` request land on a different replica.
-It does not distribute continuation, cancel, or task execution requests; those
-still require a separate execution-coordination design.
+The Redis TaskManager journals Task events in a per-task Redis Stream by default, so a reconnecting `SubscribeToTask` request may land on any replica sharing Redis. Redis 5.0 or newer is required, and all replicas must be upgraded together because older versions of the TaskManager do not write the event journal. This does not distribute continuation, cancel, or task execution requests; those still require a separate execution-coordination design.
 
 ## Command Line Options
 

--- a/taskmanager/redis/redis_cross_node_test.go
+++ b/taskmanager/redis/redis_cross_node_test.go
@@ -7,6 +7,7 @@
 package redis
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"net"
@@ -23,9 +24,8 @@ import (
 	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
 )
 
-// twoNodeManagers builds two RedisTaskManagers sharing one miniredis, both with
-// cross-node resubscribe streaming enabled: nodeA runs procA, nodeB is a
-// bystander instance a resubscribe may land on.
+// twoNodeManagers builds two RedisTaskManagers sharing one miniredis: nodeA
+// runs procA, nodeB is a bystander instance a resubscribe may land on.
 func twoNodeManagers(
 	t *testing.T,
 	procA taskmanager.MessageProcessor,
@@ -36,12 +36,11 @@ func twoNodeManagers(
 	ca := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 	cb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 	t.Cleanup(func() { ca.Close(); cb.Close() })
-	managerOpts := append([]TaskManagerOption{WithCrossNodeResubscribe(true)}, opts...)
-	a, err := NewTaskManager(procA, ca, managerOpts...)
+	a, err := NewTaskManager(procA, ca, opts...)
 	if err != nil {
 		t.Fatalf("nodeA NewTaskManager: %v", err)
 	}
-	b, err := NewTaskManager(scriptedExecutor(), cb, managerOpts...)
+	b, err := NewTaskManager(scriptedExecutor(), cb, opts...)
 	if err != nil {
 		t.Fatalf("nodeB NewTaskManager: %v", err)
 	}
@@ -65,11 +64,23 @@ type nonBlockingEmptyTransport struct {
 	reads atomic.Int64
 }
 
+// readSequenceTransport returns a configurable number of read failures before
+// one event. It exercises the manager-owned retry and cancellation behavior
+// without depending on go-redis command retries.
+type readSequenceTransport struct {
+	reads         atomic.Int64
+	failures      int64
+	event         protocol.StreamResponse
+	returnedEvent chan struct{}
+	returnOnce    sync.Once
+}
+
 func (*nonBlockingEmptyTransport) CommitTaskEvent(
 	context.Context,
 	string,
 	*protocol.Task,
 	protocol.StreamResponse,
+	bool,
 ) error {
 	return nil
 }
@@ -96,6 +107,14 @@ func (*nonBlockingEmptyTransport) LoadTaskAndCursor(
 	}, "cursor", nil
 }
 
+func (*nonBlockingEmptyTransport) RefreshTaskLease(
+	context.Context,
+	string,
+	string,
+) error {
+	return nil
+}
+
 func (t *nonBlockingEmptyTransport) ReadAfter(
 	context.Context,
 	string,
@@ -104,6 +123,67 @@ func (t *nonBlockingEmptyTransport) ReadAfter(
 ) ([]protocol.StreamResponse, string, error) {
 	t.reads.Add(1)
 	return nil, "cursor", nil
+}
+
+func (*readSequenceTransport) CommitTaskEvent(
+	context.Context,
+	string,
+	*protocol.Task,
+	protocol.StreamResponse,
+	bool,
+) error {
+	return nil
+}
+
+func (*readSequenceTransport) AppendEvent(
+	context.Context,
+	string,
+	string,
+	protocol.StreamResponse,
+) error {
+	return nil
+}
+
+func (*readSequenceTransport) LoadTaskAndCursor(
+	context.Context,
+	string,
+	string,
+) (*protocol.Task, string, error) {
+	return &protocol.Task{
+		ID: "task-read-sequence",
+		Status: protocol.TaskStatus{
+			State: protocol.TaskStateWorking,
+		},
+	}, "cursor", nil
+}
+
+func (*readSequenceTransport) RefreshTaskLease(
+	context.Context,
+	string,
+	string,
+) error {
+	return nil
+}
+
+func (t *readSequenceTransport) ReadAfter(
+	context.Context,
+	string,
+	string,
+	string,
+) ([]protocol.StreamResponse, string, error) {
+	read := t.reads.Add(1)
+	if read <= t.failures {
+		return nil, "cursor", errors.New("temporary stream read failure")
+	}
+	if t.event.Result == nil {
+		return nil, "cursor", nil
+	}
+	t.returnOnce.Do(func() {
+		if t.returnedEvent != nil {
+			close(t.returnedEvent)
+		}
+	})
+	return []protocol.StreamResponse{t.event}, "next", nil
 }
 
 func (h *blockAfterCommandHook) DialHook(next redis.DialHook) redis.DialHook {
@@ -220,7 +300,7 @@ func TestCrossNode_ResubscribeReceivesSubsequentEvents(t *testing.T) {
 }
 
 // An event published right after the atomic snapshot/cursor read, before the
-// tailer's first XREAD, is still delivered.
+// tailer's first journal read, is still delivered.
 func TestCrossNode_DeliversEventPublishedRightAfterResubscribe(t *testing.T) {
 	nodeA, nodeB := twoNodeManagers(t, scriptedExecutor())
 	task := storedTask(t, nodeA, "task-gap", "ctx-gap", protocol.TaskStateWorking)
@@ -271,20 +351,194 @@ func TestCrossNode_CancelWithoutLiveRunReachesResubscriber(t *testing.T) {
 	}
 }
 
-// With cross-node resubscribe disabled (default), no per-task stream key is
-// created and the single-node resubscribe path is unchanged.
-func TestCrossNodeResubscribe_Disabled_NoStreamKey(t *testing.T) {
-	mgr, mr := setupTest(t, scriptedExecutor(
+// Task events are journaled by default so a later subscription may resume on
+// any replica sharing Redis.
+func TestTaskEventsUseStreamByDefault(t *testing.T) {
+	mgr, _ := setupTest(t, scriptedExecutor(
 		statusEvent(protocol.TaskStateWorking, agentReply("w")),
 		statusEvent(protocol.TaskStateCompleted, agentReply("done")),
 	))
-	if _, err := mgr.OnSendMessage(context.Background(), sendParams("go", "ctx")); err != nil {
+	response, err := mgr.OnSendMessage(context.Background(), sendParams("go", "ctx"))
+	if err != nil {
 		t.Fatalf("OnSendMessage: %v", err)
 	}
-	for _, k := range mr.Keys() {
-		if strings.HasPrefix(k, streamPrefix) {
-			t.Fatalf("stream key %q created while cross-node resubscribe is off", k)
+	task := response.GetTask()
+	if task == nil {
+		t.Fatalf("expected Task response, got %+v", response)
+	}
+	if got, err := mgr.client.XLen(context.Background(), streamKey("", task.ID)).Result(); err != nil || got != 2 {
+		t.Fatalf("default event stream length = %d, want 2: %v", got, err)
+	}
+}
+
+func TestFirstTaskEventIndexesTask(t *testing.T) {
+	manager, _ := setupTest(t, scriptedExecutor(
+		statusEvent(protocol.TaskStateCompleted, agentReply("done")),
+	))
+	params := sendParams("go", "ctx-first-event-index")
+	params.Tenant = "tenant-a"
+	response, err := manager.OnSendMessage(context.Background(), params)
+	if err != nil {
+		t.Fatalf("OnSendMessage: %v", err)
+	}
+	task := response.GetTask()
+	if task == nil {
+		t.Fatalf("expected Task response, got %+v", response)
+	}
+	listed, err := manager.OnListTasks(context.Background(), protocol.ListTasksParams{Tenant: "tenant-a"})
+	if err != nil {
+		t.Fatalf("OnListTasks: %v", err)
+	}
+	if len(listed.Tasks) != 1 || listed.Tasks[0].ID != task.ID {
+		t.Fatalf("first event did not index Task %s: %+v", task.ID, listed.Tasks)
+	}
+}
+
+// Replaying an operation after a newer cross-node write neither duplicates the
+// Stream entry nor rolls the Task snapshot back. This models go-redis retrying
+// an EVALSHA whose successful reply was lost on the network.
+func TestTaskEventCommitIsIdempotentAcrossInterleavedWrite(t *testing.T) {
+	manager, _ := setupTest(t, scriptedExecutor())
+	transport := manager.eventTransport.(*redisTaskEventTransport)
+	working := &protocol.Task{
+		ID:        "task-idempotent-commit",
+		ContextID: "ctx-idempotent-commit",
+		Status:    protocol.TaskStatus{State: protocol.TaskStateWorking},
+	}
+	workingEvent := protocol.NewStreamResponseStatusUpdate(&protocol.TaskStatusUpdateEvent{
+		TaskID: working.ID, ContextID: working.ContextID, Status: working.Status,
+	})
+	if err := transport.commitTaskEventWithOperationID(
+		context.Background(), "tenant-a", working, workingEvent, true, "op-a",
+	); err != nil {
+		t.Fatalf("first commit: %v", err)
+	}
+
+	completed := copyTask(working)
+	completed.Status.State = protocol.TaskStateCompleted
+	completedEvent := protocol.NewStreamResponseStatusUpdate(&protocol.TaskStatusUpdateEvent{
+		TaskID: completed.ID, ContextID: completed.ContextID, Status: completed.Status,
+	})
+	if err := transport.commitTaskEventWithOperationID(
+		context.Background(), "tenant-a", completed, completedEvent, false, "op-b",
+	); err != nil {
+		t.Fatalf("second commit: %v", err)
+	}
+	if err := transport.commitTaskEventWithOperationID(
+		context.Background(), "tenant-a", working, workingEvent, false, "op-a",
+	); err != nil {
+		t.Fatalf("replayed first commit: %v", err)
+	}
+
+	if got, err := manager.client.XLen(
+		context.Background(), streamKey("tenant-a", working.ID),
+	).Result(); err != nil || got != 2 {
+		t.Fatalf("stream length after replay = %d, want 2: %v", got, err)
+	}
+	stored, err := manager.getTaskInternal(context.Background(), "tenant-a", working.ID)
+	if err != nil {
+		t.Fatalf("load task: %v", err)
+	}
+	if stored.Status.State != protocol.TaskStateCompleted {
+		t.Fatalf("replayed operation rolled task back to %s", stored.Status.State)
+	}
+	if got, err := manager.client.ZCard(
+		context.Background(), streamDedupeKey("tenant-a", working.ID),
+	).Result(); err != nil || got != 3 {
+		t.Fatalf("dedupe journal size = %d, want two operations plus sequence: %v", got, err)
+	}
+}
+
+func TestAppendTaskEventIsIdempotent(t *testing.T) {
+	manager, _ := setupTest(t, scriptedExecutor())
+	task := storedTask(t, manager, "task-idempotent-append", "ctx-idempotent-append", protocol.TaskStateWorking)
+	transport := manager.eventTransport.(*redisTaskEventTransport)
+	first := protocol.NewStreamResponseArtifactUpdate(artifactEvent("artifact", "chunk-a"))
+	second := protocol.NewStreamResponseArtifactUpdate(artifactEvent("artifact", "chunk-b"))
+
+	if err := transport.appendEventWithOperationID(context.Background(), "", task.ID, first, "op-a"); err != nil {
+		t.Fatalf("first append: %v", err)
+	}
+	if err := transport.appendEventWithOperationID(context.Background(), "", task.ID, second, "op-b"); err != nil {
+		t.Fatalf("second append: %v", err)
+	}
+	if err := transport.appendEventWithOperationID(context.Background(), "", task.ID, first, "op-a"); err != nil {
+		t.Fatalf("replayed append: %v", err)
+	}
+	if got, err := manager.client.XLen(context.Background(), streamKey("", task.ID)).Result(); err != nil || got != 2 {
+		t.Fatalf("stream length after append replay = %d, want 2: %v", got, err)
+	}
+}
+
+func TestTaskEventDedupeIsTenantScopedAndTypeChecked(t *testing.T) {
+	manager, _ := setupTest(t, scriptedExecutor())
+	transport := manager.eventTransport.(*redisTaskEventTransport)
+	for _, tenant := range []string{"tenant-a", "tenant-b"} {
+		task := &protocol.Task{
+			ID: "shared-task", ContextID: "ctx-" + tenant,
+			Status: protocol.TaskStatus{State: protocol.TaskStateWorking},
 		}
+		event := protocol.NewStreamResponseTask(task)
+		if err := transport.commitTaskEventWithOperationID(
+			context.Background(), tenant, task, event, true, "op-shared",
+		); err != nil {
+			t.Fatalf("commit for %s: %v", tenant, err)
+		}
+	}
+	for _, tenant := range []string{"tenant-a", "tenant-b"} {
+		if got, err := manager.client.XLen(
+			context.Background(), streamKey(tenant, "shared-task"),
+		).Result(); err != nil || got != 1 {
+			t.Fatalf("%s stream length = %d, want 1: %v", tenant, got, err)
+		}
+	}
+
+	task := storedTask(t, manager, "task-wrong-dedupe", "ctx-wrong-dedupe", protocol.TaskStateWorking)
+	before, err := manager.client.Get(context.Background(), taskKey("", task.ID)).Bytes()
+	if err != nil {
+		t.Fatalf("load original task: %v", err)
+	}
+	if err := manager.client.Set(
+		context.Background(), streamDedupeKey("", task.ID), "wrong-type", 0,
+	).Err(); err != nil {
+		t.Fatalf("seed wrong-type dedupe journal: %v", err)
+	}
+	changed := copyTask(task)
+	changed.Status.State = protocol.TaskStateCompleted
+	err = transport.commitTaskEventWithOperationID(
+		context.Background(), "", changed, protocol.NewStreamResponseTask(changed), false, "op-wrong-type",
+	)
+	if err == nil {
+		t.Fatal("commit unexpectedly succeeded with wrong-type dedupe journal")
+	}
+	after, getErr := manager.client.Get(context.Background(), taskKey("", task.ID)).Bytes()
+	if getErr != nil || !bytes.Equal(after, before) {
+		t.Fatalf("failed commit changed task: before=%s after=%s err=%v", before, after, getErr)
+	}
+	if got, xlenErr := manager.client.XLen(context.Background(), streamKey("", task.ID)).Result(); xlenErr != nil || got != 0 {
+		t.Fatalf("failed commit partially appended event: len=%d err=%v", got, xlenErr)
+	}
+}
+
+func TestReadAfterAdvancesPastMalformedEntry(t *testing.T) {
+	manager, _ := setupTest(t, scriptedExecutor())
+	task := storedTask(t, manager, "task-malformed-entry", "ctx-malformed-entry", protocol.TaskStateWorking)
+	if err := manager.client.XAdd(context.Background(), &redis.XAddArgs{
+		Stream: streamKey("", task.ID), Values: map[string]interface{}{"unexpected": "value"},
+	}).Err(); err != nil {
+		t.Fatalf("seed malformed entry: %v", err)
+	}
+	transport := manager.eventTransport.(*redisTaskEventTransport)
+	events, cursor, err := transport.ReadAfter(context.Background(), "", task.ID, "0-0")
+	if err != nil {
+		t.Fatalf("ReadAfter malformed entry: %v", err)
+	}
+	if len(events) != 0 || cursor == "0-0" {
+		t.Fatalf("malformed entry result: events=%+v cursor=%q", events, cursor)
+	}
+	events, next, err := transport.ReadAfter(context.Background(), "", task.ID, cursor)
+	if err != nil || len(events) != 0 || next != cursor {
+		t.Fatalf("malformed entry was replayed: events=%+v cursor=%q next=%q err=%v", events, cursor, next, err)
 	}
 }
 
@@ -319,6 +573,306 @@ func TestCrossNode_ClientDisconnectClosesStream(t *testing.T) {
 	}
 }
 
+// A subscription closes after the Task and its event journal expire instead of
+// polling a missing stream forever.
+func TestStreamResubscribe_TaskExpirationClosesStream(t *testing.T) {
+	manager, mr := setupTest(t, scriptedExecutor(), WithExpireTime(time.Second))
+	task := storedTask(t, manager, "task-expire", "ctx-expire", protocol.TaskStateWorking)
+
+	stream, err := manager.OnResubscribe(context.Background(), protocol.TaskIDParams{ID: task.ID})
+	if err != nil {
+		t.Fatalf("OnResubscribe: %v", err)
+	}
+	if frame, ok := recvTimeout(t, stream); !ok || frame.GetTask() == nil {
+		t.Fatalf("expected initial snapshot, got %+v", frame)
+	}
+
+	mr.FastForward(2 * time.Second)
+	if frame, ok := recvTimeout(t, stream); ok {
+		t.Fatalf("stream remained open after Task expiration: %+v", frame)
+	}
+}
+
+// A live execution renews its Task, event journal, list index, and push config
+// while the processor is silent. The lease stops after the terminal event.
+func TestStreamResubscribe_LiveTaskRenewsLeaseUntilTerminal(t *testing.T) {
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseProcessor := func() { releaseOnce.Do(func() { close(release) }) }
+	defer releaseProcessor()
+	processorDone := make(chan struct{})
+	processor := executorFunc(func(
+		context.Context, *taskmanager.ExecContext,
+	) (<-chan protocol.StreamEvent, error) {
+		out := make(chan protocol.StreamEvent)
+		go func() {
+			defer close(processorDone)
+			defer close(out)
+			out <- statusEvent(protocol.TaskStateWorking, nil)
+			<-release
+			out <- statusEvent(protocol.TaskStateCompleted, nil)
+		}()
+		return out, nil
+	})
+	const expiration = time.Second
+	manager, mr := setupTest(t, processor, WithExpireTime(expiration))
+
+	returnImmediately := true
+	params := sendParams("long task", "ctx-expired-live")
+	params.Configuration = &protocol.SendMessageConfiguration{ReturnImmediately: &returnImmediately}
+	response, err := manager.OnSendMessage(context.Background(), params)
+	if err != nil {
+		t.Fatalf("OnSendMessage: %v", err)
+	}
+	task := response.GetTask()
+	if task == nil || task.Status.State != protocol.TaskStateWorking {
+		t.Fatalf("expected working Task, got %+v", response)
+	}
+	if _, err := manager.storePushConfig(context.Background(), protocol.TaskPushNotificationConfig{
+		TaskID: task.ID, URL: "https://example.com/live-task",
+	}); err != nil {
+		t.Fatalf("store push config: %v", err)
+	}
+
+	stream, err := manager.OnResubscribe(context.Background(), protocol.TaskIDParams{ID: task.ID})
+	if err != nil {
+		t.Fatalf("OnResubscribe: %v", err)
+	}
+	if frame, ok := recvTimeout(t, stream); !ok || frame.GetTask() == nil {
+		t.Fatalf("expected initial snapshot, got %+v", frame)
+	}
+
+	// Advance more than two full TTLs in smaller steps. A real ticker beat
+	// between steps renews from Redis's current clock.
+	for i := 0; i < 4; i++ {
+		mr.FastForward(700 * time.Millisecond)
+		time.Sleep(400 * time.Millisecond)
+		for _, key := range []string{
+			taskKey("", task.ID),
+			streamKey("", task.ID),
+			streamDedupeKey("", task.ID),
+			pushNotificationKey("", task.ID),
+		} {
+			if !mr.Exists(key) {
+				t.Fatalf("live lease did not retain %s after step %d", key, i+1)
+			}
+		}
+	}
+
+	// Force the tenant index member stale; the next heartbeat must restore its
+	// score, otherwise ListTasks would prune a Task whose storage is still live.
+	if err := manager.client.ZAdd(context.Background(), taskIndexKey(""), redis.Z{
+		Score: float64(time.Now().Add(-time.Second).UnixMilli()), Member: task.ID,
+	}).Err(); err != nil {
+		t.Fatalf("stale task index: %v", err)
+	}
+	time.Sleep(400 * time.Millisecond)
+	listed, err := manager.OnListTasks(context.Background(), protocol.ListTasksParams{})
+	if err != nil {
+		t.Fatalf("OnListTasks: %v", err)
+	}
+	if len(listed.Tasks) != 1 || listed.Tasks[0].ID != task.ID {
+		t.Fatalf("heartbeat did not restore list index: %+v", listed.Tasks)
+	}
+
+	releaseProcessor()
+	select {
+	case <-processorDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("processor did not finish after releasing the terminal event")
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for liveExecutionCount(manager) != 0 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := liveExecutionCount(manager); got != 0 {
+		t.Fatalf("live execution remained registered after terminal event: %d", got)
+	}
+	if !drainForState(t, stream, protocol.TaskStateCompleted) {
+		t.Fatal("resubscriber did not receive terminal event after the silent interval")
+	}
+
+	mr.FastForward(2 * expiration)
+	if got, err := manager.client.Exists(
+		context.Background(),
+		taskKey("", task.ID),
+		streamKey("", task.ID),
+		streamDedupeKey("", task.ID),
+		pushNotificationKey("", task.ID),
+	).Result(); err != nil || got != 0 {
+		t.Fatalf("terminal task lease kept renewing: exists=%d err=%v", got, err)
+	}
+}
+
+func TestContinuationRenewsLeaseBeforeProcessor(t *testing.T) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var mr *miniredis.Miniredis
+	processor := executorFunc(func(
+		context.Context, *taskmanager.ExecContext,
+	) (<-chan protocol.StreamEvent, error) {
+		close(entered)
+		<-release
+		out := make(chan protocol.StreamEvent)
+		close(out)
+		return out, nil
+	})
+	const expiration = time.Second
+	manager, redisServer := setupTest(t, processor, WithExpireTime(expiration))
+	mr = redisServer
+	task := storedTask(t, manager, "task-near-expiry", "ctx-near-expiry", protocol.TaskStateInputRequired)
+	mr.FastForward(900 * time.Millisecond)
+
+	done := make(chan error, 1)
+	go func() {
+		params := sendParams("continue", task.ContextID)
+		params.Message.TaskID = &task.ID
+		_, err := manager.OnSendMessage(context.Background(), params)
+		done <- err
+	}()
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("processor was not called")
+	}
+	if ttl := mr.TTL(taskKey("", task.ID)); ttl != expiration {
+		t.Fatalf("task TTL at processor entry = %v, want %v", ttl, expiration)
+	}
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("continuation did not finish")
+	}
+}
+
+func TestRefreshTaskLeaseDoesNotCreateMissingTask(t *testing.T) {
+	manager, _ := setupTest(t, scriptedExecutor(), WithExpireTime(time.Second))
+	err := manager.refreshTaskLease(context.Background(), "tenant-a", "missing-task")
+	if !errors.Is(err, taskmanager.ErrTaskNotFoundSentinel) {
+		t.Fatalf("refresh missing task error = %v, want TaskNotFound", err)
+	}
+	if got, existsErr := manager.client.Exists(
+		context.Background(),
+		taskKey("tenant-a", "missing-task"),
+		streamKey("tenant-a", "missing-task"),
+		streamDedupeKey("tenant-a", "missing-task"),
+		taskIndexKey("tenant-a"),
+		pushNotificationKey("tenant-a", "missing-task"),
+	).Result(); existsErr != nil || got != 0 {
+		t.Fatalf("refresh created missing task storage: exists=%d err=%v", got, existsErr)
+	}
+}
+
+func TestCrossNodeResubscribeOptionIsDeprecatedNoOp(t *testing.T) {
+	opts := DefaultRedisTaskManagerOptions()
+	WithCrossNodeResubscribe(false)(opts)
+	if !opts.CrossNodeResubscribe {
+		t.Fatal("deprecated option disabled the always-on Redis Stream path")
+	}
+}
+
+// A transient transport error is retried and does not tear down a healthy
+// subscription before its next event arrives.
+func TestStreamResubscribe_TransientReadErrorRetries(t *testing.T) {
+	manager, _ := setupTest(t, scriptedExecutor())
+	transport := &readSequenceTransport{
+		failures: 1,
+		event: protocol.NewStreamResponseStatusUpdate(&protocol.TaskStatusUpdateEvent{
+			TaskID: "task-read-sequence",
+			Status: protocol.TaskStatus{State: protocol.TaskStateCompleted},
+		}),
+	}
+	manager.eventTransport = transport
+
+	stream, err := manager.OnResubscribe(context.Background(), protocol.TaskIDParams{ID: "task-read-sequence"})
+	if err != nil {
+		t.Fatalf("OnResubscribe: %v", err)
+	}
+	if frame, ok := recvTimeout(t, stream); !ok || frame.GetTask() == nil {
+		t.Fatalf("expected initial snapshot, got %+v", frame)
+	}
+	if frame, ok := recvTimeout(t, stream); !ok || frame.GetStatusUpdate() == nil ||
+		frame.GetStatusUpdate().Status.State != protocol.TaskStateCompleted {
+		t.Fatalf("terminal event missing after retry: %+v", frame)
+	}
+	if _, ok := recvTimeout(t, stream); ok {
+		t.Fatal("stream remained open after terminal event")
+	}
+	if got := transport.reads.Load(); got != 2 {
+		t.Fatalf("ReadAfter calls = %d, want 2", got)
+	}
+}
+
+// A longer Redis outage does not turn into a clean EOF. The tailer remains
+// attached and resumes from the same cursor when storage recovers.
+func TestStreamResubscribe_ReadOutageRecovers(t *testing.T) {
+	manager, _ := setupTest(t, scriptedExecutor())
+	transport := &readSequenceTransport{
+		failures: 4,
+		event: protocol.NewStreamResponseStatusUpdate(&protocol.TaskStatusUpdateEvent{
+			TaskID: "task-read-sequence",
+			Status: protocol.TaskStatus{State: protocol.TaskStateCompleted},
+		}),
+	}
+	manager.eventTransport = transport
+
+	stream, err := manager.OnResubscribe(context.Background(), protocol.TaskIDParams{ID: "task-read-sequence"})
+	if err != nil {
+		t.Fatalf("OnResubscribe: %v", err)
+	}
+	if frame, ok := recvTimeout(t, stream); !ok || frame.GetTask() == nil {
+		t.Fatalf("expected initial snapshot, got %+v", frame)
+	}
+	if frame, ok := recvTimeout(t, stream); !ok || frame.GetStatusUpdate() == nil ||
+		frame.GetStatusUpdate().Status.State != protocol.TaskStateCompleted {
+		t.Fatalf("terminal event missing after storage recovery: %+v", frame)
+	}
+	if _, ok := recvTimeout(t, stream); ok {
+		t.Fatal("stream remained open after terminal event")
+	}
+	if got := transport.reads.Load(); got != 5 {
+		t.Fatalf("ReadAfter calls = %d, want 5", got)
+	}
+}
+
+// Canceling the request releases a tailer even when its size-one response pipe
+// is full and the consumer has not drained the initial snapshot.
+func TestStreamResubscribe_CancelReleasesBlockedSend(t *testing.T) {
+	manager, _ := setupTest(t, scriptedExecutor())
+	returnedEvent := make(chan struct{})
+	transport := &readSequenceTransport{
+		event: protocol.NewStreamResponseStatusUpdate(&protocol.TaskStatusUpdateEvent{
+			TaskID: "task-read-sequence",
+			Status: protocol.TaskStatus{State: protocol.TaskStateWorking},
+		}),
+		returnedEvent: returnedEvent,
+	}
+	manager.eventTransport = transport
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stream, err := manager.OnResubscribe(ctx, protocol.TaskIDParams{ID: "task-read-sequence"})
+	if err != nil {
+		t.Fatalf("OnResubscribe: %v", err)
+	}
+	select {
+	case <-returnedEvent:
+	case <-time.After(5 * time.Second):
+		t.Fatal("tailer did not read the event")
+	}
+	cancel()
+
+	if frame, ok := recvTimeout(t, stream); !ok || frame.GetTask() == nil {
+		t.Fatalf("expected buffered snapshot, got %+v", frame)
+	}
+	for {
+		if _, ok := recvTimeout(t, stream); !ok {
+			break
+		}
+	}
+}
+
 // Close returns promptly and joins an active polling resubscribe tailer.
 func TestCrossNode_CloseJoinsActiveTailer(t *testing.T) {
 	nodeA, nodeB := twoNodeManagers(t, scriptedExecutor())
@@ -336,6 +890,67 @@ func TestCrossNode_CloseJoinsActiveTailer(t *testing.T) {
 	}
 }
 
+// Close cancels and joins Stream tailers before waiting for a slow processor
+// to finish, while keeping Redis open for the engine's final CANCELED commit.
+func TestCrossNode_CloseStopsTailerBeforeSlowEngine(t *testing.T) {
+	canceled := make(chan struct{})
+	release := make(chan struct{})
+	processor := executorFunc(func(
+		ctx context.Context, _ *taskmanager.ExecContext,
+	) (<-chan protocol.StreamEvent, error) {
+		out := make(chan protocol.StreamEvent)
+		go func() {
+			out <- statusEvent(protocol.TaskStateWorking, nil)
+			<-ctx.Done()
+			close(canceled)
+			<-release
+			close(out)
+		}()
+		return out, nil
+	})
+	manager, _ := setupTest(t, processor)
+	returnImmediately := true
+	params := sendParams("slow close", "ctx-slow-close")
+	params.Configuration = &protocol.SendMessageConfiguration{ReturnImmediately: &returnImmediately}
+	response, err := manager.OnSendMessage(context.Background(), params)
+	if err != nil {
+		t.Fatalf("OnSendMessage: %v", err)
+	}
+	task := response.GetTask()
+	stream, err := manager.OnResubscribe(context.Background(), protocol.TaskIDParams{ID: task.ID})
+	if err != nil {
+		t.Fatalf("OnResubscribe: %v", err)
+	}
+	if frame, ok := recvTimeout(t, stream); !ok || frame.GetTask() == nil {
+		t.Fatalf("expected initial snapshot, got %+v", frame)
+	}
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- manager.Close() }()
+	select {
+	case <-canceled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close did not cancel the processor")
+	}
+	if frame, ok := recvTimeout(t, stream); ok {
+		t.Fatalf("tailer remained open while Close waited for engine: %+v", frame)
+	}
+	select {
+	case err := <-closeDone:
+		t.Fatalf("Close returned before slow engine finished: %v", err)
+	default:
+	}
+	close(release)
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close did not return after slow engine finished")
+	}
+}
+
 // A task event committed before the atomic snapshot/cursor read is represented
 // by the snapshot only. A later event is represented by the stream only.
 func TestCrossNode_AtomicSnapshotCursorHasNoOverlapOrGap(t *testing.T) {
@@ -347,7 +962,7 @@ func TestCrossNode_AtomicSnapshotCursorHasNoOverlapOrGap(t *testing.T) {
 	first.ContextID = task.ContextID
 	task.Artifacts, _ = protocol.AppendArtifact(task.Artifacts, first.Artifact, false)
 	if err := nodeA.commitTaskEvent(
-		context.Background(), "", task, protocol.NewStreamResponseArtifactUpdate(first),
+		context.Background(), "", task, protocol.NewStreamResponseArtifactUpdate(first), false,
 	); err != nil {
 		t.Fatalf("store first task event: %v", err)
 	}
@@ -374,7 +989,7 @@ func TestCrossNode_AtomicSnapshotCursorHasNoOverlapOrGap(t *testing.T) {
 	second.Append = &appendChunk
 	task.Artifacts, _ = protocol.AppendArtifact(task.Artifacts, second.Artifact, true)
 	if err := nodeA.commitTaskEvent(
-		context.Background(), "", task, protocol.NewStreamResponseArtifactUpdate(second),
+		context.Background(), "", task, protocol.NewStreamResponseArtifactUpdate(second), false,
 	); err != nil {
 		t.Fatalf("store second task event: %v", err)
 	}
@@ -409,7 +1024,7 @@ func TestCrossNode_InputRequiredDoesNotCloseResubscribe(t *testing.T) {
 	input.ContextID = task.ContextID
 	task.Status = input.Status
 	if err := nodeA.commitTaskEvent(
-		context.Background(), "", task, protocol.NewStreamResponseStatusUpdate(input),
+		context.Background(), "", task, protocol.NewStreamResponseStatusUpdate(input), false,
 	); err != nil {
 		t.Fatalf("store input-required: %v", err)
 	}
@@ -422,7 +1037,7 @@ func TestCrossNode_InputRequiredDoesNotCloseResubscribe(t *testing.T) {
 	completed.ContextID = task.ContextID
 	task.Status = completed.Status
 	if err := nodeA.commitTaskEvent(
-		context.Background(), "", task, protocol.NewStreamResponseStatusUpdate(completed),
+		context.Background(), "", task, protocol.NewStreamResponseStatusUpdate(completed), false,
 	); err != nil {
 		t.Fatalf("store completed: %v", err)
 	}
@@ -479,11 +1094,7 @@ func TestCrossNode_ContinuationStatusMessageClearIsJournaled(t *testing.T) {
 // The Redis tailer is an independent reader, so it uses cancelable blocking
 // backpressure instead of treating a temporarily full output buffer as EOF.
 func TestCrossNode_SlowConsumerDoesNotLoseStream(t *testing.T) {
-	nodeA, nodeB := twoNodeManagers(
-		t,
-		scriptedExecutor(),
-		WithTaskSubscriberBufferSize(1),
-	)
+	nodeA, nodeB := twoNodeManagers(t, scriptedExecutor())
 	task := storedTask(t, nodeA, "task-slow", "ctx-slow", protocol.TaskStateWorking)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -491,6 +1102,9 @@ func TestCrossNode_SlowConsumerDoesNotLoseStream(t *testing.T) {
 	stream, err := nodeB.OnResubscribe(ctx, protocol.TaskIDParams{ID: task.ID})
 	if err != nil {
 		t.Fatalf("OnResubscribe: %v", err)
+	}
+	if got := cap(stream); got != 1 {
+		t.Fatalf("resubscribe response buffer = %d, want 1", got)
 	}
 	const updates = 4
 	for i := 0; i < updates; i++ {
@@ -509,8 +1123,8 @@ func TestCrossNode_SlowConsumerDoesNotLoseStream(t *testing.T) {
 		if frame, ok := recvTimeout(t, stream); !ok || frame.GetStatusUpdate() == nil {
 			t.Fatalf("slow consumer lost queued update %d, got %+v", i, frame)
 		}
-		// Keep the size-one buffer full between reads. A non-blocking tailer would
-		// evict the subscriber before all queued Redis events are delivered.
+		// Keep the size-one buffer full between reads. The tailer must apply
+		// backpressure without losing events from the Redis journal.
 		time.Sleep(10 * time.Millisecond)
 	}
 }
@@ -549,7 +1163,7 @@ func TestCrossNode_IdleTailerDoesNotStarveTaskStoragePool(t *testing.T) {
 		PoolSize:    1,
 		PoolTimeout: 50 * time.Millisecond,
 	})
-	manager, err := NewTaskManager(scriptedExecutor(), client, WithCrossNodeResubscribe(true))
+	manager, err := NewTaskManager(scriptedExecutor(), client)
 	if err != nil {
 		t.Fatalf("NewTaskManager: %v", err)
 	}
@@ -596,24 +1210,14 @@ func TestCrossNode_WrongTypeStreamFailsAtomically(t *testing.T) {
 	}
 }
 
-// A Message emitted for an existing Task is not reported to the RPC or local
-// subscribers unless its cross-node stream append succeeds.
+// A Message emitted for an existing Task is not reported to the RPC or stored
+// in history unless its stream append succeeds.
 func TestCrossNode_MessageAppendFailureIsNotExposedAsSuccess(t *testing.T) {
-	manager, _ := setupTest(
-		t,
-		scriptedExecutor(agentReply("reply")),
-		WithCrossNodeResubscribe(true),
-	)
+	manager, _ := setupTest(t, scriptedExecutor(agentReply("reply")))
 	task := storedTask(t, manager, "task-message-fail", "ctx-message-fail", protocol.TaskStateWorking)
 	if err := manager.client.Set(context.Background(), streamKey("", task.ID), "not-a-stream", 0).Err(); err != nil {
 		t.Fatalf("seed wrong-type stream key: %v", err)
 	}
-	subscriber := newTaskSubscriber(task.ID, 1, false)
-	manager.subMu.Lock()
-	manager.subscribers[newScopedID("", task.ID)] = []*taskSubscriber{subscriber}
-	manager.subMu.Unlock()
-	defer manager.cleanupFailedSubscribers("", task.ID, []*taskSubscriber{subscriber})
-
 	params := sendParams("continue", task.ContextID)
 	params.Message.TaskID = &task.ID
 	response, err := manager.OnSendMessage(context.Background(), params)
@@ -622,9 +1226,6 @@ func TestCrossNode_MessageAppendFailureIsNotExposedAsSuccess(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "task event stream has wrong type") {
 		t.Fatalf("message append returned the wrong error: %v", err)
-	}
-	if buffered := len(subscriber.Channel()); buffered != 0 {
-		t.Fatalf("message append failure reached local subscriber: buffered=%d", buffered)
 	}
 	history, err := manager.getConversationHistory(context.Background(), "", task.ContextID, 100)
 	if err != nil {
@@ -658,7 +1259,6 @@ func TestCrossNode_TaskCommitFailureIsNotExposedAsSuccess(t *testing.T) {
 			manager, _ := setupTest(
 				t,
 				scriptedExecutor(test.event),
-				WithCrossNodeResubscribe(true),
 			)
 			taskID := "task-" + test.name + "-fail"
 			contextID := "ctx-" + test.name + "-fail"
@@ -710,7 +1310,7 @@ func TestCrossNode_PersistenceFailureReturnsBeforeProcessorCloses(t *testing.T) 
 		}()
 		return out, nil
 	})
-	manager, _ := setupTest(t, processor, WithCrossNodeResubscribe(true))
+	manager, _ := setupTest(t, processor)
 	task := storedTask(t, manager, "task-fast-failure", "ctx-fast-failure", protocol.TaskStateWorking)
 	if err := manager.client.Set(context.Background(), streamKey("", task.ID), "not-a-stream", 0).Err(); err != nil {
 		t.Fatalf("seed wrong-type stream key: %v", err)
@@ -757,7 +1357,7 @@ func TestCrossNode_PersistenceFailureClosesStreamBeforeProcessorCloses(t *testin
 		}()
 		return out, nil
 	})
-	manager, _ := setupTest(t, processor, WithCrossNodeResubscribe(true))
+	manager, _ := setupTest(t, processor)
 	task := storedTask(t, manager, "task-stream-failure", "ctx-stream-failure", protocol.TaskStateWorking)
 	if err := manager.client.Set(context.Background(), streamKey("", task.ID), "not-a-stream", 0).Err(); err != nil {
 		t.Fatalf("seed wrong-type stream key: %v", err)
@@ -805,7 +1405,7 @@ func TestCrossNode_FailedStatusCommitDoesNotAdvanceHistory(t *testing.T) {
 		}()
 		return out, nil
 	})
-	manager, _ := setupTest(t, processor, WithCrossNodeResubscribe(true))
+	manager, _ := setupTest(t, processor)
 	result := make(chan error, 1)
 	go func() {
 		_, err := manager.OnSendMessage(context.Background(), sendParams("start", "ctx-history-failure"))
@@ -858,7 +1458,6 @@ func TestCrossNode_SubMillisecondExpirationIsClamped(t *testing.T) {
 	manager, _ := setupTest(
 		t,
 		scriptedExecutor(),
-		WithCrossNodeResubscribe(true),
 		WithExpireTime(time.Nanosecond),
 	)
 	if manager.expiration != time.Millisecond {
@@ -870,7 +1469,7 @@ func TestCrossNode_SubMillisecondExpirationIsClamped(t *testing.T) {
 	update.ContextID = task.ContextID
 	task.Status = update.Status
 	if err := manager.commitTaskEvent(
-		context.Background(), "", task, protocol.NewStreamResponseStatusUpdate(update),
+		context.Background(), "", task, protocol.NewStreamResponseStatusUpdate(update), false,
 	); err != nil {
 		t.Fatalf("commitTaskEvent with sub-millisecond configured TTL: %v", err)
 	}
@@ -882,7 +1481,7 @@ func TestCrossNode_SubMillisecondExpirationIsClamped(t *testing.T) {
 // The event-transport path preserves storeTask's push-registration TTL refresh
 // without pulling the cross-slot push key into the atomic Task/event script.
 func TestCrossNode_TaskCommitRefreshesPushConfigExpiration(t *testing.T) {
-	manager, _ := setupTest(t, scriptedExecutor(), WithCrossNodeResubscribe(true))
+	manager, _ := setupTest(t, scriptedExecutor())
 	task := storedTask(t, manager, "task-push-expire", "ctx-push-expire", protocol.TaskStateWorking)
 	pushKey := pushNotificationPrefix + task.ID
 	if err := manager.client.HSet(context.Background(), pushKey, "config", "value").Err(); err != nil {
@@ -896,7 +1495,7 @@ func TestCrossNode_TaskCommitRefreshesPushConfigExpiration(t *testing.T) {
 	update.ContextID = task.ContextID
 	task.Status = update.Status
 	if err := manager.commitTaskEvent(
-		context.Background(), "", task, protocol.NewStreamResponseStatusUpdate(update),
+		context.Background(), "", task, protocol.NewStreamResponseStatusUpdate(update), false,
 	); err != nil {
 		t.Fatalf("commitTaskEvent: %v", err)
 	}

--- a/taskmanager/redis/redis_engine.go
+++ b/taskmanager/redis/redis_engine.go
@@ -9,6 +9,7 @@ package redis
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"time"
@@ -176,6 +177,8 @@ func (m *TaskManager) resolveContinuation(
 // preparation: it stores the request message, resolves continuation vs new
 // task ID, builds the ExecContext, registers the cancel handle, and invokes
 // the MessageProcessor. On success the engine goroutine owns the event channel.
+//
+//nolint:gocyclo // Preparation keeps admission, continuation lease, history, and processor handoff in one rollback path.
 func (m *TaskManager) prepareExecution(
 	ctx context.Context,
 	request *protocol.SendMessageParams,
@@ -234,6 +237,14 @@ func (m *TaskManager) prepareExecution(
 		return nil, err
 	}
 	if task != nil {
+		// A continuation may take ownership just before the old TTL elapses.
+		// Renew it synchronously before invoking user code; the engine ticker
+		// takes over once ProcessMessage returns its channel.
+		if err := m.refreshTaskLease(ctx, request.Tenant, taskID); err != nil {
+			m.releaseExecution(request.Tenant, taskID, ex.live)
+			cancel()
+			return nil, err
+		}
 		// A follow-up without an explicit contextId continues the task's
 		// conversation; otherwise ec.History would miss the earlier turns.
 		if (message.ContextID == nil || *message.ContextID == "") && task.ContextID != "" {
@@ -271,7 +282,7 @@ func (m *TaskManager) prepareExecution(
 				ContextID: task.ContextID,
 				Status:    task.Status,
 			}
-			if err := m.commitTaskEvent(ctx, request.Tenant, task, protocol.NewStreamResponseStatusUpdate(event)); err != nil {
+			if err := m.commitTaskEvent(ctx, request.Tenant, task, protocol.NewStreamResponseStatusUpdate(event), false); err != nil {
 				m.releaseExecution(request.Tenant, taskID, ex.live)
 				cancel()
 				return nil, fmt.Errorf("failed to advance task status history: %w", err)
@@ -376,30 +387,60 @@ func (m *TaskManager) prepareInlinePushConfig(
 // event before broadcasting it, and always drains the channel to closure so
 // the MessageProcessor's sends never leak.
 func (ex *execution) run(events <-chan protocol.StreamEvent) {
-	mode := engineConsuming
-	for event := range events {
-		if ex.runErr != nil {
-			log.Warnf("RedisTaskManager: discarding %T for task %s after execution persistence failed",
-				event, ex.ec.TaskID)
-			continue
-		}
-		switch mode {
-		case engineDrainTerminal:
-			log.Warnf("RedisTaskManager: discarding %T for task %s emitted after terminal state",
-				event, ex.ec.TaskID)
-			continue
-		case engineDrainViolation:
-			log.Warnf("RedisTaskManager: discarding %T for task %s emitted after a contract violation",
-				event, ex.ec.TaskID)
-			continue
-		case engineDrainYielded:
-			log.Warnf("RedisTaskManager: discarding %T for task %s emitted after the round yielded (suspended task)",
-				event, ex.ec.TaskID)
-			continue
-		}
-		mode = ex.handleEvent(event)
+	leaseInterval := ex.manager.expiration / 3
+	if leaseInterval < time.Millisecond {
+		leaseInterval = time.Millisecond
 	}
-	ex.finish()
+	leaseTicker := time.NewTicker(leaseInterval)
+	defer leaseTicker.Stop()
+
+	mode := engineConsuming
+	for {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				ex.finish()
+				return
+			}
+			if ex.runErr != nil {
+				log.Warnf("RedisTaskManager: discarding %T for task %s after execution persistence failed",
+					event, ex.ec.TaskID)
+				continue
+			}
+			switch mode {
+			case engineDrainTerminal:
+				log.Warnf("RedisTaskManager: discarding %T for task %s emitted after terminal state",
+					event, ex.ec.TaskID)
+				continue
+			case engineDrainViolation:
+				log.Warnf("RedisTaskManager: discarding %T for task %s emitted after a contract violation",
+					event, ex.ec.TaskID)
+				continue
+			case engineDrainYielded:
+				log.Warnf("RedisTaskManager: discarding %T for task %s emitted after the round yielded (suspended task)",
+					event, ex.ec.TaskID)
+				continue
+			}
+			mode = ex.handleEvent(event)
+		case <-leaseTicker.C:
+			ex.refreshTaskLease()
+		}
+	}
+}
+
+func (ex *execution) refreshTaskLease() {
+	if ex.task == nil || isFinalState(ex.task.Status.State) || ex.yielded || ex.runErr != nil {
+		return
+	}
+	err := ex.manager.refreshTaskLease(context.Background(), ex.ec.Tenant, ex.ec.TaskID)
+	if err == nil {
+		return
+	}
+	if errors.Is(err, taskmanager.ErrTaskNotFoundSentinel) {
+		ex.failRun(fmt.Errorf("failed to renew live task %s: %w", ex.ec.TaskID, err))
+		return
+	}
+	log.Warnf("RedisTaskManager: failed to renew live task %s: %v", ex.ec.TaskID, err)
 }
 
 // failRun exposes a persistence failure immediately while the engine keeps
@@ -582,9 +623,10 @@ func (ex *execution) stampTaskEventIDs(taskID, contextID *string) bool {
 }
 
 // processMessageEvent stores a reply Message into the conversation and
-// forwards it to the request pipe and, when a task exists, its subscribers.
-// The immediateResult outcome is offered before the fan-out so a returnImmediately
-// waiter is never stalled behind a slow subscriber.
+// forwards it to the request pipe. When a task exists, the event journal was
+// already updated by appendTaskEvent.
+// The immediateResult outcome is offered before response delivery so a
+// returnImmediately waiter is never stalled behind a response pipe or push.
 func (ex *execution) processMessageEvent(msg *protocol.Message) {
 	contextID := ex.ec.ContextID
 	ex.manager.stampReplyMessage(&contextID, msg)
@@ -635,8 +677,7 @@ func (ex *execution) rollStatusMessage(message *protocol.Message) {
 
 // processStatusEvent applies a status update to the task (lazily creating it
 // on the first task event), persists it, and only then broadcasts it: at any
-// moment GetTask reads a state >= what the stream has delivered. Terminal
-// states also close the task's subscribers.
+// moment GetTask reads a state >= what the stream has delivered.
 func (ex *execution) processStatusEvent(ev *protocol.TaskStatusUpdateEvent) {
 	if ev.Status.State == "" || ev.Status.State == protocol.TaskStateUnspecified {
 		// A stateless status event would strand the task in a dangling
@@ -662,7 +703,8 @@ func (ex *execution) processStatusEvent(ev *protocol.TaskStatusUpdateEvent) {
 		Timestamp: timestamp,
 	}
 	var previousStatusMessage *protocol.Message
-	if ex.task == nil {
+	allowCreate := ex.task == nil
+	if allowCreate {
 		ex.task = ex.newTask(ev.TaskID, ev.ContextID, status)
 	} else {
 		previousStatusMessage = ex.task.Status.Message
@@ -686,7 +728,7 @@ func (ex *execution) processStatusEvent(ev *protocol.TaskStatusUpdateEvent) {
 	// execution result: the mutated working copy is never returned as if it had
 	// committed successfully.
 	response := protocol.NewStreamResponseStatusUpdate(ev)
-	if err := ex.manager.commitTaskEvent(context.Background(), ex.ec.Tenant, ex.task, response); err != nil {
+	if err := ex.manager.commitTaskEvent(context.Background(), ex.ec.Tenant, ex.task, response, allowCreate); err != nil {
 		if yielding {
 			ex.manager.abortExecutionYield(ex.ec.Tenant, ex.ec.TaskID, ex.live)
 		}
@@ -711,7 +753,7 @@ func (ex *execution) processStatusEvent(ev *protocol.TaskStatusUpdateEvent) {
 		// queue may delay publication, but a client can never observe a state it
 		// cannot yet continue. The handoff starts before enqueue so a client that
 		// polls the persisted task also waits instead of being rejected. It also
-		// serializes task-subscriber fan-out with a continuation round.
+		// serializes current-request delivery with a continuation round.
 		ex.manager.dispatchPush(ex.ec.Tenant, ex.ec.TaskID, response)
 		ex.offerImmediateTask()
 		ex.broadcastWithoutPush(response)
@@ -720,12 +762,11 @@ func (ex *execution) processStatusEvent(ev *protocol.TaskStatusUpdateEvent) {
 		return
 	}
 
-	// Immediate result first: a returnImmediately waiter must never be stalled behind
-	// a slow subscriber in the fan-out below.
+	// Immediate result first: a returnImmediately waiter must never be stalled
+	// behind response delivery or push dispatch below.
 	ex.offerImmediateTask()
 	ex.broadcast(response)
 	if final {
-		ex.manager.cleanSubscribers(ex.ec.Tenant, ev.TaskID)
 		// Nothing can follow a terminal frame: end the response stream here
 		// instead of trusting the MessageProcessor to close its channel promptly.
 		ex.closePipe()
@@ -742,7 +783,8 @@ func (ex *execution) processArtifactEvent(ev *protocol.TaskArtifactUpdateEvent) 
 			ex.ec.TaskID, ex.task.Status.State)
 		return
 	}
-	if ex.task == nil {
+	allowCreate := ex.task == nil
+	if allowCreate {
 		ex.task = ex.newTask(ev.TaskID, ev.ContextID, protocol.TaskStatus{
 			State:     protocol.TaskStateSubmitted,
 			Timestamp: time.Now().UTC().Format(time.RFC3339),
@@ -757,7 +799,7 @@ func (ex *execution) processArtifactEvent(ev *protocol.TaskArtifactUpdateEvent) 
 	ex.taskTouched = true
 	// Persist before broadcast (consistency order).
 	response := protocol.NewStreamResponseArtifactUpdate(ev)
-	if err := ex.manager.commitTaskEvent(context.Background(), ex.ec.Tenant, ex.task, response); err != nil {
+	if err := ex.manager.commitTaskEvent(context.Background(), ex.ec.Tenant, ex.task, response, allowCreate); err != nil {
 		ex.failRun(fmt.Errorf("failed to store task %s artifact: %w", ev.TaskID, err))
 		return
 	}
@@ -766,8 +808,8 @@ func (ex *execution) processArtifactEvent(ev *protocol.TaskArtifactUpdateEvent) 
 		ex.failTask("failed to persist inline push config")
 		return
 	}
-	// Immediate result first: a returnImmediately waiter must never be stalled behind
-	// a slow subscriber in the fan-out below.
+	// Immediate result first: a returnImmediately waiter must never be stalled
+	// behind response delivery or push dispatch below.
 	ex.offerImmediateTask()
 	ex.broadcast(response)
 }
@@ -805,7 +847,8 @@ func (ex *execution) closePipe() {
 }
 
 // broadcast forwards an event to the request pipe and, when a task exists,
-// to the task's subscribers. Storage was already updated by the caller.
+// dispatches push notifications. The event journal was already updated by the
+// caller and SubscribeToTask readers consume it independently.
 func (ex *execution) broadcast(event protocol.StreamResponse) {
 	if ex.pipe != nil {
 		if err := ex.pipe.Send(event); err != nil {
@@ -813,7 +856,7 @@ func (ex *execution) broadcast(event protocol.StreamResponse) {
 		}
 	}
 	if ex.task != nil {
-		ex.manager.notifySubscribers(ex.ec.Tenant, ex.ec.TaskID, event)
+		ex.manager.dispatchPush(ex.ec.Tenant, ex.ec.TaskID, event)
 	}
 }
 
@@ -824,9 +867,6 @@ func (ex *execution) broadcastWithoutPush(event protocol.StreamResponse) {
 		if err := ex.pipe.Send(event); err != nil {
 			log.Warnf("RedisTaskManager: failed to send event to request pipe for task %s: %v", ex.ec.TaskID, err)
 		}
-	}
-	if ex.task != nil {
-		ex.manager.notifyLiveSubscribers(ex.ec.Tenant, ex.ec.TaskID, event)
 	}
 }
 

--- a/taskmanager/redis/redis_engine_test.go
+++ b/taskmanager/redis/redis_engine_test.go
@@ -161,52 +161,6 @@ func TestTaskSubscriber_BlockingSendWedgeReleasableByClose(t *testing.T) {
 }
 
 // =============================================================================
-// FIX-C: evicted slow subscribers must have their channel closed
-// =============================================================================
-
-// A non-blocking subscriber whose buffer overflows is evicted from the map and
-// its channel must be closed, or its consumer's range loop hangs forever.
-func TestNotifySubscribers_EvictedSlowSubscriberChannelIsClosed(t *testing.T) {
-	m, _ := setupTest(t, scriptedExecutor())
-	taskID := "task-slow"
-
-	// Register a non-blocking subscriber with a tiny buffer directly.
-	sub := newTaskSubscriber(taskID, 1, false)
-	m.subMu.Lock()
-	m.subscribers[newScopedID("", taskID)] = []*taskSubscriber{sub}
-	m.subMu.Unlock()
-
-	event := protocol.NewStreamResponseStatusUpdate(&protocol.TaskStatusUpdateEvent{TaskID: taskID})
-	// First fills the buffer, second overflows and evicts the subscriber.
-	m.notifySubscribers("", taskID, event)
-	m.notifySubscribers("", taskID, event)
-
-	// The evicted subscriber's channel must be closed: draining it must end.
-	done := make(chan struct{})
-	go func() {
-		for range sub.Channel() {
-		}
-		close(done)
-	}()
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("evicted subscriber channel was never closed; consumer range loop hangs")
-	}
-	if !sub.Closed() {
-		t.Error("evicted subscriber must be marked closed")
-	}
-
-	// It must also be gone from the map.
-	m.subMu.RLock()
-	_, exists := m.subscribers[newScopedID("", taskID)]
-	m.subMu.RUnlock()
-	if exists {
-		t.Error("evicted subscriber must be removed from the map")
-	}
-}
-
-// =============================================================================
 // FIX-D: register-or-reject — a concurrent continuation is rejected
 // =============================================================================
 

--- a/taskmanager/redis/redis_event_transport.go
+++ b/taskmanager/redis/redis_event_transport.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	redisclient "github.com/redis/go-redis/v9"
@@ -28,12 +29,14 @@ import (
 // two.
 type taskEventTransport interface {
 	// CommitTaskEvent atomically stores a Task snapshot and the event that
-	// produced it.
+	// produced it. allowCreate is true only for a task's first event; later
+	// events must not recreate a Task that expired while execution was silent.
 	CommitTaskEvent(
 		ctx context.Context,
 		tenant string,
 		task *protocol.Task,
 		event protocol.StreamResponse,
+		allowCreate bool,
 	) error
 	// AppendEvent stores an event that does not modify the Task snapshot.
 	AppendEvent(
@@ -58,6 +61,9 @@ type taskEventTransport interface {
 		taskID string,
 		cursor string,
 	) ([]protocol.StreamResponse, string, error)
+	// RefreshTaskLease extends an existing live Task and its event journal. It
+	// must not create a missing Task.
+	RefreshTaskLease(ctx context.Context, tenant string, taskID string) error
 }
 
 const (
@@ -65,11 +71,14 @@ const (
 	// streamKey adds the task key as a Redis Cluster hash tag so the task and
 	// stream can be read or written atomically by one script.
 	streamPrefix = "stream:"
+	// streamDedupePrefix keys the bounded operation journal that makes a Lua
+	// write safe when go-redis retries after an ambiguous network failure.
+	streamDedupePrefix = "stream-dedupe:"
 	// streamField is the single XADD field carrying the JSON-encoded StreamResponse.
 	streamField = "e"
 	// streamMaxLen caps each task's event stream (XADD MAXLEN ~).
 	streamMaxLen = 10000
-	// streamReadCount caps entries returned per XREAD.
+	// streamReadCount caps entries returned per read.
 	streamReadCount = 64
 )
 
@@ -78,15 +87,33 @@ const (
 // with respect to other clients but do not roll back commands after a runtime
 // error. The task and stream keys share one Redis Cluster slot (see streamKey).
 var commitTaskEventScript = redisclient.NewScript(`
+if ARGV[6] ~= '1' and redis.call('EXISTS', KEYS[1]) == 0 then
+    return redis.error_reply('task does not exist')
+end
 local stream_type = redis.call('TYPE', KEYS[2]).ok
 if stream_type ~= 'none' and stream_type ~= 'stream' then
     return redis.error_reply('task event stream has wrong type')
+end
+local dedupe_type = redis.call('TYPE', KEYS[3]).ok
+if dedupe_type ~= 'none' and dedupe_type ~= 'zset' then
+    return redis.error_reply('task event dedupe journal has wrong type')
+end
+local existing = redis.call('ZSCORE', KEYS[3], ARGV[7])
+if existing then
+    return existing
 end
 local event_id = redis.call(
     'XADD', KEYS[2], 'MAXLEN', '~', ARGV[3], '*', ARGV[4], ARGV[2]
 )
 redis.call('SET', KEYS[1], ARGV[1], 'PX', ARGV[5])
 redis.call('PEXPIRE', KEYS[2], ARGV[5])
+local sequence = redis.call('ZINCRBY', KEYS[3], 1, '__seq')
+redis.call('ZADD', KEYS[3], sequence, ARGV[7])
+local excess = redis.call('ZCARD', KEYS[3]) - (tonumber(ARGV[3]) + 1)
+if excess > 0 then
+    redis.call('ZREMRANGEBYRANK', KEYS[3], 0, excess - 1)
+end
+redis.call('PEXPIRE', KEYS[3], ARGV[5])
 return event_id
 `)
 
@@ -102,15 +129,70 @@ local stream_type = redis.call('TYPE', KEYS[2]).ok
 if stream_type ~= 'none' and stream_type ~= 'stream' then
     return redis.error_reply('task event stream has wrong type')
 end
+local dedupe_type = redis.call('TYPE', KEYS[3]).ok
+if dedupe_type ~= 'none' and dedupe_type ~= 'zset' then
+    return redis.error_reply('task event dedupe journal has wrong type')
+end
+local existing = redis.call('ZSCORE', KEYS[3], ARGV[4])
+if existing then
+    return existing
+end
 local event_id = redis.call(
     'XADD', KEYS[2], 'MAXLEN', '~', ARGV[2], '*', ARGV[3], ARGV[1]
 )
+local sequence = redis.call('ZINCRBY', KEYS[3], 1, '__seq')
+redis.call('ZADD', KEYS[3], sequence, ARGV[4])
+local excess = redis.call('ZCARD', KEYS[3]) - (tonumber(ARGV[2]) + 1)
+if excess > 0 then
+    redis.call('ZREMRANGEBYRANK', KEYS[3], 0, excess - 1)
+end
 if task_ttl == -1 then
     redis.call('PERSIST', KEYS[2])
+    redis.call('PERSIST', KEYS[3])
 else
     redis.call('PEXPIRE', KEYS[2], math.max(1, task_ttl))
+    redis.call('PEXPIRE', KEYS[3], math.max(1, task_ttl))
 end
 return event_id
+`)
+
+// readAfterScript reads strictly after the cursor and checks Task existence at
+// the same Redis linearization point. Keeping both operations in one script
+// halves idle subscriber traffic without pinning a shared pool connection.
+var readAfterScript = redisclient.NewScript(`
+local entries = redis.call('XRANGE', KEYS[2], ARGV[1], '+', 'COUNT', tonumber(ARGV[2]) + 1)
+local result = {}
+local event_count = 0
+for _, entry in ipairs(entries) do
+    if entry[1] ~= ARGV[1] and event_count < tonumber(ARGV[2]) then
+        local payload = ''
+        for field_index = 1, #entry[2], 2 do
+            if entry[2][field_index] == ARGV[3] then
+                payload = entry[2][field_index + 1]
+                break
+            end
+        end
+        table.insert(result, entry[1])
+        table.insert(result, payload)
+        event_count = event_count + 1
+    end
+end
+if #result == 0 and redis.call('EXISTS', KEYS[1]) == 0 then
+    return redis.error_reply('task does not exist')
+end
+return result
+`)
+
+// refreshTaskLeaseScript conditionally renews the Task, Stream, and dedupe
+// journal in one cluster slot. PEXPIRE returns zero for a missing Task, so a
+// late heartbeat cannot resurrect an expired execution.
+var refreshTaskLeaseScript = redisclient.NewScript(`
+if redis.call('PEXPIRE', KEYS[1], ARGV[1]) == 0 then
+    return 0
+end
+redis.call('PEXPIRE', KEYS[2], ARGV[1])
+redis.call('PEXPIRE', KEYS[3], ARGV[1])
+return 1
 `)
 
 // loadTaskAndCursorScript returns a Task snapshot and the stream tail from one
@@ -150,11 +232,29 @@ func streamKey(tenant, taskID string) string {
 	return streamPrefix + "{" + taskKey(tenant, taskID) + "}"
 }
 
+func streamDedupeKey(tenant, taskID string) string {
+	return streamDedupePrefix + "{" + taskKey(tenant, taskID) + "}"
+}
+
 func (t *redisTaskEventTransport) CommitTaskEvent(
 	ctx context.Context,
 	tenant string,
 	task *protocol.Task,
 	event protocol.StreamResponse,
+	allowCreate bool,
+) error {
+	return t.commitTaskEventWithOperationID(
+		ctx, tenant, task, event, allowCreate, "op-"+protocol.GenerateMessageID(),
+	)
+}
+
+func (t *redisTaskEventTransport) commitTaskEventWithOperationID(
+	ctx context.Context,
+	tenant string,
+	task *protocol.Task,
+	event protocol.StreamResponse,
+	allowCreate bool,
+	operationID string,
 ) error {
 	taskBytes, err := json.Marshal(task)
 	if err != nil {
@@ -164,15 +264,25 @@ func (t *redisTaskEventTransport) CommitTaskEvent(
 	if err != nil {
 		return fmt.Errorf("failed to serialize task event: %w", err)
 	}
+	allowCreateFlag := 0
+	if allowCreate {
+		allowCreateFlag = 1
+	}
 	if _, err := commitTaskEventScript.Run(
 		ctx,
 		t.client,
-		[]string{taskKey(tenant, task.ID), streamKey(tenant, task.ID)},
+		[]string{
+			taskKey(tenant, task.ID),
+			streamKey(tenant, task.ID),
+			streamDedupeKey(tenant, task.ID),
+		},
 		taskBytes,
 		eventBytes,
 		streamMaxLen,
 		streamField,
 		t.expiration.Milliseconds(),
+		allowCreateFlag,
+		operationID,
 	).Result(); err != nil {
 		return fmt.Errorf("failed to store task and event: %w", err)
 	}
@@ -185,6 +295,18 @@ func (t *redisTaskEventTransport) AppendEvent(
 	taskID string,
 	event protocol.StreamResponse,
 ) error {
+	return t.appendEventWithOperationID(
+		ctx, tenant, taskID, event, "op-"+protocol.GenerateMessageID(),
+	)
+}
+
+func (t *redisTaskEventTransport) appendEventWithOperationID(
+	ctx context.Context,
+	tenant string,
+	taskID string,
+	event protocol.StreamResponse,
+	operationID string,
+) error {
 	payload, err := json.Marshal(event)
 	if err != nil {
 		return fmt.Errorf("failed to marshal stream event for task %s: %w", taskID, err)
@@ -192,10 +314,15 @@ func (t *redisTaskEventTransport) AppendEvent(
 	if _, err := appendEventScript.Run(
 		ctx,
 		t.client,
-		[]string{taskKey(tenant, taskID), streamKey(tenant, taskID)},
+		[]string{
+			taskKey(tenant, taskID),
+			streamKey(tenant, taskID),
+			streamDedupeKey(tenant, taskID),
+		},
 		payload,
 		streamMaxLen,
 		streamField,
+		operationID,
 	).Result(); err != nil {
 		return fmt.Errorf("failed to append stream event for task %s: %w", taskID, err)
 	}
@@ -246,42 +373,68 @@ func (t *redisTaskEventTransport) ReadAfter(
 	taskID string,
 	cursor string,
 ) ([]protocol.StreamResponse, string, error) {
-	res, err := t.client.XRead(ctx, &redisclient.XReadArgs{
-		Streams: []string{streamKey(tenant, taskID), cursor},
-		// Do not pin the TaskManager's shared Redis connection pool while a
-		// subscription is idle. The manager applies a context-aware backoff when
-		// this non-blocking read has no event or cursor progress.
-		Block: -1,
-		Count: streamReadCount,
-	}).Result()
-	if errors.Is(err, redisclient.Nil) {
-		return nil, cursor, nil
-	}
+	values, err := readAfterScript.Run(
+		ctx,
+		t.client,
+		[]string{taskKey(tenant, taskID), streamKey(tenant, taskID)},
+		cursor,
+		streamReadCount,
+		streamField,
+	).Slice()
 	if err != nil {
+		if errors.Is(err, redisclient.Nil) || strings.Contains(err.Error(), "task does not exist") {
+			return nil, cursor, taskmanager.ErrTaskNotFound(taskID)
+		}
 		return nil, cursor, err
 	}
 
 	nextCursor := cursor
-	events := make([]protocol.StreamResponse, 0)
-	for _, stream := range res {
-		for _, entry := range stream.Messages {
-			nextCursor = entry.ID
-			var payload []byte
-			switch raw := entry.Values[streamField].(type) {
-			case string:
-				payload = []byte(raw)
-			case []byte:
-				payload = raw
-			default:
-				continue
-			}
-			var event protocol.StreamResponse
-			if err := json.Unmarshal(payload, &event); err != nil {
-				log.Warnf("RedisTaskManager: discarding malformed stream entry for task %s: %v", taskID, err)
-				continue
-			}
-			events = append(events, event)
+	events := make([]protocol.StreamResponse, 0, len(values)/2)
+	for i := 0; i+1 < len(values); i += 2 {
+		entryID, ok := values[i].(string)
+		if !ok || entryID == "" {
+			continue
 		}
+		nextCursor = entryID
+		var payload []byte
+		switch raw := values[i+1].(type) {
+		case string:
+			payload = []byte(raw)
+		case []byte:
+			payload = raw
+		default:
+			continue
+		}
+		var event protocol.StreamResponse
+		if err := json.Unmarshal(payload, &event); err != nil {
+			log.Warnf("RedisTaskManager: discarding malformed stream entry for task %s: %v", taskID, err)
+			continue
+		}
+		events = append(events, event)
 	}
 	return events, nextCursor, nil
+}
+
+func (t *redisTaskEventTransport) RefreshTaskLease(
+	ctx context.Context,
+	tenant string,
+	taskID string,
+) error {
+	refreshed, err := refreshTaskLeaseScript.Run(
+		ctx,
+		t.client,
+		[]string{
+			taskKey(tenant, taskID),
+			streamKey(tenant, taskID),
+			streamDedupeKey(tenant, taskID),
+		},
+		t.expiration.Milliseconds(),
+	).Int()
+	if err != nil {
+		return fmt.Errorf("failed to refresh task %s lease: %w", taskID, err)
+	}
+	if refreshed == 0 {
+		return taskmanager.ErrTaskNotFound(taskID)
+	}
+	return nil
 }

--- a/taskmanager/redis/redis_manager.go
+++ b/taskmanager/redis/redis_manager.go
@@ -13,7 +13,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"reflect"
 	"sort"
 	"strconv"
 	"sync"
@@ -106,7 +105,7 @@ return 1
 // TaskManager interface. It persists messages, conversations, and tasks in
 // Redis and delegates the agent logic to an injected Processor: the MessageProcessor
 // reports progress on an event channel and the manager owns the task
-// lifecycle (lazy creation, persistence, subscriber fan-out).
+// lifecycle, persistence, and resumable Redis event journal.
 // It is safe for concurrent use.
 type TaskManager struct {
 	// processor is the user-provided agent logic.
@@ -115,15 +114,8 @@ type TaskManager struct {
 	client redis.UniversalClient
 	// expiration is the time after which Redis keys expire.
 	expiration time.Duration
-	// eventTransport distributes task events between manager instances. It is
-	// nil when cross-node resubscribe is disabled.
+	// eventTransport persists the per-task event journal used by SubscribeToTask.
 	eventTransport taskEventTransport
-
-	// subMu is a mutex for the subscribers map.
-	subMu sync.RWMutex
-	// subscribers is indexed by tenant and task ID.
-	subscribers map[scopedID][]*taskSubscriber
-
 	// cancelMu is a mutex for the executions map and the closed flag.
 	cancelMu sync.RWMutex
 	// executions maps tenant-scoped task IDs to live execution handles so OnCancelTask can
@@ -148,7 +140,7 @@ type TaskManager struct {
 	// nil when push is disabled or the agent selected manual delivery.
 	pushDispatcher *push.Dispatcher
 
-	// tailerWg counts cross-node resubscribe tailer goroutines so Close joins
+	// tailerWg counts Stream subscription tailer goroutines so Close joins
 	// them before closing the Redis client. baseCtx is canceled by Close to
 	// unpark a tailer parked in a blocking transport read.
 	tailerWg   sync.WaitGroup
@@ -160,6 +152,7 @@ type TaskManager struct {
 }
 
 // NewTaskManager creates a new Redis-based TaskManager with the provided options.
+// Redis 5.0 or newer is required for the per-task event Streams.
 func NewTaskManager(
 	processor taskmanager.MessageProcessor,
 	client redis.UniversalClient,
@@ -195,16 +188,13 @@ func NewTaskManager(
 	}
 
 	manager := &TaskManager{
-		processor:   processor,
-		client:      client,
-		expiration:  expiration,
-		subscribers: make(map[scopedID][]*taskSubscriber),
-		executions:  make(map[scopedID]*liveExecution),
-		pushEnabled: options.Push.Sender != nil || options.Push.ManualDelivery,
-		options:     options,
-	}
-	if options.CrossNodeResubscribe {
-		manager.eventTransport = newRedisTaskEventTransport(client, expiration)
+		processor:      processor,
+		client:         client,
+		expiration:     expiration,
+		eventTransport: newRedisTaskEventTransport(client, expiration),
+		executions:     make(map[scopedID]*liveExecution),
+		pushEnabled:    options.Push.Sender != nil || options.Push.ManualDelivery,
+		options:        options,
 	}
 	manager.pushCtx, manager.pushCancel = context.WithCancel(context.Background())
 	if options.Push.Sender != nil && !options.Push.ManualDelivery {
@@ -446,10 +436,9 @@ func (m *TaskManager) OnCancelTask(
 	}
 }
 
-// cancelWithoutLiveRun persists CANCELED for a task with no live execution:
-// persist first, then broadcast, then close the task's subscribers. The caller
-// holds the task's execution slot (sentinel), making this the task's single
-// writer.
+// cancelWithoutLiveRun persists CANCELED for a task with no live execution and
+// dispatches push after the event journal commit. The caller holds the task's
+// execution slot (sentinel), making this the task's single writer.
 func (m *TaskManager) cancelWithoutLiveRun(
 	ctx context.Context,
 	params protocol.TaskIDParams,
@@ -477,12 +466,11 @@ func (m *TaskManager) cancelWithoutLiveRun(
 	response := protocol.NewStreamResponseStatusUpdate(event)
 	// Persist with a background context (like every engine write): the CANCELED
 	// state must land even if the cancel request's own context is already done.
-	if err := m.commitTaskEvent(context.Background(), params.Tenant, task, response); err != nil {
+	if err := m.commitTaskEvent(context.Background(), params.Tenant, task, response, false); err != nil {
 		log.Errorf("Error storing cancelled task %s: %v", params.ID, err)
 		return nil, err
 	}
-	m.notifySubscribers(params.Tenant, params.ID, response)
-	m.cleanSubscribers(params.Tenant, params.ID)
+	m.dispatchPush(params.Tenant, params.ID, response)
 
 	return task, nil
 }
@@ -801,85 +789,6 @@ func (m *TaskManager) OnResubscribe(
 	ctx context.Context,
 	params protocol.TaskIDParams,
 ) (<-chan protocol.StreamResponse, error) {
-	if m.eventTransport != nil {
-		return m.onCrossNodeResubscribe(ctx, params)
-	}
-	// The snapshot read happens OUTSIDE subMu: getTaskInternal is a network
-	// round-trip and subMu sits on every broadcast's fan-out path — holding it
-	// across a slow Redis call would stall every stream in the process.
-	task, err := m.getTaskInternal(ctx, params.Tenant, params.ID)
-	if err != nil {
-		return nil, err
-	}
-
-	// v1.0: a subscription is only valid for a non-terminal task; a task already
-	// in a terminal state must be rejected with UnsupportedOperationError.
-	if isFinalState(task.Status.State) {
-		return nil, taskmanager.ErrUnsupportedOperation(
-			fmt.Sprintf("subscribe to task %s in terminal state %s", params.ID, task.Status.State))
-	}
-
-	subscriber := newTaskSubscriber(
-		params.ID,
-		m.options.TaskSubscriberBufSize,
-		m.options.TaskSubscriberBlockingSend,
-	)
-
-	// v1.0: the first stream event must be the current Task snapshot. The
-	// subscriber is not registered yet, so nothing can precede this frame.
-	if err := subscriber.Send(protocol.NewStreamResponseTask(task)); err != nil {
-		subscriber.Close()
-		return nil, err
-	}
-	m.subMu.Lock()
-	key := newScopedID(params.Tenant, params.ID)
-	m.subscribers[key] = append(m.subscribers[key], subscriber)
-	m.subMu.Unlock()
-
-	// The snapshot predates the registration, so an update persisted between
-	// the two may be in neither. Re-read and, when anything changed, send a
-	// second snapshot superseding whatever was missed: persist-before-broadcast
-	// guarantees the re-read covers every event broadcast before registration.
-	// (Boundary events may be delivered both in a snapshot and as themselves —
-	// at-least-once, as before.)
-	current, err := m.getTaskInternal(ctx, params.Tenant, params.ID)
-	if err == nil && taskChanged(task, current) {
-		if isFinalState(current.Status.State) {
-			// The task ended between the two reads: its terminal broadcast (and
-			// cleanSubscribers) may have run before the registration, which
-			// would leave this subscriber open forever. Reject like the
-			// up-front terminal check does; nothing was delivered to the caller.
-			m.cleanupFailedSubscribers(params.Tenant, params.ID, []*taskSubscriber{subscriber})
-			return nil, taskmanager.ErrUnsupportedOperation(
-				fmt.Sprintf("subscribe to task %s in terminal state %s", params.ID, current.Status.State))
-		}
-		if err := subscriber.Send(protocol.NewStreamResponseTask(current)); err != nil {
-			log.Warnf("RedisTaskManager: failed to send refreshed snapshot for task %s: %v", params.ID, err)
-		}
-	}
-
-	// Tie the subscription to the request: when the client goes away the
-	// subscriber is removed and closed, so the server-side drain ends and the
-	// slot is not leaked (a suspended task may never reach a terminal state
-	// that would clean it).
-	go func() {
-		select {
-		case <-ctx.Done():
-			m.cleanupFailedSubscribers(params.Tenant, params.ID, []*taskSubscriber{subscriber})
-		case <-subscriber.done:
-		}
-	}()
-
-	return subscriber.Channel(), nil
-}
-
-// onCrossNodeResubscribe is the cross-node resubscribe path (opt-in via
-// WithCrossNodeResubscribe). The first frame is the current snapshot; a tailer
-// then reads events committed after the snapshot's atomic event cursor.
-func (m *TaskManager) onCrossNodeResubscribe(
-	ctx context.Context,
-	params protocol.TaskIDParams,
-) (<-chan protocol.StreamResponse, error) {
 	// The transport loads the Task and event cursor at one atomic boundary. A
 	// concurrent task-event commit is therefore either reflected by both values
 	// or by neither: the snapshot and subsequent read contain no gap or overlap.
@@ -895,7 +804,7 @@ func (m *TaskManager) onCrossNodeResubscribe(
 
 	subscriber := newTaskSubscriber(
 		params.ID,
-		m.options.TaskSubscriberBufSize,
+		1,
 		true,
 	)
 	// v1.0: the first stream event must be the current Task snapshot.
@@ -904,9 +813,9 @@ func (m *TaskManager) onCrossNodeResubscribe(
 		return nil, err
 	}
 
-	// The subscriber is NOT registered in the local map: the event transport is
-	// its only source, whose producer may be another instance. Admit the tailer
-	// under cancelMu so Close cannot wait before this goroutine is counted.
+	// The event journal is the subscription's only source, whose producer may be
+	// another instance. Admit the tailer under cancelMu so Close cannot wait
+	// before this goroutine is counted.
 	m.cancelMu.Lock()
 	if m.closed {
 		m.cancelMu.Unlock()
@@ -923,6 +832,8 @@ func (m *TaskManager) onCrossNodeResubscribe(
 // tailTaskEvents feeds a resubscriber from the configured event transport,
 // reading strictly after startID. It closes the subscriber and returns on the
 // terminal status frame, when the request ends, or when the manager closes.
+//
+//nolint:gocyclo // Retry, backpressure, cancellation, and terminal handling stay in one ordered tailer loop.
 func (m *TaskManager) tailTaskEvents(
 	ctx context.Context,
 	tenant, taskID, startID string,
@@ -953,6 +864,27 @@ func (m *TaskManager) tailTaskEvents(
 	for i := 0; i < len(taskID); i++ {
 		jitterUnit = (jitterUnit*33 + int64(taskID[i])) % 1000
 	}
+	waitForRetry := func() bool {
+		jitterRange := idleDelay / 4
+		waitDelay := idleDelay
+		if jitterRange > 0 {
+			waitDelay += jitterRange * time.Duration(jitterUnit) / 1000
+		}
+		timer := time.NewTimer(waitDelay)
+		select {
+		case <-readCtx.Done():
+			timer.Stop()
+			return false
+		case <-timer.C:
+		}
+		if idleDelay < taskEventReadIdleMaxDelay {
+			idleDelay *= 2
+			if idleDelay > taskEventReadIdleMaxDelay {
+				idleDelay = taskEventReadIdleMaxDelay
+			}
+		}
+		return true
+	}
 	for {
 		// ReadAfter implementations may use bounded blocking reads, so re-check
 		// cancellation between batches.
@@ -964,30 +896,22 @@ func (m *TaskManager) tailTaskEvents(
 		previousID := startID
 		events, nextID, err := m.eventTransport.ReadAfter(readCtx, tenant, taskID, startID)
 		if err != nil {
-			return // read context canceled, transport closed, or a storage error.
+			if readCtx.Err() != nil || errors.Is(err, taskmanager.ErrTaskNotFoundSentinel) {
+				return
+			}
+			log.Warnf("RedisTaskManager: failed to read event stream for task %s: %v", taskID, err)
+			if !waitForRetry() {
+				return
+			}
+			continue
 		}
 		startID = nextID
 		// A transport may implement ReadAfter as a non-blocking poll. Exponential
 		// backoff keeps long-idle subscriptions from producing fixed-rate Redis
 		// traffic; per-tailer jitter avoids synchronized polling across replicas.
 		if len(events) == 0 && nextID == previousID {
-			jitterRange := idleDelay / 4
-			waitDelay := idleDelay
-			if jitterRange > 0 {
-				waitDelay += jitterRange * time.Duration(jitterUnit) / 1000
-			}
-			timer := time.NewTimer(waitDelay)
-			select {
-			case <-readCtx.Done():
-				timer.Stop()
+			if !waitForRetry() {
 				return
-			case <-timer.C:
-			}
-			if idleDelay < taskEventReadIdleMaxDelay {
-				idleDelay *= 2
-				if idleDelay > taskEventReadIdleMaxDelay {
-					idleDelay = taskEventReadIdleMaxDelay
-				}
 			}
 			continue
 		}
@@ -1008,30 +932,14 @@ func (m *TaskManager) tailTaskEvents(
 
 // appendTaskEvent distributes an event that does not modify the Task snapshot.
 // Task-changing events use commitTaskEvent so their snapshot and event share
-// one atomic commit. It is a no-op when no event transport is configured.
+// one atomic commit.
 func (m *TaskManager) appendTaskEvent(
 	ctx context.Context,
 	tenant string,
 	taskID string,
 	event protocol.StreamResponse,
 ) error {
-	if m.eventTransport == nil {
-		return nil
-	}
 	return m.eventTransport.AppendEvent(ctx, tenant, taskID, event)
-}
-
-// taskChanged reports whether two snapshots of the same task differ in what a
-// stream conveys: status or artifacts. It deep-compares Artifacts rather than
-// counting them — an append=true chunk merges into an existing artifact without
-// growing the slice, so a length check would miss it and the registration-race
-// compensation in OnResubscribe would drop that chunk from the stream.
-// Resubscribe is a low-frequency control op, so the deep compare is cheap, and
-// an occasional redundant snapshot is already documented as acceptable.
-func taskChanged(before, after *protocol.Task) bool {
-	return before.Status.State != after.Status.State ||
-		before.Status.Timestamp != after.Status.Timestamp ||
-		!reflect.DeepEqual(before.Artifacts, after.Artifacts)
 }
 
 // =============================================================================
@@ -1192,22 +1100,19 @@ func (m *TaskManager) storeTask(ctx context.Context, tenant string, task *protoc
 	return m.storeTaskWithoutIndex(ctx, tenant, task)
 }
 
-// commitTaskEvent atomically persists a Task snapshot and distributes the event
-// that produced it when an event transport is configured. Without one it keeps
-// the original single-key Task persistence path.
+// commitTaskEvent atomically persists a Task snapshot and the event that
+// produced it in the per-task journal.
 func (m *TaskManager) commitTaskEvent(
 	ctx context.Context,
 	tenant string,
 	task *protocol.Task,
 	event protocol.StreamResponse,
+	allowCreate bool,
 ) error {
 	if err := m.ensureTaskIndexed(ctx, tenant, task.ID); err != nil {
 		return err
 	}
-	if m.eventTransport == nil {
-		return m.storeTaskWithoutIndex(ctx, tenant, task)
-	}
-	if err := m.eventTransport.CommitTaskEvent(ctx, tenant, task, event); err != nil {
+	if err := m.eventTransport.CommitTaskEvent(ctx, tenant, task, event, allowCreate); err != nil {
 		return err
 	}
 	// Keep the latest v2 storeTask behavior: every Task write refreshes its push
@@ -1216,6 +1121,23 @@ func (m *TaskManager) commitTaskEvent(
 	// already-committed Task/event pair into a false negative result.
 	if err := m.client.Expire(ctx, pushNotificationKey(tenant, task.ID), m.expiration).Err(); err != nil {
 		log.Warnf("RedisTaskManager: failed to refresh push config expiration for task %s: %v", task.ID, err)
+	}
+	return nil
+}
+
+// refreshTaskLease extends the storage owned by a live execution without
+// recreating an expired Task. The Task/Stream/dedupe keys renew atomically;
+// the tenant index and push registrations live in other cluster slots and are
+// refreshed afterwards.
+func (m *TaskManager) refreshTaskLease(ctx context.Context, tenant, taskID string) error {
+	if err := m.eventTransport.RefreshTaskLease(ctx, tenant, taskID); err != nil {
+		return err
+	}
+	if err := m.ensureTaskIndexed(ctx, tenant, taskID); err != nil {
+		return err
+	}
+	if err := m.client.Expire(ctx, pushNotificationKey(tenant, taskID), m.expiration).Err(); err != nil {
+		log.Warnf("RedisTaskManager: failed to refresh push config expiration for task %s: %v", taskID, err)
 	}
 	return nil
 }
@@ -1371,8 +1293,8 @@ func (m *TaskManager) deregisterExecution(tenant, taskID string, live *liveExecu
 }
 
 // beginExecutionYield turns an active slot into a short handoff barrier. The
-// slot remains owned by live until its suspend frame has reached every local
-// observer, but continuations wait for the handoff instead of failing.
+// slot remains owned by live until its suspend frame is committed and current
+// request publication completes, but continuations wait instead of failing.
 func (m *TaskManager) beginExecutionYield(tenant, taskID string, live *liveExecution) bool {
 	key := newScopedID(tenant, taskID)
 	m.cancelMu.Lock()
@@ -1393,124 +1315,6 @@ func (m *TaskManager) abortExecutionYield(tenant, taskID string, live *liveExecu
 	if m.executions[key] == live && live.yieldDone != nil {
 		close(live.yieldDone)
 		live.yieldDone = nil
-	}
-}
-
-// cleanSubscribers closes and removes all subscribers for a task. Subscribers
-// are closed outside subMu so a stuck blocking send can never wedge the
-// manager-wide lock.
-func (m *TaskManager) cleanSubscribers(tenant, taskID string) {
-	key := newScopedID(tenant, taskID)
-	m.subMu.Lock()
-	subs, exists := m.subscribers[key]
-	if !exists {
-		m.subMu.Unlock()
-		return
-	}
-	delete(m.subscribers, key)
-	m.subMu.Unlock()
-
-	for _, sub := range subs {
-		sub.Close()
-	}
-	log.Debugf("Cleaned subscribers for task %s", taskID)
-}
-
-// notifySubscribers notifies all subscribers of a task.
-func (m *TaskManager) notifySubscribers(tenant, taskID string, event protocol.StreamResponse) {
-	// Deliver push notifications independently of live SSE subscribers: reaching
-	// clients that are not currently streaming is the whole point of push.
-	m.dispatchPush(tenant, taskID, event)
-	m.notifyLiveSubscribers(tenant, taskID, event)
-}
-
-// notifyLiveSubscribers fans out to process-local task subscribers without
-// dispatching push a second time.
-func (m *TaskManager) notifyLiveSubscribers(tenant, taskID string, event protocol.StreamResponse) {
-	key := newScopedID(tenant, taskID)
-	m.subMu.RLock()
-	subs, exists := m.subscribers[key]
-	if !exists || len(subs) == 0 {
-		m.subMu.RUnlock()
-		return
-	}
-
-	subsCopy := make([]*taskSubscriber, len(subs))
-	copy(subsCopy, subs)
-	m.subMu.RUnlock()
-
-	log.Debugf("Notifying %d subscribers for task %s", len(subsCopy), taskID)
-
-	var failedSubscribers []*taskSubscriber
-
-	for _, sub := range subsCopy {
-		if sub.Closed() {
-			log.Debugf("Subscriber for task %s is already closed, marking for removal", taskID)
-			failedSubscribers = append(failedSubscribers, sub)
-			continue
-		}
-
-		err := sub.Send(event)
-		if err != nil {
-			log.Warnf("Failed to send event to subscriber for task %s: %v", taskID, err)
-			failedSubscribers = append(failedSubscribers, sub)
-		}
-	}
-
-	// Clean up failed or closed subscribers.
-	if len(failedSubscribers) > 0 {
-		m.cleanupFailedSubscribers(tenant, taskID, failedSubscribers)
-	}
-}
-
-// cleanupFailedSubscribers removes failed or closed subscribers from the map
-// and closes them. Removed subscribers are closed outside subMu so a stuck
-// blocking send can never wedge the manager-wide lock; an evicted subscriber
-// must be closed or its consumer's range loop never ends.
-func (m *TaskManager) cleanupFailedSubscribers(
-	tenant, taskID string,
-	failedSubscribers []*taskSubscriber,
-) {
-	key := newScopedID(tenant, taskID)
-	m.subMu.Lock()
-
-	subs, exists := m.subscribers[key]
-	if !exists {
-		m.subMu.Unlock()
-		return
-	}
-
-	// Filter out failed subscribers.
-	filteredSubs := make([]*taskSubscriber, 0, len(subs))
-	removedSubs := make([]*taskSubscriber, 0, len(failedSubscribers))
-
-	for _, sub := range subs {
-		shouldRemove := false
-		for _, failedSub := range failedSubscribers {
-			if sub == failedSub {
-				shouldRemove = true
-				removedSubs = append(removedSubs, sub)
-				break
-			}
-		}
-		if !shouldRemove {
-			filteredSubs = append(filteredSubs, sub)
-		}
-	}
-
-	if len(removedSubs) > 0 {
-		m.subscribers[key] = filteredSubs
-		log.Debugf("Removed %d failed subscribers for task %s", len(removedSubs), taskID)
-
-		// If there are no subscribers left, delete the entire entry.
-		if len(filteredSubs) == 0 {
-			delete(m.subscribers, key)
-		}
-	}
-	m.subMu.Unlock()
-
-	for _, sub := range removedSubs {
-		sub.Close()
 	}
 }
 
@@ -1542,31 +1346,16 @@ func (m *TaskManager) Close() error {
 		for _, pipe := range pipes {
 			pipe.Close()
 		}
-
-		// Close all fan-out subscribers (outside subMu, so a stuck blocking
-		// send can never wedge the manager-wide lock) — engine broadcasts must
-		// not be able to block either.
-		m.subMu.Lock()
-		subsToClose := make([]*taskSubscriber, 0)
-		for _, subscribers := range m.subscribers {
-			subsToClose = append(subsToClose, subscribers...)
-		}
-		m.subscribers = make(map[scopedID][]*taskSubscriber)
-		m.subMu.Unlock()
-		for _, sub := range subsToClose {
-			sub.Close()
-		}
-
+		// Tailers do not participate in engine persistence. Cancel them before
+		// waiting for processors so subscriptions close promptly even when a
+		// processor takes time to honor cancellation. Redis remains open until
+		// both groups have joined.
+		m.baseCancel()
+		m.tailerWg.Wait()
 		// Wait for the detached engines: their final persists (close-rule
 		// CANCELED) must land while the Redis client is still usable.
 		m.engineWg.Wait()
-
-		// Stop cross-node resubscribe tailers. baseCancel ends readers between
-		// polls; closing the client below also releases an in-flight Redis command.
-		// Join after that close so no tailer goroutine outlives the manager.
-		m.baseCancel()
 		m.closeErr = m.client.Close()
-		m.tailerWg.Wait()
 	})
 	return m.closeErr
 }

--- a/taskmanager/redis/redis_manager_test.go
+++ b/taskmanager/redis/redis_manager_test.go
@@ -1402,29 +1402,6 @@ func TestStorageTTL(t *testing.T) {
 	}
 }
 
-// taskChanged deep-compares Artifacts, so an append=true chunk that merges into
-// an existing artifact (growing its Parts without growing the slice) is still
-// detected — the OnResubscribe registration-race compensation depends on this.
-func TestTaskChanged_DetectsMergedArtifactChunk(t *testing.T) {
-	before := &protocol.Task{
-		Status:    protocol.TaskStatus{State: protocol.TaskStateWorking, Timestamp: "t"},
-		Artifacts: []protocol.Artifact{{ArtifactID: "a", Parts: []*protocol.Part{protocol.NewTextPart("p1")}}},
-	}
-	// Same status, same artifact count — only the merged artifact's Parts grew.
-	after := &protocol.Task{
-		Status: protocol.TaskStatus{State: protocol.TaskStateWorking, Timestamp: "t"},
-		Artifacts: []protocol.Artifact{{ArtifactID: "a", Parts: []*protocol.Part{
-			protocol.NewTextPart("p1"), protocol.NewTextPart("p2"),
-		}}},
-	}
-	if !taskChanged(before, after) {
-		t.Fatal("taskChanged must detect a same-ID append chunk that grew an artifact's Parts")
-	}
-	if taskChanged(before, before) {
-		t.Error("taskChanged must be false for identical snapshots")
-	}
-}
-
 // storeMessage is atomically idempotent by MessageID: concurrent stores (e.g.
 // from reply and status paths) leave one conversation index entry.
 func TestStoreMessage_IdempotentByMessageID(t *testing.T) {

--- a/taskmanager/redis/redis_options.go
+++ b/taskmanager/redis/redis_options.go
@@ -21,12 +21,11 @@ type TaskManagerOptions struct {
 	// MaxHistoryLength is the maximum number of messages to keep in conversation history.
 	MaxHistoryLength int
 
-	// TaskSubscriberBufSize is the buffer size for task subscriber channels.
+	// TaskSubscriberBufSize is the buffer size for message/stream response pipes.
 	TaskSubscriberBufSize int
 
-	// TaskSubscriberBlockingSend enables blocking send for local task subscribers
-	// and request pipes. Cross-node resubscribe tailers always use blocking send:
-	// their Redis reader can wait without blocking a task producer.
+	// TaskSubscriberBlockingSend enables blocking send for message/stream
+	// response pipes. SubscribeToTask readers always use independent backpressure.
 	TaskSubscriberBlockingSend bool
 
 	// Push configures push-notification delivery (see push.Config). Push is
@@ -34,13 +33,9 @@ type TaskManagerOptions struct {
 	// application-owned delivery.
 	Push push.Config
 
-	// CrossNodeResubscribe, when true, mirrors each task's events onto a per-task
-	// Redis stream and serves OnResubscribe by tailing that stream. This makes
-	// SubscribeToTask work across instances (a reconnect landing on a different
-	// node than the one running the task), at the cost of one XADD per event.
-	// Each task stream retains approximately the latest 10,000 events.
-	// When false (default) resubscribe is served from the in-process subscriber
-	// map only — correct for single-instance deployments.
+	// CrossNodeResubscribe is retained for source compatibility. Redis
+	// SubscribeToTask always uses Redis Streams and this value is ignored.
+	// Deprecated: cross-node resubscribe is always enabled.
 	CrossNodeResubscribe bool
 }
 
@@ -51,6 +46,7 @@ func DefaultRedisTaskManagerOptions() *TaskManagerOptions {
 		MaxHistoryLength:           defaultMaxHistoryLength,
 		TaskSubscriberBufSize:      defaultTaskSubscriberBufferSize,
 		TaskSubscriberBlockingSend: false,
+		CrossNodeResubscribe:       true,
 	}
 }
 
@@ -75,7 +71,7 @@ func WithMaxHistoryLength(length int) TaskManagerOption {
 	}
 }
 
-// WithTaskSubscriberBufferSize sets the buffer size for task subscriber channels.
+// WithTaskSubscriberBufferSize sets the buffer size for message/stream response pipes.
 func WithTaskSubscriberBufferSize(size int) TaskManagerOption {
 	return func(opts *TaskManagerOptions) {
 		if size > 0 {
@@ -84,8 +80,8 @@ func WithTaskSubscriberBufferSize(size int) TaskManagerOption {
 	}
 }
 
-// WithTaskSubscriberBlockingSend sets blocking send for local task subscribers
-// and request pipes. Cross-node resubscribe tailers always block independently.
+// WithTaskSubscriberBlockingSend sets blocking send for message/stream response
+// pipes. SubscribeToTask readers always block independently.
 func WithTaskSubscriberBlockingSend(blockingSend bool) TaskManagerOption {
 	return func(opts *TaskManagerOptions) {
 		opts.TaskSubscriberBlockingSend = blockingSend
@@ -103,14 +99,11 @@ func WithPushNotifications(cfg push.Config) TaskManagerOption {
 	}
 }
 
-// WithCrossNodeResubscribe enables cross-instance SubscribeToTask by mirroring
-// each task's events onto a per-task Redis stream. Enable it on every replica
-// sharing Redis when a resubscribe may land on a different instance than the one
-// running the task. It does not distribute execution, continuation, or cancel
-// requests between replicas. Each task stream retains approximately the latest
-// 10,000 events.
+// WithCrossNodeResubscribe is retained for source compatibility. Redis
+// SubscribeToTask always uses Redis Streams regardless of enabled.
+// Deprecated: cross-node resubscribe is always enabled.
 func WithCrossNodeResubscribe(enabled bool) TaskManagerOption {
 	return func(opts *TaskManagerOptions) {
-		opts.CrossNodeResubscribe = enabled
+		opts.CrossNodeResubscribe = true
 	}
 }

--- a/taskmanager/redis/redis_regression_test.go
+++ b/taskmanager/redis/redis_regression_test.go
@@ -353,9 +353,9 @@ func TestStream_ClosesAtTerminalWithoutChannelClose(t *testing.T) {
 	waitStreamClosed(t, pipe)
 }
 
-// A resubscribe stream is dropped (removed and closed) when its client goes
-// away, so a suspended task cannot accumulate dead subscribers forever.
-func TestResubscribe_ClientDisconnectDropsSubscriber(t *testing.T) {
+// A resubscribe stream closes when its client goes away, so a suspended task
+// cannot retain a Stream tailer forever.
+func TestResubscribe_ClientDisconnectClosesTailer(t *testing.T) {
 	processor := scriptedExecutor(statusEvent(protocol.TaskStateInputRequired, agentReply("need more")))
 	manager, _ := setupTest(t, processor)
 
@@ -374,17 +374,6 @@ func TestResubscribe_ClientDisconnectDropsSubscriber(t *testing.T) {
 
 	subCancel()
 	waitStreamClosed(t, ch)
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		manager.subMu.RLock()
-		left := len(manager.subscribers[newScopedID("", taskID)])
-		manager.subMu.RUnlock()
-		if left == 0 {
-			return
-		}
-		time.Sleep(2 * time.Millisecond)
-	}
-	t.Fatal("disconnected subscriber was not removed")
 }
 
 // The request's inline push-notification config reaches the MessageProcessor via

--- a/taskmanager/redis/redis_types.go
+++ b/taskmanager/redis/redis_types.go
@@ -15,11 +15,9 @@ import (
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
 )
 
-// taskSubscriber is an in-process event channel attached to a task. It is
-// internal machinery: the MessageProcessor contract exposes only event channels, so
-// subscribers are created by the manager for resubscribe and for the
-// message/stream request pipe. Cross-node resubscribe tailers also feed one of
-// these local channels; the subscriber itself has no distributed semantics.
+// taskSubscriber is an in-process response pipe. It adapts both the current
+// message/stream execution and a Redis Stream tailer to the TaskManager channel
+// API; it is never registered as durable or manager-global subscription state.
 type taskSubscriber struct {
 	taskID     string
 	eventQueue chan protocol.StreamResponse

--- a/taskmanager/redis/tenant_isolation_test.go
+++ b/taskmanager/redis/tenant_isolation_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	redisc "github.com/redis/go-redis/v9"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
@@ -125,15 +126,31 @@ func TestTaskManagerTenantDataIsolationAndTaskIndex(t *testing.T) {
 		t.Fatalf("tenant stream hash tag = %q, want %q", got, want)
 	}
 
-	subscriberA := newTaskSubscriber(taskID, 1, false)
-	manager.subMu.Lock()
-	manager.subscribers[newScopedID("tenant-a", taskID)] = []*taskSubscriber{subscriberA}
-	manager.subMu.Unlock()
-	manager.notifySubscribers("tenant-b", taskID, protocol.NewStreamResponseTask(taskB))
+	subCtx, subCancel := context.WithCancel(ctx)
+	defer subCancel()
+	subscriberB, err := manager.OnResubscribe(subCtx, protocol.TaskIDParams{Tenant: "tenant-b", ID: taskID})
+	if err != nil {
+		t.Fatalf("resubscribe tenant-b: %v", err)
+	}
+	if initial, ok := recvTimeout(t, subscriberB); !ok || initial.GetTask() == nil {
+		t.Fatalf("tenant-b initial snapshot = %+v", initial)
+	}
+	foreign := protocol.NewStreamResponseMessage(agentReply("tenant-a-only"))
+	if err := manager.appendTaskEvent(ctx, "tenant-a", taskID, foreign); err != nil {
+		t.Fatalf("append tenant-a event: %v", err)
+	}
 	select {
-	case <-subscriberA.Channel():
-		t.Fatal("tenant-b event reached tenant-a subscriber")
-	default:
+	case event, ok := <-subscriberB:
+		t.Fatalf("tenant-a event reached tenant-b subscriber: event=%+v open=%v", event, ok)
+	case <-time.After(250 * time.Millisecond):
+	}
+	local := protocol.NewStreamResponseMessage(agentReply("tenant-b-only"))
+	if err := manager.appendTaskEvent(ctx, "tenant-b", taskID, local); err != nil {
+		t.Fatalf("append tenant-b event: %v", err)
+	}
+	if event, ok := recvTimeout(t, subscriberB); !ok || event.GetMessage() == nil ||
+		event.GetMessage().Parts[0].TextContent() != "tenant-b-only" {
+		t.Fatalf("tenant-b subscriber did not receive its event: %+v", event)
 	}
 
 	liveA := &liveExecution{cancel: func() {}}


### PR DESCRIPTION
## Summary

- journal every Redis TaskManager task event in a per-task Redis Stream and use that journal for `SubscribeToTask` on every instance
- remove the process-local resubscribe registry so reconnects may land on any replica sharing Redis, while keeping request response pipes local and bounded
- preserve tenant-scoped keys and task indexing from the latest `v2` branch; live executions renew Task, Stream, dedupe, index, and push-config leases without recreating expired Tasks
- make Task/event Lua commits idempotent across ambiguous go-redis retries with one bounded per-task sorted-set journal
- combine idle Stream reads and Task existence checks into one Lua round trip, retry read outages until cancellation or Task expiry, and stop tailers before waiting for slow engines during shutdown
- retain `WithCrossNodeResubscribe` as a deprecated no-op for source compatibility

## Compatibility

- requires Redis 5.0 or newer and access to `XADD`, `XRANGE`, `XREVRANGE`, `ZADD`, `ZSCORE`, `ZINCRBY`, `ZCARD`, `ZREMRANGEBYRANK`, `EVAL`, and `EVALSHA`
- requires a coordinated rollout because older replicas do not write the event journal consumed by the Stream-only subscriber path

## Validation

- `GOWORK=off go test ./...` (root module and `taskmanager/redis` module)
- `GOWORK=off go test -race ./...` and `GOWORK=off go vet ./...` (`taskmanager/redis` module)
- targeted Stream, lease, idempotency, and cross-node lifecycle tests with `-count=5`
- Redis-module production lint with tests skipped, matching CI
- `GOWORK=off go test ./...` (`examples` module)
- `mkdocs build --strict`
