### PR TITLE
client: preserve exact JSON-RPC endpoint URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Client endpoint handling
+
+- **The v2 JSON-RPC client now uses the URL passed to `NewA2AClient` as the exact endpoint instead of automatically appending `/`.** Root URLs and explicitly slash-terminated endpoints are unchanged; callers that require a trailing slash must now include it. HTTP+JSON operation-path construction and relative Agent Card discovery retain their path-joining behavior.
+
 ### Task lifecycle streaming
 
 - Memory and Redis TaskManagers now let the first valid processor event select the `SendStreamingMessage` response shape: a `Message` completes a taskless response, while a status or artifact starts a task lifecycle with the pre-update `Task` snapshot first, as required by A2A 1.0. Initial Task history follows the request's `historyLength`. The compat/v0 JSON-RPC endpoint forwards the snapshot as a legacy `task` event for task-mode streams; normal `SubscribeToTask` framing, push delivery, and the Redis event journal are unchanged.

--- a/client/client.go
+++ b/client/client.go
@@ -593,15 +593,19 @@ func (c *A2AClient) GetAgentCard(
 		// Treat the endpoint as a directory for this discovery-only operation;
 		// JSON-RPC requests still use the exact endpoint URL.
 		resolveBase := *c.baseURL
-		if !strings.HasSuffix(resolveBase.Path, "/") {
+		if !strings.HasSuffix(resolveBase.EscapedPath(), "/") {
 			resolveBase.Path += "/"
+			if resolveBase.RawPath != "" {
+				resolveBase.RawPath += "/"
+			}
 		}
 		baseForCard = *resolveBase.ResolveReference(parsedURL)
 	}
 
 	// Try the new path first (A2A spec v0.2.5+)
 	newPathURL := baseForCard
-	newPathURL.Path = path.Join(baseForCard.Path, protocol.AgentCardPath)
+	newPathURL.RawPath = path.Join(baseForCard.EscapedPath(), protocol.AgentCardPath)
+	newPathURL.Path, _ = url.PathUnescape(newPathURL.RawPath)
 	card, err := c.getAgentCardFromURL(ctx, newPathURL.String(), opts...)
 	if err == nil {
 		return card, nil
@@ -612,7 +616,8 @@ func (c *A2AClient) GetAgentCard(
 
 	// Fallback to the old path for backward compatibility
 	oldPathURL := baseForCard
-	oldPathURL.Path = path.Join(baseForCard.Path, protocol.OldAgentCardPath)
+	oldPathURL.RawPath = path.Join(baseForCard.EscapedPath(), protocol.OldAgentCardPath)
+	oldPathURL.Path, _ = url.PathUnescape(oldPathURL.RawPath)
 	card, fallbackErr := c.getAgentCardFromURL(ctx, oldPathURL.String(), opts...)
 	if fallbackErr == nil {
 		log.Debugf("A2A Client GetAgentCard: successfully fetched from fallback path %s", oldPathURL.String())

--- a/client/client.go
+++ b/client/client.go
@@ -36,7 +36,7 @@ const (
 // A2AClient provides methods to interact with an A2A agent server over the
 // JSON-RPC or HTTP+JSON protocol binding.
 type A2AClient struct {
-	baseURL         *url.URL            // Parsed base URL of the agent server.
+	baseURL         *url.URL            // Exact JSON-RPC endpoint or HTTP+JSON route base.
 	httpClient      *http.Client        // Underlying HTTP client.
 	userAgent       string              // User-Agent header string.
 	authProvider    auth.ClientProvider // Authentication provider.
@@ -51,7 +51,8 @@ type A2AClient struct {
 }
 
 // NewA2AClient creates a new A2A client targeting the specified agentURL.
-// The agentURL should be the base endpoint for the agent (e.g., "http://localhost:8080/").
+// JSON-RPC requests use agentURL as the exact endpoint. HTTP+JSON requests use
+// it as the base URL for operation routes.
 // Options can be provided to configure the client, such as setting a custom http.Client or timeout.
 // Returns an error if the agentURL is invalid.
 func NewA2AClient(agentURL string, opts ...Option) (*A2AClient, error) {
@@ -89,15 +90,6 @@ func parseAgentURL(agentURL string) (*url.URL, error) {
 	parsedURL, err := url.ParseRequestURI(agentURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid agent URL %q: %w", agentURL, err)
-	}
-	// Normalize only the URL path. Appending to the original string corrupts a
-	// trailing query ("?token=x" would become "?token=x/"). Preserve RawPath
-	// when present so escaped endpoint paths continue to round-trip.
-	if !strings.HasSuffix(parsedURL.Path, "/") {
-		parsedURL.Path += "/"
-		if parsedURL.RawPath != "" {
-			parsedURL.RawPath += "/"
-		}
 	}
 	return parsedURL, nil
 }
@@ -431,8 +423,7 @@ func (c *A2AClient) doRequest(ctx context.Context, request *jsonrpc.Request, opt
 		// Use a more specific error message prefix.
 		return nil, fmt.Errorf("a2aClient.doRequest: failed to marshal request: %w", err)
 	}
-	// Construct the target URL using the base URL.
-	// Assume the RPC endpoint is at the root of the baseURL.
+	// Use the exact JSON-RPC endpoint supplied by the caller.
 	targetURL := c.baseURL.String()
 	req, err := http.NewRequestWithContext(
 		ctx,
@@ -575,7 +566,7 @@ func (c *A2AClient) DeletePushNotification(
 //     (tries baseURL + /.well-known/agent-card.json first,
 //     then falls back to baseURL + /.well-known/agent.json)
 //   - Relative path: Uses baseURL + agentCardURL + standard paths with fallback
-//     (e.g., "/api" -> baseURL/api/.well-known/agent-card.json, then baseURL/api/.well-known/agent.json)
+//     (e.g., "api" -> baseURL/api/.well-known/agent-card.json, then baseURL/api/.well-known/agent.json)
 //   - Absolute URL: Used as-is without fallback (e.g., "https://cdn.example.com/card.json")
 func (c *A2AClient) GetAgentCard(
 	ctx context.Context,
@@ -598,8 +589,14 @@ func (c *A2AClient) GetAgentCard(
 			return c.getAgentCardFromURL(ctx, agentCardURL, opts...)
 		}
 
-		// Relative path: resolve against baseURL to create new base
-		baseForCard = *c.baseURL.ResolveReference(parsedURL)
+		// Relative Agent Card locations are appended to the client endpoint.
+		// Treat the endpoint as a directory for this discovery-only operation;
+		// JSON-RPC requests still use the exact endpoint URL.
+		resolveBase := *c.baseURL
+		if !strings.HasSuffix(resolveBase.Path, "/") {
+			resolveBase.Path += "/"
+		}
+		baseForCard = *resolveBase.ResolveReference(parsedURL)
 	}
 
 	// Try the new path first (A2A spec v0.2.5+)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -587,6 +588,59 @@ func createMockServerHandler(
 	}
 }
 
+func TestA2AClient_JSONRPCUsesExactEndpointURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+	}{
+		{name: "without trailing slash", endpoint: "https://agent.example.com/a2a/v1?token=secret"},
+		{name: "with trailing slash", endpoint: "https://agent.example.com/a2a/v1/?token=secret"},
+		{name: "with escaped path", endpoint: "https://agent.example.com/a2a%2Fv1?token=secret"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotURLs []string
+			handler := &mockHTTPReqHandler{handleFunc: func(
+				_ context.Context,
+				_ *http.Client,
+				req *http.Request,
+			) (*http.Response, error) {
+				gotURLs = append(gotURLs, req.URL.String())
+				resp := &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body:       http.NoBody,
+				}
+				if req.Header.Get("Accept") == protocol.MediaTypeEventStream {
+					resp.Header.Set("Content-Type", protocol.MediaTypeEventStream)
+					return resp, nil
+				}
+				resp.Header.Set("Content-Type", protocol.MediaTypeJSON)
+				resp.Body = io.NopCloser(strings.NewReader(
+					`{"jsonrpc":"2.0","id":"request-1","result":{}}`,
+				))
+				return resp, nil
+			}}
+
+			client, err := NewA2AClient(tt.endpoint, WithHTTPReqHandler(handler))
+			require.NoError(t, err)
+
+			_, err = client.doRequest(
+				context.Background(), jsonrpc.NewRequest(protocol.MethodTasksGet, "request-1"),
+			)
+			require.NoError(t, err)
+
+			streamResp, err := client.sendA2AStreamRequest(
+				context.Background(), "request-2", protocol.MethodMessageStream, []byte(`{}`),
+			)
+			require.NoError(t, err)
+			require.NoError(t, streamResp.Body.Close())
+
+			assert.Equal(t, []string{tt.endpoint, tt.endpoint}, gotURLs)
+		})
+	}
+}
+
 // TestA2AClient_GetAgentCard tests the GetAgentCard client method.
 func TestA2AClient_GetAgentCard(t *testing.T) {
 	t.Run("GetAgentCard Success - Default URL (New Path)", func(t *testing.T) {
@@ -756,11 +810,10 @@ func TestA2AClient_GetAgentCard(t *testing.T) {
 			Skills:             []server.AgentSkill{},
 		}
 
-		// Create a mock server that serves the agent card at baseURL + /api/v1 + /.well-known/agent-card.json
+		// Create a mock server that serves the agent card below a JSON-RPC endpoint.
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodGet, r.Method)
-			// Expect: /api/v1/.well-known/agent-card.json
-			assert.Equal(t, "/api/v1/.well-known/agent-card.json", r.URL.Path)
+			assert.Equal(t, "/rpc/api/v1/.well-known/agent-card.json", r.URL.Path)
 
 			w.Header().Set("Content-Type", "application/json; charset=utf-8")
 			w.WriteHeader(http.StatusOK)
@@ -769,11 +822,11 @@ func TestA2AClient_GetAgentCard(t *testing.T) {
 		defer server.Close()
 
 		// Create client
-		client, err := NewA2AClient(server.URL)
+		client, err := NewA2AClient(server.URL + "/rpc")
 		require.NoError(t, err)
 
 		// Call GetAgentCard with custom relative path
-		card, err := client.GetAgentCard(context.Background(), "/api/v1")
+		card, err := client.GetAgentCard(context.Background(), "api/v1")
 
 		// Assertions
 		require.NoError(t, err)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -23,6 +23,7 @@ import (
 	"trpc.group/trpc-go/trpc-a2a-go/v2/internal/jsonrpc"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/server"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager/stateless"
 )
 
 // TestA2AClient_ResubscribeTask tests the ResubscribeTask client method for SSE.
@@ -639,6 +640,59 @@ func TestA2AClient_JSONRPCUsesExactEndpointURL(t *testing.T) {
 			assert.Equal(t, []string{tt.endpoint, tt.endpoint}, gotURLs)
 		})
 	}
+}
+
+func TestA2AClient_JSONRPCUsesAdvertisedSubpathEndpoint(t *testing.T) {
+	const basePath = "/api/v1/agent"
+	testServer := httptest.NewUnstartedServer(nil)
+	t.Cleanup(testServer.Close)
+	endpoint := "http://" + testServer.Listener.Addr().String() + basePath + "/"
+
+	manager, err := stateless.NewTaskManager(httpJSONEchoProcessor{})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, manager.Close()) })
+	card := protocol.AgentCard{
+		Name:               "Subpath Agent",
+		Description:        "test",
+		Version:            "1",
+		DefaultInputModes:  []string{"text/plain"},
+		DefaultOutputModes: []string{"text/plain"},
+		Skills:             []protocol.AgentSkill{},
+		SupportedInterfaces: []protocol.AgentInterface{{
+			URL:             endpoint,
+			ProtocolBinding: protocol.ProtocolBindingJSONRPC,
+			ProtocolVersion: protocol.ProtocolVersionV1,
+		}},
+	}
+	a2aServer, err := server.NewA2AServer(
+		manager,
+		server.WithAgentCard(card),
+		server.WithBasePath(basePath),
+	)
+	require.NoError(t, err)
+	testServer.Config.Handler = a2aServer.Handler()
+	testServer.Start()
+
+	discoveryClient, err := NewA2AClient(testServer.URL + basePath)
+	require.NoError(t, err)
+	discovered, err := discoveryClient.GetAgentCard(context.Background(), "")
+	require.NoError(t, err)
+	require.Len(t, discovered.SupportedInterfaces, 1)
+	iface := discovered.SupportedInterfaces[0]
+	assert.Equal(t, endpoint, iface.URL)
+
+	rpcClient, err := NewA2AClient(iface.URL, WithProtocolBinding(iface.ProtocolBinding))
+	require.NoError(t, err)
+	response, err := rpcClient.SendMessage(context.Background(), protocol.SendMessageParams{
+		Message: protocol.Message{
+			MessageID: "message-1",
+			Role:      protocol.MessageRoleUser,
+			Parts:     []*protocol.Part{protocol.NewTextPart("hello")},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, response.GetMessage())
+	assert.Equal(t, "echo: hello", response.GetMessage().Parts[0].TextContent())
 }
 
 // TestA2AClient_GetAgentCard tests the GetAgentCard client method.

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -888,6 +888,52 @@ func TestA2AClient_GetAgentCard(t *testing.T) {
 		assert.Equal(t, "Custom Path Agent", card.Name)
 	})
 
+	t.Run("GetAgentCard Success - Escaped Endpoint with Relative Path", func(t *testing.T) {
+		tests := []struct {
+			name             string
+			endpointPath     string
+			expectedCardPath string
+		}{
+			{
+				name:             "escaped slash",
+				endpointPath:     "/rpc%2Fv1",
+				expectedCardPath: "/rpc%2Fv1/child/.well-known/agent-card.json",
+			},
+			{
+				name:             "escaped dot segments",
+				endpointPath:     "/rpc/%2e%2e/v1",
+				expectedCardPath: "/rpc/%2e%2e/v1/child/.well-known/agent-card.json",
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				mockCard := server.AgentCard{
+					Name:               "Escaped Path Agent",
+					Description:        "Agent discovered below an escaped endpoint",
+					Version:            "1.0.0",
+					DefaultInputModes:  []string{"text"},
+					DefaultOutputModes: []string{"text"},
+					Skills:             []server.AgentSkill{},
+				}
+
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					assert.Equal(t, http.MethodGet, r.Method)
+					assert.Equal(t, tt.expectedCardPath, r.URL.EscapedPath())
+					w.Header().Set("Content-Type", "application/json; charset=utf-8")
+					require.NoError(t, json.NewEncoder(w).Encode(mockCard))
+				}))
+				defer server.Close()
+
+				client, err := NewA2AClient(server.URL + tt.endpointPath)
+				require.NoError(t, err)
+				card, err := client.GetAgentCard(context.Background(), "child")
+				require.NoError(t, err)
+				require.NotNil(t, card)
+				assert.Equal(t, "Escaped Path Agent", card.Name)
+			})
+		}
+	})
+
 	t.Run("GetAgentCard Success - Custom Relative Path with Fallback to Old Path", func(t *testing.T) {
 		mockCard := server.AgentCard{
 			Name:               "Legacy Custom Path Agent",

--- a/client/http_json_test.go
+++ b/client/http_json_test.go
@@ -107,7 +107,7 @@ func TestWithProtocolBindingSelectsHTTPJSON(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, protocol.ProtocolBindingHTTPJSON, client.protocolBinding)
 	assert.Equal(t, "tenant-a", client.tenant)
-	assert.Equal(t, "https://rest.example/api/", client.baseURL.String())
+	assert.Equal(t, "https://rest.example/api", client.baseURL.String())
 
 	_, err = NewA2AClient("https://rest.example/api", WithProtocolBinding("CUSTOM"))
 	require.Error(t, err)

--- a/docs/mkdocs/en/client.md
+++ b/docs/mkdocs/en/client.md
@@ -33,6 +33,8 @@ selectedClient, _ := client.NewA2AClient(
 )
 ```
 
+For JSON-RPC, the selected interface URL is the complete request endpoint and is used exactly as declared, including whether its path ends in `/`. HTTP+JSON treats the URL as a route base and appends the operation path.
+
 JSON-RPC requests continue to use `application/json`. HTTP+JSON requests use REST paths and send `application/a2a+json`; unary responses accept both `application/a2a+json` and the 1.0.0-era `application/json` for compatibility.
 
 ## The four consumption modes

--- a/docs/mkdocs/zh/client.md
+++ b/docs/mkdocs/zh/client.md
@@ -34,6 +34,8 @@ selectedClient, _ := client.NewA2AClient(
 )
 ```
 
+对于 JSON-RPC，所选 interface 的 URL 就是完整请求 endpoint，client 会严格按声明使用，包括是否以 `/` 结尾。对于 HTTP+JSON，该 URL 是路由基址，client 会继续拼接具体操作路径。
+
 JSON-RPC 请求继续使用 `application/json`。HTTP+JSON 使用 REST 路由并发送 `application/a2a+json`；一元响应同时接受 `application/a2a+json` 与兼容 1.0.0 实现的 `application/json`。默认没有超时；生产代码通常会传 `client.WithTimeout(...)` 或自定义 `http.Client`。
 
 ## 先发现 Agent

--- a/examples/subpath/README.md
+++ b/examples/subpath/README.md
@@ -1,8 +1,8 @@
 # Subpath Example
 
 This example demonstrates how to serve an A2A agent under a custom path with
-`server.WithBasePath`. Agent Card URLs are discovery metadata for clients and
-do not drive server mounting.
+`server.WithBasePath`. Agent Card `supportedInterfaces` URLs are discovery
+metadata for clients and do not drive server mounting.
 
 ## Quick Start
 
@@ -41,8 +41,12 @@ func (p *simpleProcessor) ProcessMessage(
 func main() {
     agentCard := server.AgentCard{
         Name: "My Agent",
-        // Discovery URL advertised to clients (may differ from listen path).
-        URL: "http://localhost:8080/api/v1/agent",
+        // The advertised URL is the complete JSON-RPC endpoint.
+        SupportedInterfaces: []server.AgentInterface{{
+            URL:             "http://localhost:8080/api/v1/agent/",
+            ProtocolBinding: protocol.ProtocolBindingJSONRPC,
+            ProtocolVersion: protocol.ProtocolVersionV1,
+        }},
     }
 
     taskManager, _ := memory.NewTaskManager(&simpleProcessor{})
@@ -60,12 +64,19 @@ func main() {
 - JSON-RPC: `http://localhost:8080/api/v1/agent/`
 - JWKS (when enabled): `http://localhost:8080/api/v1/agent/.well-known/jwks.json`
 
+The trailing slash in the advertised JSON-RPC interface is significant: `WithBasePath` mounts JSON-RPC at that exact path, and v2 clients use the interface URL as declared.
+
 ### External URL differs from internal route
 
 ```go
 agentCard := server.AgentCard{
     Name: "My Agent",
-    URL:  "https://example.com/external/path", // What clients discover
+    SupportedInterfaces: []server.AgentInterface{{
+        // The complete public endpoint clients use; it may differ from the listen path.
+        URL:             "https://example.com/external/path/",
+        ProtocolBinding: protocol.ProtocolBindingJSONRPC,
+        ProtocolVersion: protocol.ProtocolVersionV1,
+    }},
 }
 
 a2aServer, _ := server.NewA2AServer(

--- a/examples/subpath/main.go
+++ b/examples/subpath/main.go
@@ -37,12 +37,16 @@ func (p *simpleProcessor) ProcessMessage(
 }
 
 func main() {
-	// Card URL is discovery metadata for clients; mounting uses WithBasePath.
+	// Interface URLs are discovery metadata for clients; mounting uses WithBasePath.
 	agentCard := server.AgentCard{
 		Name:        "Subpath Agent",
 		Description: "Demo agent with subpath",
-		URL:         "http://localhost:8080/api/v1/agent",
 		Version:     "1.0.0",
+		SupportedInterfaces: []server.AgentInterface{{
+			URL:             "http://localhost:8080/api/v1/agent/",
+			ProtocolBinding: protocol.ProtocolBindingJSONRPC,
+			ProtocolVersion: protocol.ProtocolVersionV1,
+		}},
 	}
 
 	// Create task manager with simple processor


### PR DESCRIPTION
## Summary

- Preserve the exact URL passed to `NewA2AClient` for unary and streaming JSON-RPC requests instead of automatically appending `/`.
- Keep HTTP+JSON operation-route construction and relative Agent Card discovery scoped to their own path-joining logic.
- Align the subpath example with the exact JSON-RPC mount by advertising a v1 `supportedInterfaces` URL ending in `/`.
- Document the endpoint semantics and add regression coverage for slashless, slash-terminated, escaped, query-bearing, and discovered subpath URLs.

## Root cause

`NewA2AClient` normalized every URL as a directory before the protocol binding was selected. That was useful for relative path resolution, but an `AgentInterface.url` for JSON-RPC is a complete endpoint. As a result, a declared endpoint such as `/a2a/v1` was sent as `/a2a/v1/` for both unary and streaming requests.

The repository's subpath example also advertised `/api/v1/agent` while `WithBasePath("/api/v1/agent")` mounts JSON-RPC at `/api/v1/agent/`. The example now declares the actual endpoint explicitly, and an integration test covers Agent Card discovery followed by a real JSON-RPC request to that subpath.

## Compatibility

This is an intentional v2 prerelease behavior correction. Root endpoints and explicitly slash-terminated endpoints are unchanged. Applications that intentionally expose JSON-RPC at a slash-terminated non-root endpoint must include the trailing slash in the URL they pass to the client or advertise in `supportedInterfaces`.

HTTP+JSON still appends its operation paths, relative Agent Card discovery retains the existing directory-style resolution, and the separate `compat/v0` client is unchanged. The client does not retry a failed POST at the alternate slash form because retrying non-idempotent message operations could execute them twice.

## Validation

- `GOWORK=off go build ./...`
- `GOWORK=off go test -count=1 -coverprofile=coverage.out ./...` (78.0% overall; 84.6% client)
- `GOWORK=off go test -count=1 -race ./client`
- `GOWORK=off go vet ./...`
- `GOWORK=off golangci-lint run --new-from-rev=origin/v2 ./...`
- `GOWORK=off go mod tidy -diff`
- `GOWORK=off go test -count=1 ./...` and `go mod tidy -diff` in `examples` and `examples/multi`
- `mkdocs build --strict -f docs/mkdocs.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * JSON-RPC and streaming requests now use the configured endpoint URL exactly, preserving query strings, trailing slashes, and escaped paths.
  * Relative Agent Card URLs resolve correctly for nested endpoints and subpaths.
* **Documentation**
  * Clarified URL handling differences between JSON-RPC and HTTP+JSON protocols.
  * Updated subpath examples to advertise complete supported endpoints and protocol metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->