### PR TITLE
taskmanager: emit the initial Task before streaming updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Task lifecycle streaming
 
-- Memory and Redis TaskManagers now start task-lifecycle `SendStreamingMessage` responses with the pre-update `Task` snapshot before status or artifact updates, as required by A2A 1.0. The compat/v0 JSON-RPC endpoint forwards that snapshot as a legacy `task` event for task-mode streams. Message-only responses, `SubscribeToTask`, push delivery, and the Redis event journal are unchanged.
+- Memory and Redis TaskManagers now let the first valid processor event select the `SendStreamingMessage` response shape: a `Message` completes a taskless response, while a status or artifact starts a task lifecycle with the pre-update `Task` snapshot first, as required by A2A 1.0. Initial Task history follows the request's `historyLength`. The compat/v0 JSON-RPC endpoint forwards the snapshot as a legacy `task` event for task-mode streams; normal `SubscribeToTask` framing, push delivery, and the Redis event journal are unchanged.
+
+### Memory TaskManager
+
+- Publishing `input-required` or `auth-required` now cancels the yielded old round's processor context before its execution slot is released. This is round teardown rather than task cancellation: the Task stays suspended while the manager drains the processor channel. Shutdown rejects new resubscriptions once it begins and still waits cooperatively for processors to close their channels.
 
 ### HTTP+JSON protocol binding
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Task lifecycle streaming
+
+- Memory and Redis TaskManagers now start task-lifecycle `SendStreamingMessage` responses with the pre-update `Task` snapshot before status or artifact updates, as required by A2A 1.0. The compat/v0 JSON-RPC endpoint forwards that snapshot as a legacy `task` event for task-mode streams. Message-only responses, `SubscribeToTask`, push delivery, and the Redis event journal are unchanged.
+
 ### HTTP+JSON protocol binding
 
 - **The v2 client and server now implement the A2A v1.0 HTTP+JSON/REST binding.** It uses the standard operation routes, `application/a2a+json` request and response bodies, direct protocol objects instead of JSON-RPC envelopes, raw `StreamResponse` SSE data, and `google.rpc.Status` JSON errors. JSON-RPC remains the default for direct client construction and continues to use `application/json`.

--- a/client/http_json_e2e_test.go
+++ b/client/http_json_e2e_test.go
@@ -91,6 +91,47 @@ func newHTTPJSONTask(t *testing.T, c *A2AClient, messageID string) string {
 	return response.GetTask().ID
 }
 
+func TestStreamingInitialTaskParityAcrossBindings(t *testing.T) {
+	rest, rpc := newHTTPJSONFixture(t)
+	tests := []struct {
+		name      string
+		client    *A2AClient
+		messageID string
+	}{
+		{name: "JSON-RPC", client: rpc, messageID: "stream-rpc"},
+		{name: "HTTP+JSON", client: rest, messageID: "stream-http-json"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stream, err := test.client.StreamMessage(context.Background(), protocol.SendMessageParams{
+				Message: protocol.Message{
+					MessageID: test.messageID,
+					Role:      protocol.MessageRoleUser,
+					Parts:     []*protocol.Part{protocol.NewTextPart("go")},
+				},
+			})
+			require.NoError(t, err)
+
+			var events []protocol.StreamResponse
+			for event := range stream {
+				events = append(events, event)
+			}
+			require.Len(t, events, 3)
+			initial := events[0].GetTask()
+			require.NotNil(t, initial)
+			assert.Equal(t, protocol.TaskStateSubmitted, initial.Status.State)
+			working := events[1].GetStatusUpdate()
+			require.NotNil(t, working)
+			assert.Equal(t, protocol.TaskStateWorking, working.Status.State)
+			completed := events[2].GetStatusUpdate()
+			require.NotNil(t, completed)
+			assert.Equal(t, protocol.TaskStateCompleted, completed.Status.State)
+			assert.Equal(t, initial.ID, working.TaskID)
+			assert.Equal(t, initial.ID, completed.TaskID)
+		})
+	}
+}
+
 // The task-scoped and push-config operations must round-trip over the REST
 // binding, not just message:send and message:stream.
 func TestHTTPJSONEndToEndOperations(t *testing.T) {

--- a/compat/v0/jsonrpc_server_test.go
+++ b/compat/v0/jsonrpc_server_test.go
@@ -20,7 +20,22 @@ import (
 
 	"trpc.group/trpc-go/trpc-a2a-go/v2/internal/sse"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager/memory"
 )
+
+type legacyStreamingProcessor struct{}
+
+func (legacyStreamingProcessor) ProcessMessage(
+	_ context.Context,
+	_ *taskmanager.ExecContext,
+) (<-chan protocol.StreamEvent, error) {
+	events := make(chan protocol.StreamEvent, 2)
+	events <- &protocol.TaskStatusUpdateEvent{Status: protocol.TaskStatus{State: protocol.TaskStateWorking}}
+	events <- &protocol.TaskStatusUpdateEvent{Status: protocol.TaskStatus{State: protocol.TaskStateCompleted}}
+	close(events)
+	return events, nil
+}
 
 // fakeTaskManager is a minimal v1 TaskManager that records the converted
 // request and returns canned v1 responses, so the tests exercise exactly the
@@ -182,19 +197,10 @@ func TestHandler_TasksGet_LegacyWire(t *testing.T) {
 }
 
 func TestHandler_Streaming_LegacyWire(t *testing.T) {
-	fake := &fakeTaskManager{
-		streamEvents: []protocol.StreamResponse{
-			{Result: &protocol.TaskStatusUpdateEvent{
-				TaskID: "task-1", ContextID: "ctx-1",
-				Status: protocol.TaskStatus{State: protocol.TaskStateWorking},
-			}},
-			{Result: &protocol.TaskStatusUpdateEvent{
-				TaskID: "task-1", ContextID: "ctx-1",
-				Status: protocol.TaskStatus{State: protocol.TaskStateCompleted},
-			}},
-		},
-	}
-	h := NewJSONRPCHandler(fake)
+	manager, err := memory.NewTaskManager(legacyStreamingProcessor{})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, manager.Close()) })
+	h := NewJSONRPCHandler(manager)
 
 	w := postJSON(t, h, `{
 		"jsonrpc": "2.0", "id": "req-3", "method": "message/stream",
@@ -223,18 +229,24 @@ func TestHandler_Streaming_LegacyWire(t *testing.T) {
 		payloads = append(payloads, rpcResp.Result)
 	}
 
-	require.Len(t, events, 2)
-	assert.Equal(t, EventStatusUpdate, events[0], "legacy SSE event name expected")
+	require.Len(t, events, 3)
+	assert.Equal(t, EventTask, events[0], "legacy SSE event name expected")
+	assert.Equal(t, "task", payloads[0]["kind"])
+	initialStatus := payloads[0]["status"].(map[string]interface{})
+	assert.Equal(t, "submitted", initialStatus["state"])
+
+	assert.Equal(t, EventStatusUpdate, events[1], "legacy SSE event name expected")
 	// Legacy kind discriminator and lowercase states on the wire.
-	assert.Equal(t, "status-update", payloads[0]["kind"])
-	status := payloads[0]["status"].(map[string]interface{})
+	assert.Equal(t, "status-update", payloads[1]["kind"])
+	status := payloads[1]["status"].(map[string]interface{})
 	assert.Equal(t, "working", status["state"])
-	assert.Equal(t, false, payloads[0]["final"])
+	assert.Equal(t, false, payloads[1]["final"])
+	assert.Equal(t, payloads[0]["id"], payloads[1]["taskId"])
 
 	// Terminal event must carry the derived final=true flag.
-	finalStatus := payloads[1]["status"].(map[string]interface{})
+	finalStatus := payloads[2]["status"].(map[string]interface{})
 	assert.Equal(t, "completed", finalStatus["state"])
-	assert.Equal(t, true, payloads[1]["final"])
+	assert.Equal(t, true, payloads[2]["final"])
 }
 
 func TestHandler_PushConfig_LegacyWire(t *testing.T) {

--- a/docs/mkdocs/en/protocol.md
+++ b/docs/mkdocs/en/protocol.md
@@ -124,7 +124,7 @@ sequenceDiagram
 
 ### 2. A tracked job with live progress
 
-Same request shape, the streaming endpoint: every event reaches you the moment it happens. The processor selects task mode by emitting a status or artifact update; the framework materializes the Task and sends its pre-update snapshot first.
+Same request shape, the streaming endpoint: every event reaches you the moment it happens. The first valid processor event selects the response shape: a Message completes a direct response, while a status or artifact selects task mode and makes the framework send the pre-update Task snapshot first.
 
 ```mermaid
 sequenceDiagram
@@ -353,7 +353,7 @@ last frame, after which the SSE stream closes. Everything else — an explicit
 `submitted`, how many `working` frames, whether progress text rides on status
 messages — is the agent's choice.
 
-This ownership split is intentional: a pure `Message` round remains taskless, while the first status/artifact event selects task mode and causes the framework to materialize the initial Task snapshot.
+This ownership split is intentional: a first `Message` completes a taskless response and later events are discarded, while a first status/artifact event selects task mode and causes the framework to materialize the initial Task snapshot.
 
 Next: [Server](server.md) explains how this framework turns that event
 stream into persisted tasks and derived responses; [Server](server.md) shows how

--- a/docs/mkdocs/en/protocol.md
+++ b/docs/mkdocs/en/protocol.md
@@ -48,10 +48,7 @@ flowchart LR
     end
 ```
 
-Not every exchange creates a task. A quick answer is just a `Message` back —
-no lifecycle, no cleanup. The agent opens a task only when there is work worth
-tracking; from then on, everything the agent reports is an **event**: a status
-update (progress) or an artifact update (deliverable chunk).
+Not every exchange creates a task. A quick answer is just a `Message` back — no lifecycle, no cleanup. When the agent emits a status or artifact update, the framework opens a task and, for streaming calls, sends the initial Task snapshot before that first update.
 
 ## Discovery: the Agent Card
 
@@ -127,14 +124,14 @@ sequenceDiagram
 
 ### 2. A tracked job with live progress
 
-Same request shape, the streaming endpoint: every event reaches you the moment
-it happens. The first task event is where the task comes into existence.
+Same request shape, the streaming endpoint: every event reaches you the moment it happens. The processor selects task mode by emitting a status or artifact update; the framework materializes the Task and sends its pre-update snapshot first.
 
 ```mermaid
 sequenceDiagram
     participant C as Client
     participant A as Agent
     C->>A: SendStreamingMessage "Generate the Q3 report"
+    A-->>C: Task {id, submitted}
     A-->>C: status working
     A-->>C: artifact report.pdf (chunk 1)
     A-->>C: artifact report.pdf (chunk 2, lastChunk)
@@ -196,6 +193,7 @@ sequenceDiagram
     participant C as Client
     participant A as Agent
     C->>A: SendStreamingMessage "crunch this dataset"
+    A-->>C: Task {id, submitted}
     A-->>C: status working
     C->>A: CancelTask {id}
     A-->>C: Task {working} — cancellation requested
@@ -299,7 +297,7 @@ slash-delimited names, shown for reference):
 | Method (v1.0) | Kind | Purpose | v0.2.x name |
 | --- | --- | --- | --- |
 | `SendMessage` | unary | Send a message; the response is a **`Task` or a `Message`** (a union). By default it **waits** for the round to finish. | `message/send` |
-| `SendStreamingMessage` | SSE | Same request; every event streams live. | `message/stream` |
+| `SendStreamingMessage` | SSE | Same request; a task-producing stream starts with a Task snapshot, then carries status/artifact updates. A pure direct reply has no Task. | `message/stream` |
 | `GetTask` | unary | Fetch a task snapshot; `historyLength` shapes attached history. | `tasks/get` |
 | `ListTasks` | unary | Enumerate tasks: filter by `contextId`/state, paginate. | — (new in v1.0) |
 | `CancelTask` | unary | Request cancellation. | `tasks/cancel` |
@@ -340,7 +338,7 @@ Standard JSON-RPC codes apply (`-32700` parse error, `-32600` invalid request, `
 
 ### The canonical event paradigm
 
-The typical shape of a task-producing round, and what is actually mandatory:
+The processor emits the task updates below; it does not emit the initial `Task`. For `SendStreamingMessage`, the framework derives that wire frame from the task state before applying the first update.
 
 ```
 status  -> submitted     optional: creation implies submitted
@@ -354,6 +352,8 @@ and mark artifact chunks; the terminal (or interrupted) status is the stream's
 last frame, after which the SSE stream closes. Everything else — an explicit
 `submitted`, how many `working` frames, whether progress text rides on status
 messages — is the agent's choice.
+
+This ownership split is intentional: a pure `Message` round remains taskless, while the first status/artifact event selects task mode and causes the framework to materialize the initial Task snapshot.
 
 Next: [Server](server.md) explains how this framework turns that event
 stream into persisted tasks and derived responses; [Server](server.md) shows how

--- a/docs/mkdocs/en/server.md
+++ b/docs/mkdocs/en/server.md
@@ -111,7 +111,7 @@ go func() {
 return out, nil
 ```
 
-The first status or artifact event selects a task-producing round. The processor does not emit `*protocol.Task`; for `SendStreamingMessage`, the manager materializes the required initial Task snapshot before forwarding that first update. A fresh round starts from `submitted`, while a continuation starts from `ec.Task`. A round that only calls `Reply` stays taskless.
+The first valid event selects the response shape. A `Reply` completes a taskless direct response, so later events from that round are discarded. A status or artifact selects a task-producing round. The processor does not emit `*protocol.Task`; for `SendStreamingMessage`, the manager materializes the required initial Task snapshot before forwarding that first update. A fresh round starts from `submitted`, while a continuation starts from `ec.Task`.
 
 ([examples/simple](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples/simple)
 is a processor written entirely on the raw channel.)
@@ -124,10 +124,7 @@ is a processor written entirely on the raw channel.)
   loops and just close on cancellation (the framework persists `CANCELED`).
   → [examples/basic](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples/basic)
   (`/long-task` and client `-stream`)
-- **Multi-turn** — suspend with
-  `h.UpdateTaskState(protocol.TaskStateInputRequired, protocol.NewAgentText("need more"))`,
-  close, and handle the follow-up (which echoes the `taskId`) as a new round
-  with `ec.Task` set.
+- **Multi-turn** — suspend with `h.UpdateTaskState(protocol.TaskStateInputRequired, protocol.NewAgentText("need more"))`, close promptly, and handle the follow-up (which echoes the `taskId`) as a new round with `ec.Task` set. Memory cancels the yielded old round's `ctx` as a teardown signal after publishing the suspend frame; this does not cancel the Task.
   → [examples/inputrequired](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples/inputrequired)
 
 ### Usage constraints
@@ -137,7 +134,7 @@ is a processor written entirely on the raw channel.)
 - End every round in a terminal or suspend state; closing in `working` marks
   the task `FAILED`.
 - One round drives exactly one task; never emit `*protocol.Task`.
-- The processor chooses the response shape indirectly: `Reply` is the taskless direct-response path, while the first status/artifact event starts a task lifecycle and lets the manager add the Task wire framing.
+- The first valid event chooses the response shape: `Reply` completes the taskless direct-response path and later events are discarded, while a status/artifact event starts a task lifecycle and lets the manager add the Task wire framing.
 - The current `status.message` stays only on `Task.Status`. When a later status
   or follow-up user message supersedes it, the previous message moves into
   history. A terminal status message stays current forever. Emit a final answer
@@ -155,7 +152,7 @@ the request.
 
 ### Round lifecycle
 
-- **Lazy task creation** — the task materializes when the first *task event* is applied. For `SendStreamingMessage`, the response starts with the pre-update Task snapshot required by the wire protocol, then the triggering status/artifact update. Retaining managers persist the updated task and triggering event before delivering either response frame; the extra Task frame is not journaled as another event. A round that only emits a `Message` leaves no task behind (`GetTask` for that round's pre-allocated ID returns not-found).
+- **Lazy task creation** — the task materializes when the first *task event* is applied. For `SendStreamingMessage`, the response starts with the pre-update Task snapshot required by the wire protocol, then the triggering status/artifact update. Retaining managers persist the updated task and triggering event before delivering either response frame; the extra Task frame is not journaled as another event. If the first valid event is a `Message`, the direct response completes immediately and later processor events are discarded; no task is created (`GetTask` for that round's pre-allocated ID returns not-found).
 - **One active run per task** — a second message for a task whose round is
   still running is rejected (`-32602`, "already has an active execution").
 - **The round ends when you close the channel** — and only then. The close
@@ -168,10 +165,7 @@ the request.
   | `submitted` / `working` | **`FAILED`** — "processor finished without terminal state" (a bug signal) |
   | cancellation was requested | **`CANCELED`** |
 
-- **Suspend yields the round** — emitting `input-required`/`auth-required`
-  releases the task immediately so a continuation can start; anything the old
-  round emits afterwards is discarded. Deliver the completion from the
-  continuation round.
+- **Suspend yields the round** — emitting `input-required`/`auth-required` releases the task immediately so a continuation can start; anything the old round emits afterwards is discarded. Memory also cancels the yielded old round's `ctx` after publishing the suspend frame and before releasing the slot. This is a round-teardown signal, not `CancelTask`: the Task remains suspended. Close the old round's channel promptly and deliver completion from the continuation round.
 - **Contract violations fail fast** — emitting an event for a foreign `taskId`,
   a `*protocol.Task` snapshot (framework-only in v1.0), or an invalid status
   marks an already-materialized task `FAILED` and discards the rest.
@@ -187,10 +181,8 @@ the request.
 - Stateless rounds are request-bound: a disconnect or manager shutdown cancels
   the processor because there is no retained task to retrieve or resubscribe
   to.
-- In memory and Redis managers, only `CancelTask` (and manager shutdown)
-  cancels the processor's `ctx`. The polite reaction is to **stop emitting and
-  close** — the framework persists `CANCELED`. A terminal event emitted *after*
-  the cancel still wins.
+- In memory and Redis managers, `CancelTask` and manager shutdown cancel active processor work. The polite reaction is to **stop emitting and close** — the framework persists `CANCELED`. A terminal event emitted *after* the cancel still wins.
+- Memory additionally cancels a yielded round's `ctx` after publishing `input-required`/`auth-required`. This signal only tears down the old round; it does **not** mark the suspended Task `CANCELED`.
 - `CancelTask` **returns the snapshot at the moment cancellation was requested**
   (possibly still `working`); the terminal `CANCELED` lands when the round winds
   down. Canceling an already-terminal task returns `-32002`.

--- a/docs/mkdocs/en/server.md
+++ b/docs/mkdocs/en/server.md
@@ -111,6 +111,8 @@ go func() {
 return out, nil
 ```
 
+The first status or artifact event selects a task-producing round. The processor does not emit `*protocol.Task`; for `SendStreamingMessage`, the manager materializes the required initial Task snapshot before forwarding that first update. A fresh round starts from `submitted`, while a continuation starts from `ec.Task`. A round that only calls `Reply` stays taskless.
+
 ([examples/simple](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples/simple)
 is a processor written entirely on the raw channel.)
 
@@ -135,6 +137,7 @@ is a processor written entirely on the raw channel.)
 - End every round in a terminal or suspend state; closing in `working` marks
   the task `FAILED`.
 - One round drives exactly one task; never emit `*protocol.Task`.
+- The processor chooses the response shape indirectly: `Reply` is the taskless direct-response path, while the first status/artifact event starts a task lifecycle and lets the manager add the Task wire framing.
 - The current `status.message` stays only on `Task.Status`. When a later status
   or follow-up user message supersedes it, the previous message moves into
   history. A terminal status message stays current forever. Emit a final answer
@@ -152,9 +155,7 @@ the request.
 
 ### Round lifecycle
 
-- **Lazy task creation** — the task materializes when the first *task event* is
-  persisted. A round that only emits a `Message` leaves no task behind
-  (`GetTask` for that round's pre-allocated ID returns not-found).
+- **Lazy task creation** — the task materializes when the first *task event* is applied. For `SendStreamingMessage`, the response starts with the pre-update Task snapshot required by the wire protocol, then the triggering status/artifact update. Retaining managers persist the updated task and triggering event before delivering either response frame; the extra Task frame is not journaled as another event. A round that only emits a `Message` leaves no task behind (`GetTask` for that round's pre-allocated ID returns not-found).
 - **One active run per task** — a second message for a task whose round is
   still running is rejected (`-32602`, "already has an active execution").
 - **The round ends when you close the channel** — and only then. The close
@@ -204,10 +205,7 @@ the request.
 - **`SendMessage` with `returnImmediately=true`** answers with the **earliest
   usable result**: the first task snapshot or the first Message. Retaining
   managers can keep a non-terminal task running; stateless cannot.
-- **`SendStreamingMessage`** forwards every event in order. Memory and Redis
-  persist task events before delivery; stateless first emits a request-local
-  Task snapshot and then its status/artifact updates. The stream ends at the
-  terminal or suspend frame.
+- **`SendStreamingMessage`** returns a direct Message without Task framing for a pure-message round. For a task-producing round, every manager first emits the operation-local Task snapshot and then forwards status/artifact updates in order; memory and Redis persist each update before delivery, while stateless applies it only to the request-local snapshot. The stream ends at the terminal or suspend frame.
 - **`SubscribeToTask`** sends the current task snapshot first, then live
   increments; terminal tasks are rejected.
 

--- a/docs/mkdocs/zh/protocol.md
+++ b/docs/mkdocs/zh/protocol.md
@@ -38,7 +38,7 @@ flowchart LR
     end
 ```
 
-不是每次交流都会产生任务：一个即答问题可以只返回一条 `Message`，没有任务生命周期，也没有任务清理负担。注意这不等于“没有会话历史”；具体实现可以把请求消息和 agent 发出的 `Message` 事件放入同一个 `contextId` 的历史里。只有值得跟踪的工作才需要开任务；从那之后，agent 汇报的一切都是**事件**：状态更新（进度）或 artifact 更新（交付物分块）。
+不是每次交流都会产生任务：一个即答问题可以只返回一条 `Message`，没有任务生命周期，也没有任务清理负担。注意这不等于“没有会话历史”；具体实现可以把请求消息和 agent 发出的 `Message` 事件放入同一个 `contextId` 的历史里。当 agent 发出 status 或 artifact 更新时，框架才创建 Task；对于流式调用，框架会在首个更新前先发送初始 Task 快照。
 
 ## 发现：Agent Card
 
@@ -103,7 +103,7 @@ agentCard := server.AgentCard{
 | 问一句、直接拿回答 | `SendMessage`，agent 返回 `Message` | 没有 `Task`，不能查询或取消。 |
 | 提交任务并等到结束 | `SendMessage` 默认模式 | 最终 `Task` 快照，包含状态和 artifacts。 |
 | 提交后马上返回 | `SendMessage` + `returnImmediately=true` | 最早可用的 `Task` 或 `Message`；任务可继续跑。 |
-| 实时看进度 | `SendStreamingMessage` | SSE 事件流：status / artifact / message。 |
+| 实时看进度 | `SendStreamingMessage` | Task 轮次先给初始快照，再给 status / artifact；直接 Message 轮次没有 Task。 |
 | 断线后接回任务 | `SubscribeToTask` | 先给当前 `Task` 快照，再给实时增量。 |
 | 不在线也要拿进展 | push notification | 服务端回调 client 的 webhook。 |
 
@@ -121,13 +121,14 @@ sequenceDiagram
 
 ### 2. 带实时进度的跟踪任务
 
-同样的请求换到流式端点：每个事件发生的瞬间就到达你这里。首个任务事件就是任务诞生的时刻。
+同样的请求换到流式端点：每个事件发生的瞬间就到达你这里。processor 通过发出 status 或 artifact 更新选择 Task 模式；框架负责创建 Task，并先发送更新前快照。
 
 ```mermaid
 sequenceDiagram
     participant C as Client
     participant A as Agent
     C->>A: SendStreamingMessage "生成 Q3 报告"
+    A-->>C: Task {id, submitted}
     A-->>C: status working
     A-->>C: artifact report.pdf（分块 1）
     A-->>C: artifact report.pdf（分块 2，lastChunk）
@@ -179,6 +180,7 @@ sequenceDiagram
     participant C as Client
     participant A as Agent
     C->>A: SendStreamingMessage "处理这个数据集"
+    A-->>C: Task {id, submitted}
     A-->>C: status working
     C->>A: CancelTask {id}
     A-->>C: Task {working} — 取消已受理
@@ -263,7 +265,7 @@ v1.0 JSON-RPC 绑定定义的方法名如下（v0.2.x wire 用的是斜杠分隔
 | 方法（v1.0） | 类型 | 用途 | v0.2.x 名称 |
 | --- | --- | --- | --- |
 | `SendMessage` | 一元 | 发送消息；响应是 **`Task` 或 `Message`**（union）。默认**等待**该轮结束。 | `message/send` |
-| `SendStreamingMessage` | SSE | 同样的请求；每个事件实时流出。 | `message/stream` |
+| `SendStreamingMessage` | SSE | 同样的请求；Task 轮次先给快照，再给 status/artifact 更新；纯直接回复没有 Task。 | `message/stream` |
 | `GetTask` | 一元 | 取任务快照；`historyLength` 决定随附多少历史。 | `tasks/get` |
 | `ListTasks` | 一元 | 枚举任务：可按 `contextId`/状态过滤、分页。 | —（v1.0 新增） |
 | `CancelTask` | 一元 | 请求取消。 | `tasks/cancel` |
@@ -308,7 +310,7 @@ v1.0 spec 定义了三种功能等价的传输绑定——JSON-RPC、gRPC、HTTP
 
 ### 典型事件范式
 
-常见输出分两类。
+常见输出分两类。下面 Task 模式中的 status/artifact 由 processor 发出；初始 `Task` 不由 processor 发送，而由框架根据首个更新前的任务状态生成。
 
 ```
 纯消息回复（不创建任务）：
@@ -321,7 +323,7 @@ artifact -> chunk 1..N     同一 artifact 的分块用 append/lastChunk
 status   -> completed      必须：以合法状态收尾；终态即关闭流
 ```
 
-强制项：产生任务后，要以合法状态结束（终态，或多轮场景的挂起态）并标注 artifact 分块；终态（或中断态）的那一帧即流的最后一帧，之后 SSE 流关闭。其余——要不要显式 `submitted`、发几帧 `working`、进度文字挂不挂在 status message 上——都由 agent 自定。
+强制项：产生任务后，要以合法状态结束（终态，或多轮场景的挂起态）并标注 artifact 分块；终态（或中断态）的那一帧即流的最后一帧，之后 SSE 流关闭。其余——要不要显式 `submitted`、发几帧 `working`、进度文字挂不挂在 status message 上——都由 agent 自定。这个所有权边界是刻意设计的：纯 `Message` 轮次不产生 Task，首个 status/artifact 则选择 Task 模式，并触发框架生成初始 Task 快照。
 
 实现层面还有一个重要边界：`TaskStatus.message` 更适合放进度解释，它会被下一个 status 覆盖；需要跨轮进入会话历史的最终回答，应作为独立 `Message` 事件发出。详见 [服务端](server.md)。
 

--- a/docs/mkdocs/zh/protocol.md
+++ b/docs/mkdocs/zh/protocol.md
@@ -121,7 +121,7 @@ sequenceDiagram
 
 ### 2. 带实时进度的跟踪任务
 
-同样的请求换到流式端点：每个事件发生的瞬间就到达你这里。processor 通过发出 status 或 artifact 更新选择 Task 模式；框架负责创建 Task，并先发送更新前快照。
+同样的请求换到流式端点：每个事件发生的瞬间就到达你这里。processor 的首个有效事件决定响应形态：Message 会完成直接响应，status 或 artifact 则选择 Task 模式，并让框架先发送更新前 Task 快照。
 
 ```mermaid
 sequenceDiagram
@@ -323,7 +323,7 @@ artifact -> chunk 1..N     同一 artifact 的分块用 append/lastChunk
 status   -> completed      必须：以合法状态收尾；终态即关闭流
 ```
 
-强制项：产生任务后，要以合法状态结束（终态，或多轮场景的挂起态）并标注 artifact 分块；终态（或中断态）的那一帧即流的最后一帧，之后 SSE 流关闭。其余——要不要显式 `submitted`、发几帧 `working`、进度文字挂不挂在 status message 上——都由 agent 自定。这个所有权边界是刻意设计的：纯 `Message` 轮次不产生 Task，首个 status/artifact 则选择 Task 模式，并触发框架生成初始 Task 快照。
+强制项：产生任务后，要以合法状态结束（终态，或多轮场景的挂起态）并标注 artifact 分块；终态（或中断态）的那一帧即流的最后一帧，之后 SSE 流关闭。其余——要不要显式 `submitted`、发几帧 `working`、进度文字挂不挂在 status message 上——都由 agent 自定。这个所有权边界是刻意设计的：首个 `Message` 会完成不产生 Task 的直接响应，本轮后续事件被丢弃；首个 status/artifact 则选择 Task 模式，并触发框架生成初始 Task 快照。
 
 实现层面还有一个重要边界：`TaskStatus.message` 更适合放进度解释，它会被下一个 status 覆盖；需要跨轮进入会话历史的最终回答，应作为独立 `Message` 事件发出。详见 [服务端](server.md)。
 

--- a/docs/mkdocs/zh/server.md
+++ b/docs/mkdocs/zh/server.md
@@ -96,6 +96,8 @@ go func() {
 return out, nil
 ```
 
+首个 status 或 artifact 事件表示 processor 选择了 Task 生命周期。processor 不需要也不允许发送 `*protocol.Task`；对于 `SendStreamingMessage`，manager 会在转发首个更新前生成协议要求的初始 Task 快照：新任务从 `submitted` 开始，续跑任务从 `ec.Task` 开始。只调用 `Reply` 的轮次仍然不产生 Task。
+
 （[examples/simple](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples/simple)是一个完全用裸 channel 写的 processor。）
 
 ### 常见形态
@@ -111,6 +113,7 @@ return out, nil
 - **谁发事件，谁负责关闭。** 如果你在 goroutine 里发事件，就在那个 goroutine 里关闭 channel 或 `TaskHandle`。channel 不关闭，轮次就不会结束，任务也会一直占着执行槽。
 - **每轮都要给出结论。** 正常结束用 `completed` / `failed` / `canceled` / `rejected`；需要用户继续输入时用 `input-required` / `auth-required`。如果还停在 `submitted` 或 `working` 就关闭，框架会把任务标成 `FAILED`。
 - **一轮只属于一个任务。** 事件默认属于 `ec.TaskID`。不要发其他 `taskId` 的事件，也不要自己发 `*protocol.Task` 快照；任务快照只由框架生成。
+- **processor 间接选择响应形态。** `Reply` 选择不产生 Task 的直接回复；首个 status/artifact 事件选择 Task 生命周期，manager 随后补齐 wire 上的 Task 首帧。
 - **要让后续对话记住终答，就发 `Message`。** 当前 `status.message` 只留在 `Task.Status`；后续状态或 follow-up 用户消息取代它时，上一条 status message 才会移入历史。终态 status message 不会再被取代，只留在 `status.Message`；artifact 也永不进历史。需要保留的回答，尤其是 LLM 最终回复，请作为 `Message` 事件发出。
 
 ## 轮次生命周期
@@ -124,12 +127,12 @@ Task 和会话历史；[TaskManager 实现](#taskmanager)中的 stateless manage
 
 1. 框架收到 `SendMessage` 或 `SendStreamingMessage`，准备好 `ExecContext`，然后调用你的 `ProcessMessage`。
 2. 你的 processor 返回事件 channel。
-3. 框架读取事件：每个事件都会先持久化，再返回给调用方或订阅者。
+3. 框架读取并应用事件：持久化型 manager 会先落库更新后的 Task 和触发事件；对于 `SendStreamingMessage`，response stream 先返回取自更新前状态的 Task 框架帧，再返回该事件。这个额外 Task 帧不会作为一条事件写入日志或广播。
 4. channel 关闭时，本轮结束；框架根据最后的任务状态收尾。
 
 关键语义如下：
 
-- **任务是懒创建的。** 只有发出 status 或 artifact 这类任务事件后，任务才真正落库。只发 `Message` 的轮次不会留下任务；对该轮预分配 ID 调 `GetTask` 会得到 not-found。
+- **任务是懒创建的。** 只有发出 status 或 artifact 这类任务事件后，任务才真正落库。对于 `SendStreamingMessage`，response stream 会先发送 wire 协议要求的更新前 Task 快照，再发送触发创建的 status/artifact；持久化型 manager 在投递这两帧前已经落库更新后的 Task 和触发事件，但不会把额外 Task 帧再记成一条事件。只发 `Message` 的轮次不会留下任务；对该轮预分配 ID 调 `GetTask` 会得到 not-found。
 - **同一任务同一时间只能跑一轮。** 上一轮还没结束时，针对同一个 `taskId` 的后续消息会被拒绝：`-32602`，`"already has an active execution"`。
 - **channel 关闭才算结束。** 关闭时框架应用下面的规则：
 
@@ -162,7 +165,7 @@ stateless manager 的轮次与请求绑定：client 断开或 manager 停机时�
 | --- | --- |
 | `SendMessage`（默认阻塞） | 本轮创建过任务时返回任务快照：memory / Redis 等轮次结束，stateless 等到终态。直接 `Message` 本身就是完整响应，stateless 收到第一条后立即返回。没有任何事件是 processor bug，返回 `-32006`。 |
 | `SendMessage` + `returnImmediately=true` | 返回最早可用的任务快照或第一条 `Message`。有状态 manager 可以让非终态任务继续后台运行；stateless 不可以。 |
-| `SendStreamingMessage` | 按事件顺序实时转发。memory / Redis 在投递前持久化任务事件；stateless 先发请求内 Task 快照，再发 status / artifact 更新。流在终态或挂起帧结束。 |
+| `SendStreamingMessage` | 纯 `Message` 轮次直接返回 Message，不添加 Task。Task 轮次由所有 manager 先发本次操作的 Task 快照，再按顺序转发 status / artifact；memory / Redis 在投递前持久化更新，stateless 只应用到请求内快照。流在终态或挂起帧结束。 |
 | `SubscribeToTask` | 先发送当前任务快照，再发送实时增量。终态任务不能订阅。 |
 
 ## 会话、历史，以及什么会被记住

--- a/docs/mkdocs/zh/server.md
+++ b/docs/mkdocs/zh/server.md
@@ -96,7 +96,7 @@ go func() {
 return out, nil
 ```
 
-首个 status 或 artifact 事件表示 processor 选择了 Task 生命周期。processor 不需要也不允许发送 `*protocol.Task`；对于 `SendStreamingMessage`，manager 会在转发首个更新前生成协议要求的初始 Task 快照：新任务从 `submitted` 开始，续跑任务从 `ec.Task` 开始。只调用 `Reply` 的轮次仍然不产生 Task。
+首个有效事件决定响应形态。`Reply` 会完成不产生 Task 的直接响应，本轮后续事件会被丢弃；status 或 artifact 则选择 Task 生命周期。processor 不需要也不允许发送 `*protocol.Task`；对于 `SendStreamingMessage`，manager 会在转发首个更新前生成协议要求的初始 Task 快照：新任务从 `submitted` 开始，续跑任务从 `ec.Task` 开始。
 
 （[examples/simple](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples/simple)是一个完全用裸 channel 写的 processor。）
 
@@ -104,7 +104,7 @@ return out, nil
 
 - **纯回复**(不产生任务):`h.Reply(protocol.NewAgentText("..."))`。
 - **实时流式**——把函数体放进 goroutine,事件就会实时到达 `SendStreamingMessage` 的消费者;长循环里检查 `ctx.Err()`,被取消时直接关闭(框架落 `CANCELED`)。→ [examples/basic](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples/basic)（`/long-task` 与 client `-stream`）
-- **多轮**——用 `h.UpdateTaskState(protocol.TaskStateInputRequired, protocol.NewAgentText("need more"))` 挂起并关闭;后续消息(回传 `taskId`)作为新一轮到来,此时 `ec.Task` 已就位。→ [examples/inputrequired](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples/inputrequired)
+- **多轮**——用 `h.UpdateTaskState(protocol.TaskStateInputRequired, protocol.NewAgentText("need more"))` 挂起并及时关闭；后续消息（回传 `taskId`）作为新一轮到来，此时 `ec.Task` 已就位。Memory 会在发布挂起帧后取消已让出的旧轮次 `ctx`，这是轮次清理信号，不会取消 Task。→ [examples/inputrequired](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples/inputrequired)
 
 ### 写 Processor 时记住这几条
 
@@ -113,7 +113,7 @@ return out, nil
 - **谁发事件，谁负责关闭。** 如果你在 goroutine 里发事件，就在那个 goroutine 里关闭 channel 或 `TaskHandle`。channel 不关闭，轮次就不会结束，任务也会一直占着执行槽。
 - **每轮都要给出结论。** 正常结束用 `completed` / `failed` / `canceled` / `rejected`；需要用户继续输入时用 `input-required` / `auth-required`。如果还停在 `submitted` 或 `working` 就关闭，框架会把任务标成 `FAILED`。
 - **一轮只属于一个任务。** 事件默认属于 `ec.TaskID`。不要发其他 `taskId` 的事件，也不要自己发 `*protocol.Task` 快照；任务快照只由框架生成。
-- **processor 间接选择响应形态。** `Reply` 选择不产生 Task 的直接回复；首个 status/artifact 事件选择 Task 生命周期，manager 随后补齐 wire 上的 Task 首帧。
+- **首个有效事件决定响应形态。** `Reply` 会完成不产生 Task 的直接回复，后续事件会被丢弃；status/artifact 则选择 Task 生命周期，manager 随后补齐 wire 上的 Task 首帧。
 - **要让后续对话记住终答，就发 `Message`。** 当前 `status.message` 只留在 `Task.Status`；后续状态或 follow-up 用户消息取代它时，上一条 status message 才会移入历史。终态 status message 不会再被取代，只留在 `status.Message`；artifact 也永不进历史。需要保留的回答，尤其是 LLM 最终回复，请作为 `Message` 事件发出。
 
 ## 轮次生命周期
@@ -132,7 +132,7 @@ Task 和会话历史；[TaskManager 实现](#taskmanager)中的 stateless manage
 
 关键语义如下：
 
-- **任务是懒创建的。** 只有发出 status 或 artifact 这类任务事件后，任务才真正落库。对于 `SendStreamingMessage`，response stream 会先发送 wire 协议要求的更新前 Task 快照，再发送触发创建的 status/artifact；持久化型 manager 在投递这两帧前已经落库更新后的 Task 和触发事件，但不会把额外 Task 帧再记成一条事件。只发 `Message` 的轮次不会留下任务；对该轮预分配 ID 调 `GetTask` 会得到 not-found。
+- **任务是懒创建的。** 只有发出 status 或 artifact 这类任务事件后，任务才真正落库。对于 `SendStreamingMessage`，response stream 会先发送 wire 协议要求的更新前 Task 快照，再发送触发创建的 status/artifact；持久化型 manager 在投递这两帧前已经落库更新后的 Task 和触发事件，但不会把额外 Task 帧再记成一条事件。如果首个有效事件是 `Message`，直接响应会立即完成，本轮后续事件被丢弃且不会创建 Task；对该轮预分配 ID 调 `GetTask` 会得到 not-found。
 - **同一任务同一时间只能跑一轮。** 上一轮还没结束时，针对同一个 `taskId` 的后续消息会被拒绝：`-32602`，`"already has an active execution"`。
 - **channel 关闭才算结束。** 关闭时框架应用下面的规则：
 
@@ -143,7 +143,7 @@ Task 和会话历史；[TaskManager 实现](#taskmanager)中的 stateless manage
   | 停在 `submitted` / `working` | 标记为 `FAILED`，错误信息是 `"processor finished without terminal state"` |
   | 收到取消且没有发出终态 | 标记为 `CANCELED` |
 
-- **挂起会立刻让出任务。** 发出 `input-required` / `auth-required` 后，框架允许续跑轮次开始。旧轮次之后再发出的事件会被丢弃；完成结果应该由续跑轮次交付。
+- **挂起会立刻让出任务。** 发出 `input-required` / `auth-required` 后，框架允许续跑轮次开始。旧轮次之后再发出的事件会被丢弃；Memory 还会在发布挂起帧后、释放执行槽前取消旧轮次 `ctx`。这是轮次清理信号，不等于 `CancelTask`，Task 仍保持挂起。旧轮次应尽快关闭 channel，完成结果由续跑轮次交付。
 - **违反事件契约会失败。** 例如给别的 `taskId` 发事件、发 `*protocol.Task` 快照、发没有状态的 status，都会让本轮任务失败，并丢弃后续事件。
 - **挂起必须有可留存的状态。** stateless 会拒绝 `input-required` / `auth-required`，因为它无法接受这些状态要求的后续 continuation。
 
@@ -153,7 +153,9 @@ memory 与 Redis manager 中，client 断开连接不会自动取消 agent 的�
 
 stateless manager 的轮次与请求绑定：client 断开或 manager 停机时会取消 processor，因为此时没有可供后续查询的 Task，也没有可重新订阅的流。
 
-对于 memory 与 Redis，真正会取消 processor `ctx` 的只有两类动作：client 调 `CancelTask`，或者 manager / server 停机。收到取消后，推荐做法是停止继续发送普通进度，尽快关闭 channel；如果你需要收尾，也可以发出自己的终态事件，框架会尊重它。
+对于 memory 与 Redis，client 调 `CancelTask` 或 manager / server 停机会取消正在执行的 processor `ctx`。收到任务取消后，推荐做法是停止继续发送普通进度，尽快关闭 channel；如果你需要收尾，也可以发出自己的终态事件，框架会尊重它。
+
+Memory 还会在发布 `input-required` / `auth-required` 后取消已让出的旧轮次 `ctx`。该信号只用于结束旧轮次，不会把保持挂起的 Task 标成 `CANCELED`。
 
 `CancelTask` 返回的是“发起取消那一刻”的任务快照，所以它可能仍然是 `working`。最终是否落成 `CANCELED`，要等 processor 停下并关闭 channel。已经终态的任务不能取消，会返回 `-32002`。
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -426,14 +426,17 @@ func TestA2ASrv_HandleMessageStream_SSE(t *testing.T) {
 		Parts:     []*protocol.Part{protocol.NewTextPart("SSE test input")},
 	}
 
-	// Configure mock streaming events for message/stream
-	// Use TaskStatusUpdateEvent to simulate message streaming progress
+	// Configure mock streaming events for message/stream. A task lifecycle
+	// stream starts with the initial Task, followed by status/artifact updates.
+	initialTask := protocol.NewTask(messageID, "test-context")
 	event1 := protocol.TaskStatusUpdateEvent{
-		TaskID: messageID,
-		Status: protocol.TaskStatus{State: protocol.TaskStateWorking},
+		TaskID:    messageID,
+		ContextID: initialTask.ContextID,
+		Status:    protocol.TaskStatus{State: protocol.TaskStateWorking},
 	}
 	event2 := protocol.TaskArtifactUpdateEvent{
-		TaskID: messageID,
+		TaskID:    messageID,
+		ContextID: initialTask.ContextID,
 		Artifact: protocol.Artifact{
 			ArtifactID: "stream-artifact-1",
 			Parts:      []*protocol.Part{protocol.NewTextPart("Streaming response")},
@@ -441,12 +444,14 @@ func TestA2ASrv_HandleMessageStream_SSE(t *testing.T) {
 	}
 	final := true
 	event3 := protocol.TaskStatusUpdateEvent{
-		TaskID: messageID,
-		Status: protocol.TaskStatus{State: protocol.TaskStateCompleted},
-		Final:  final,
+		TaskID:    messageID,
+		ContextID: initialTask.ContextID,
+		Status:    protocol.TaskStatus{State: protocol.TaskStateCompleted},
+		Final:     final,
 	}
 	// Configure mock events for message streaming
 	mockTM.sendMessageStreamEvents = []protocol.StreamResponse{
+		protocol.NewStreamResponseTask(initialTask),
 		{Result: &event1},
 		{Result: &event2},
 		{Result: &event3},
@@ -529,7 +534,11 @@ func TestA2ASrv_HandleMessageStream_SSE(t *testing.T) {
 			t.Fatalf("Test context canceled: %v", ctx.Err())
 		}
 	}
-	require.Greater(t, len(receivedEvents), 0, "Should have received at least one event")
+	require.Len(t, receivedEvents, 4, "Should have received the initial Task and three updates")
+	require.NotNil(t, receivedEvents[0].GetTask(), "First event should be a Task")
+	assert.Equal(t, protocol.TaskStateSubmitted, receivedEvents[0].GetTask().Status.State)
+	require.NotNil(t, receivedEvents[1].GetStatusUpdate(), "Initial Task should be followed by the first status update")
+	assert.Equal(t, protocol.TaskStateWorking, receivedEvents[1].GetStatusUpdate().Status.State)
 	var lastStatusEvent *protocol.TaskStatusUpdateEvent
 	for i := len(receivedEvents) - 1; i >= 0; i-- {
 		if receivedEvents[i].GetStatusUpdate() != nil {

--- a/taskmanager/interface.go
+++ b/taskmanager/interface.go
@@ -77,6 +77,15 @@ type ExecContext struct {
 //   - *protocol.Task is never accepted: task snapshots are materialized by
 //     managers from the event stream. Emitting one is a contract violation.
 //
+// The processor therefore selects the response shape without emitting a Task:
+// a pure Message round remains taskless, while emitting a status or artifact
+// selects a task lifecycle. For message/stream, the manager emits an
+// operation-local Task snapshot before that round's first task update. A fresh
+// round starts from SUBMITTED; a continuation starts from ExecContext.Task.
+// This framing snapshot is not a processor event and is not journaled or
+// broadcast as an update. Retaining managers persist the triggering task event
+// before delivering the response frames.
+//
 // Task events may leave TaskID/ContextID empty; the manager stamps them. A
 // direct Message may leave ContextID empty. Foreign IDs are a contract
 // violation: an already-materialized task is failed, otherwise the request is
@@ -147,10 +156,13 @@ type TaskManager interface {
 	) (*protocol.SendMessageResponse, error)
 
 	// OnSendMessageStream handles a request corresponding to the 'message/stream' RPC method.
-	// It invokes the MessageProcessor and returns a channel that carries emitted
-	// events. Retaining managers persist task events before delivery; stateless
-	// managers apply them only to the request-local task. The channel is closed
-	// when the round ends; setup errors are returned directly.
+	// It invokes the MessageProcessor and returns a channel carrying the derived
+	// response stream. A pure Message round has no Task framing. A task-producing
+	// round starts with a manager-materialized Task snapshot, followed by the
+	// processor's status/artifact events. Retaining managers persist task events
+	// before delivery; stateless managers apply them only to the request-local
+	// task. The channel is closed when the round ends; setup errors are returned
+	// directly.
 	OnSendMessageStream(
 		ctx context.Context,
 		request protocol.SendMessageParams,

--- a/taskmanager/interface.go
+++ b/taskmanager/interface.go
@@ -77,14 +77,14 @@ type ExecContext struct {
 //   - *protocol.Task is never accepted: task snapshots are materialized by
 //     managers from the event stream. Emitting one is a contract violation.
 //
-// The processor therefore selects the response shape without emitting a Task:
-// a pure Message round remains taskless, while emitting a status or artifact
-// selects a task lifecycle. For message/stream, the manager emits an
-// operation-local Task snapshot before that round's first task update. A fresh
-// round starts from SUBMITTED; a continuation starts from ExecContext.Task.
-// This framing snapshot is not a processor event and is not journaled or
-// broadcast as an update. Retaining managers persist the triggering task event
-// before delivering the response frames.
+// The first valid event selects the response shape without emitting a Task: a
+// Message completes a taskless direct response, and later events from that round
+// are discarded; a status or artifact selects a task lifecycle. For
+// message/stream, the manager emits an operation-local Task snapshot before that
+// round's first task update. A fresh round starts from SUBMITTED; a continuation
+// starts from ExecContext.Task. This framing snapshot is not a processor event
+// and is not journaled or broadcast as an update. Retaining managers persist the
+// triggering task event before delivering the response frames.
 //
 // Task events may leave TaskID/ContextID empty; the manager stamps them. A
 // direct Message may leave ContextID empty. Foreign IDs are a contract
@@ -113,11 +113,15 @@ type ExecContext struct {
 // suspending). The message/stream response stream ends at the terminal or
 // suspend frame; the channel itself is still drained until closed.
 //
-// For retaining managers, ctx is canceled when the task is canceled via
-// CancelTask. A client disconnect does NOT cancel ctx: the work keeps running
-// and its results remain retrievable (GetTask / SubscribeToTask). A stateless
-// manager cancels ctx on disconnect and discards its request-local task. The
-// framework always drains the channel until it is closed, so senders never leak.
+// For retaining managers, CancelTask and manager shutdown cancel active work.
+// The Memory manager also cancels a yielded round's ctx after publishing its
+// input-required/auth-required frame and before releasing the task slot. That is
+// round teardown, not task cancellation: the suspended Task stays unchanged and
+// the processor must close its channel promptly. A client disconnect does NOT
+// cancel retaining work, whose results remain retrievable (GetTask /
+// SubscribeToTask). A stateless manager cancels ctx on disconnect and discards
+// its request-local task. The framework always drains the channel until it is
+// closed, so senders never leak.
 //
 // The framework starts consuming the channel only after ProcessMessage
 // returns: sends beyond the channel buffer from inside ProcessMessage itself

--- a/taskmanager/memory/execution_registry.go
+++ b/taskmanager/memory/execution_registry.go
@@ -1,0 +1,206 @@
+// Tencent is pleased to support the open source community by making trpc-a2a-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-a2a-go is licensed under the Apache License Version 2.0.
+
+package memory
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
+)
+
+// executionRegistry is the single writer for live MessageProcessor runs.
+// It serializes admission, suspend handoff, cancellation, and Close:
+// at most one live slot per scoped task ID.
+type executionRegistry struct {
+	mu         sync.Mutex
+	executions map[scopedID]*execution
+	closed     bool
+	engines    sync.WaitGroup
+}
+
+func newExecutionRegistry() *executionRegistry {
+	return &executionRegistry{executions: make(map[scopedID]*execution)}
+}
+
+// register publishes the cancellation handle of a starting run. A task admits
+// at most one live run; a continuation waits through the previous round's
+// short suspend handoff, while any other concurrent round is rejected.
+func (r *executionRegistry) register(ctx context.Context, tenant, taskID string, exec *execution) error {
+	key := newScopedID(tenant, taskID)
+	for {
+		r.mu.Lock()
+		if r.closed {
+			r.mu.Unlock()
+			return taskmanager.ErrInternalError("task manager is closed")
+		}
+		current, exists := r.executions[key]
+		if !exists {
+			r.executions[key] = exec
+			// Counted under the registry lock so Close (which flips closed first)
+			// can never begin waiting before a just-admitted run is counted.
+			r.engines.Add(1)
+			r.mu.Unlock()
+			return nil
+		}
+		yieldDone := current.yieldDone
+		r.mu.Unlock()
+		if yieldDone == nil {
+			return taskmanager.ErrInvalidParams(fmt.Sprintf("task %s already has an active execution", taskID))
+		}
+		select {
+		case <-yieldDone:
+			// The previous round has finished publishing its suspend event. Retry
+			// under the lock so Close or another continuation can win cleanly.
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+// release aborts a registered run whose engine never started: it undoes
+// register's registration and engine count.
+func (r *executionRegistry) release(tenant, taskID string, exec *execution) {
+	r.deregister(tenant, taskID, exec)
+	r.engines.Done()
+}
+
+// engineDone marks one drain engine finished (paired with register's Add).
+func (r *executionRegistry) engineDone() {
+	r.engines.Done()
+}
+
+// wait blocks until every registered engine has finished.
+func (r *executionRegistry) wait() {
+	r.engines.Wait()
+}
+
+// claimCancelSlot atomically returns the task's live run or — when there is
+// none — claims the execution slot with a sentinel, so a no-live cancel's
+// CANCELED write gets the same single-writer guarantee as a run: no
+// continuation can register (and then write) concurrently with it.
+func (r *executionRegistry) claimCancelSlot(
+	tenant string,
+	taskID string,
+) (live *execution, sentinel *execution, yieldDone <-chan struct{}) {
+	key := newScopedID(tenant, taskID)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if exec, ok := r.executions[key]; ok {
+		if exec.yieldDone != nil {
+			return nil, nil, exec.yieldDone
+		}
+		return exec, nil, nil
+	}
+	sentinel = &execution{cancel: func() {}}
+	r.executions[key] = sentinel
+	return nil, sentinel, nil
+}
+
+// requestCancel linearizes an accepted cancellation against a suspend handoff.
+// It returns the handoff channel when yield won, or accepted after publishing
+// cancelRequested under the registry lock.
+func (r *executionRegistry) requestCancel(
+	tenant string,
+	taskID string,
+	exec *execution,
+) (yieldDone <-chan struct{}, accepted bool) {
+	key := newScopedID(tenant, taskID)
+	r.mu.Lock()
+	if r.executions[key] != exec {
+		r.mu.Unlock()
+		return nil, false
+	}
+	if exec.yieldDone != nil {
+		yieldDone = exec.yieldDone
+		r.mu.Unlock()
+		return yieldDone, false
+	}
+	exec.cancelRequested.Store(true)
+	r.mu.Unlock()
+	exec.cancel()
+	return nil, true
+}
+
+// deregister removes the handle if it still belongs to this run.
+func (r *executionRegistry) deregister(tenant, taskID string, exec *execution) {
+	key := newScopedID(tenant, taskID)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.executions[key] == exec {
+		delete(r.executions, key)
+		if exec.yieldDone != nil {
+			close(exec.yieldDone)
+			exec.yieldDone = nil
+		}
+	}
+}
+
+// beginYield turns an active slot into a short handoff barrier. The slot
+// remains owned by exec until its suspend frame has reached every local
+// observer, but continuations wait for the handoff instead of failing.
+func (r *executionRegistry) beginYield(tenant, taskID string, exec *execution) bool {
+	key := newScopedID(tenant, taskID)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.executions[key] == exec && exec.yieldDone == nil && !exec.cancelRequested.Load() {
+		exec.yieldDone = make(chan struct{})
+		return true
+	}
+	return false
+}
+
+// abortYield restores an active slot when committing the suspended state fails.
+// Waiters wake and re-evaluate it as an ordinary active run.
+func (r *executionRegistry) abortYield(tenant, taskID string, exec *execution) {
+	key := newScopedID(tenant, taskID)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.executions[key] == exec && exec.yieldDone != nil {
+		close(exec.yieldDone)
+		exec.yieldDone = nil
+	}
+}
+
+// live returns the cancellation handle of the task's live run, if any.
+func (r *executionRegistry) live(tenant, taskID string) *execution {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.executions[newScopedID(tenant, taskID)]
+}
+
+// isClosed reports whether shutdown has begun.
+func (r *executionRegistry) isClosed() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.closed
+}
+
+// shutdown refuses new runs, cancels every live one, and returns their stream
+// pipes so the caller can unblock engines parked on a blocking pipe send.
+func (r *executionRegistry) shutdown() []*taskSubscriber {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.closed = true
+	pipes := make([]*taskSubscriber, 0, len(r.executions))
+	for _, exec := range r.executions {
+		exec.cancelRequested.Store(true)
+		exec.cancel()
+		if exec.pipe != nil {
+			pipes = append(pipes, exec.pipe)
+		}
+	}
+	return pipes
+}
+
+// len returns the number of registered slots (tests / diagnostics).
+func (r *executionRegistry) len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.executions)
+}

--- a/taskmanager/memory/memory.go
+++ b/taskmanager/memory/memory.go
@@ -177,17 +177,9 @@ type TaskManager struct {
 	// nil when push is disabled or the agent selected manual delivery.
 	pushDispatcher *push.Dispatcher
 
-	// executions tracks the cancellation handle of every live MessageProcessor run,
-	// keyed by task ID. Registered before ProcessMessage, removed when the engine
-	// finishes; OnCancelTask cancels through it.
-	executions map[scopedID]*execution
-	// execMu protects the executions and closed fields
-	execMu sync.Mutex
-	// closed rejects new runs once Close has begun tearing the manager down.
-	closed bool
-	// engineWg counts live drain engines so Close can wait for their final
-	// persists instead of clearing state under them.
-	engineWg sync.WaitGroup
+	// runs is the sole owner of live MessageProcessor slots (admission,
+	// suspend handoff, cancellation, Close). See executionRegistry.
+	runs *executionRegistry
 
 	// options
 	options *TaskManagerOptions
@@ -226,7 +218,7 @@ func NewTaskManager(processor taskmanager.MessageProcessor, opts ...TaskManagerO
 		subscribers:   make(map[scopedID][]*taskSubscriber),
 		pushStore:     newPushConfigStore(),
 		pushEnabled:   options.Push.Sender != nil || options.Push.ManualDelivery,
-		executions:    make(map[scopedID]*execution),
+		runs:          newExecutionRegistry(),
 		options:       options,
 		stopCleanup:   make(chan struct{}),
 	}
@@ -363,7 +355,7 @@ func (m *TaskManager) OnGetTask(ctx context.Context, params protocol.TaskQueryPa
 // sentinel so no continuation can start (and write) concurrently.
 func (m *TaskManager) OnCancelTask(ctx context.Context, params protocol.TaskIDParams) (*protocol.Task, error) {
 	for {
-		live, sentinel, yieldDone := m.claimCancelSlot(params.Tenant, params.ID)
+		live, sentinel, yieldDone := m.runs.claimCancelSlot(params.Tenant, params.ID)
 		if yieldDone != nil {
 			select {
 			case <-yieldDone:
@@ -373,7 +365,7 @@ func (m *TaskManager) OnCancelTask(ctx context.Context, params protocol.TaskIDPa
 			}
 		}
 		if live == nil {
-			defer m.deregisterExecution(params.Tenant, params.ID, sentinel)
+			defer m.runs.deregister(params.Tenant, params.ID, sentinel)
 			return m.cancelWithoutLiveRun(params)
 		}
 
@@ -397,7 +389,7 @@ func (m *TaskManager) OnCancelTask(ctx context.Context, params protocol.TaskIDPa
 		// Linearize cancellation against a concurrent suspend handoff. If the
 		// handoff won, wait for it and retry as a no-live cancel; otherwise the
 		// close rule is guaranteed to observe cancelRequested.
-		yieldDone, accepted := m.requestExecutionCancel(params.Tenant, params.ID, live)
+		yieldDone, accepted := m.runs.requestCancel(params.Tenant, params.ID, live)
 		if yieldDone != nil {
 			select {
 			case <-yieldDone:
@@ -410,7 +402,7 @@ func (m *TaskManager) OnCancelTask(ctx context.Context, params protocol.TaskIDPa
 			continue
 		}
 
-		if m.liveExecution(params.Tenant, params.ID) != live {
+		if m.runs.live(params.Tenant, params.ID) != live {
 			// The run yielded (suspend) or finished while we were canceling, so
 			// its close rule will not persist CANCELED on our behalf. Reassess:
 			// the next pass either claims the free slot and persists CANCELED
@@ -796,10 +788,7 @@ func (m *TaskManager) dispatchPush(tenant, taskID string, event protocol.StreamR
 	if len(registrations) == 0 {
 		return
 	}
-	m.execMu.Lock()
-	closed := m.closed
-	m.execMu.Unlock()
-	if closed {
+	if m.runs.isClosed() {
 		return
 	}
 	if err := m.pushDispatcher.Enqueue(registrations, event); err != nil && !errors.Is(err, push.ErrDispatcherClosed) {
@@ -1011,7 +1000,7 @@ func (m *TaskManager) cleanExpiredTasks(maxAge time.Duration) int {
 		// A terminal task normally has no live execution, but its engine may
 		// still be draining; cancel the MessageProcessor ctx so a stuck run can exit.
 		for _, taskKey := range expiredTaskIDs {
-			if exec := m.liveExecution(taskKey.tenant, taskKey.id); exec != nil {
+			if exec := m.runs.live(taskKey.tenant, taskKey.id); exec != nil {
 				exec.cancel()
 			}
 		}
@@ -1040,17 +1029,7 @@ func (m *TaskManager) Close() error {
 		// Refuse new runs, request cancellation of every live one, and collect
 		// their stream pipes: closing a pipe unblocks an engine parked on a
 		// blocking pipe send.
-		m.execMu.Lock()
-		m.closed = true
-		pipes := make([]*taskSubscriber, 0, len(m.executions))
-		for _, exec := range m.executions {
-			exec.cancelRequested.Store(true)
-			exec.cancel()
-			if exec.pipe != nil {
-				pipes = append(pipes, exec.pipe)
-			}
-		}
-		m.execMu.Unlock()
+		pipes := m.runs.shutdown()
 		// Unblock an enqueue waiting on a full queue and cancel slow webhook
 		// calls before waiting for engines that may be inside dispatch.
 		m.pushDispatcher.Close()
@@ -1075,7 +1054,7 @@ func (m *TaskManager) Close() error {
 		// Wait for the detached engines: their final persists (close-rule
 		// CANCELED) land before teardown, and nothing re-populates the maps
 		// afterwards.
-		m.engineWg.Wait()
+		m.runs.wait()
 
 		m.taskMu.Lock()
 		m.tasks = make(map[scopedID]*protocol.Task)

--- a/taskmanager/memory/memory.go
+++ b/taskmanager/memory/memory.go
@@ -574,6 +574,13 @@ func (m *TaskManager) OnResubscribe(
 ) (<-chan protocol.StreamResponse, error) {
 	m.taskMu.Lock()
 	defer m.taskMu.Unlock()
+	// Close marks the execution registry closed before sweeping subscribers.
+	// Check that state while holding taskMu so a subscriber admitted just before
+	// shutdown is necessarily included in the sweep, while one arriving after
+	// shutdown is rejected instead of leaking past Close.
+	if m.runs.isClosed() {
+		return nil, taskmanager.ErrInternalError("task manager is closed")
+	}
 	key := newScopedID(params.Tenant, params.ID)
 
 	// Check if task exists

--- a/taskmanager/memory/memory_engine.go
+++ b/taskmanager/memory/memory_engine.go
@@ -159,13 +159,13 @@ func (m *TaskManager) prepareExecContext(
 	// write — the slot frees only after that write — so the snapshot below can
 	// never be a stale pre-terminal copy that would smuggle writes past a
 	// terminal state.
-	if err := m.registerExecution(ctx, request.Tenant, taskID, exec); err != nil {
+	if err := m.runs.register(ctx, request.Tenant, taskID, exec); err != nil {
 		return nil, err
 	}
 	releaseOnError := true
 	defer func() {
 		if releaseOnError {
-			m.releaseExecution(request.Tenant, taskID, exec)
+			m.runs.release(request.Tenant, taskID, exec)
 		}
 	}()
 
@@ -369,12 +369,12 @@ func (m *TaskManager) startExecution(
 	events, err := m.processor.ProcessMessage(execCtx, &processorEC)
 	if err != nil {
 		// Failed start (§3.5): no events are consumed, nothing was persisted.
-		m.releaseExecution(ec.Tenant, ec.TaskID, exec)
+		m.runs.release(ec.Tenant, ec.TaskID, exec)
 		cancel()
 		return nil, err
 	}
 	if events == nil {
-		m.releaseExecution(ec.Tenant, ec.TaskID, exec)
+		m.runs.release(ec.Tenant, ec.TaskID, exec)
 		cancel()
 		return nil, taskmanager.ErrInternalError("processor returned nil channel")
 	}
@@ -389,151 +389,10 @@ func (m *TaskManager) startExecution(
 		done:              make(chan struct{}),
 	}
 	go func() {
-		defer m.engineWg.Done()
+		defer m.runs.engineDone()
 		eng.run(events)
 	}()
 	return eng, nil
-}
-
-// registerExecution publishes the cancellation handle of a starting run. A
-// task admits at most one live run; a continuation waits through the previous
-// round's short suspend handoff, while any other concurrent round is rejected.
-func (m *TaskManager) registerExecution(
-	ctx context.Context,
-	tenant, taskID string,
-	exec *execution,
-) error {
-	key := newScopedID(tenant, taskID)
-	for {
-		m.execMu.Lock()
-		if m.closed {
-			m.execMu.Unlock()
-			return taskmanager.ErrInternalError("task manager is closed")
-		}
-		current, exists := m.executions[key]
-		if !exists {
-			m.executions[key] = exec
-			// Counted under the registry lock so Close (which flips m.closed first)
-			// can never begin waiting before a just-admitted run is counted.
-			m.engineWg.Add(1)
-			m.execMu.Unlock()
-			return nil
-		}
-		yieldDone := current.yieldDone
-		m.execMu.Unlock()
-		if yieldDone == nil {
-			return taskmanager.ErrInvalidParams(
-				fmt.Sprintf("task %s already has an active execution", taskID))
-		}
-		select {
-		case <-yieldDone:
-			// The previous round has finished publishing its suspend event. Retry
-			// under the lock so Close or another continuation can win cleanly.
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-	}
-}
-
-// releaseExecution aborts a registered run whose engine never started: it
-// undoes registerExecution's registration and engine count.
-func (m *TaskManager) releaseExecution(tenant, taskID string, exec *execution) {
-	m.deregisterExecution(tenant, taskID, exec)
-	m.engineWg.Done()
-}
-
-// claimCancelSlot atomically returns the task's live run or — when there is
-// none — claims the execution slot with a sentinel, so a no-live cancel's
-// CANCELED write gets the same single-writer guarantee as a run: no
-// continuation can register (and then write) concurrently with it.
-func (m *TaskManager) claimCancelSlot(
-	tenant string,
-	taskID string,
-) (live *execution, sentinel *execution, yieldDone <-chan struct{}) {
-	key := newScopedID(tenant, taskID)
-	m.execMu.Lock()
-	defer m.execMu.Unlock()
-	if exec, ok := m.executions[key]; ok {
-		if exec.yieldDone != nil {
-			return nil, nil, exec.yieldDone
-		}
-		return exec, nil, nil
-	}
-	sentinel = &execution{cancel: func() {}}
-	m.executions[key] = sentinel
-	return nil, sentinel, nil
-}
-
-// requestExecutionCancel linearizes an accepted cancellation against a
-// suspend handoff. It returns the handoff channel when yield won, or accepted
-// after publishing cancelRequested under the registry lock.
-func (m *TaskManager) requestExecutionCancel(
-	tenant string,
-	taskID string,
-	exec *execution,
-) (yieldDone <-chan struct{}, accepted bool) {
-	key := newScopedID(tenant, taskID)
-	m.execMu.Lock()
-	if m.executions[key] != exec {
-		m.execMu.Unlock()
-		return nil, false
-	}
-	if exec.yieldDone != nil {
-		yieldDone = exec.yieldDone
-		m.execMu.Unlock()
-		return yieldDone, false
-	}
-	exec.cancelRequested.Store(true)
-	m.execMu.Unlock()
-	exec.cancel()
-	return nil, true
-}
-
-// deregisterExecution removes the handle if it still belongs to this run.
-func (m *TaskManager) deregisterExecution(tenant, taskID string, exec *execution) {
-	key := newScopedID(tenant, taskID)
-	m.execMu.Lock()
-	defer m.execMu.Unlock()
-	if m.executions[key] == exec {
-		delete(m.executions, key)
-		if exec.yieldDone != nil {
-			close(exec.yieldDone)
-			exec.yieldDone = nil
-		}
-	}
-}
-
-// beginExecutionYield turns an active slot into a short handoff barrier. The
-// slot remains owned by exec until its suspend frame has reached every local
-// observer, but continuations wait for the handoff instead of failing.
-func (m *TaskManager) beginExecutionYield(tenant, taskID string, exec *execution) bool {
-	key := newScopedID(tenant, taskID)
-	m.execMu.Lock()
-	defer m.execMu.Unlock()
-	if m.executions[key] == exec && exec.yieldDone == nil && !exec.cancelRequested.Load() {
-		exec.yieldDone = make(chan struct{})
-		return true
-	}
-	return false
-}
-
-// abortExecutionYield restores an active slot when committing the suspended
-// state fails. Waiters wake and re-evaluate it as an ordinary active run.
-func (m *TaskManager) abortExecutionYield(tenant, taskID string, exec *execution) {
-	key := newScopedID(tenant, taskID)
-	m.execMu.Lock()
-	defer m.execMu.Unlock()
-	if m.executions[key] == exec && exec.yieldDone != nil {
-		close(exec.yieldDone)
-		exec.yieldDone = nil
-	}
-}
-
-// liveExecution returns the cancellation handle of the task's live run, if any.
-func (m *TaskManager) liveExecution(tenant, taskID string) *execution {
-	m.execMu.Lock()
-	defer m.execMu.Unlock()
-	return m.executions[newScopedID(tenant, taskID)]
 }
 
 // run consumes the MessageProcessor channel until it closes. After a terminal state or
@@ -671,6 +530,15 @@ func (eng *engine) rollStatusMessage(message *protocol.Message) {
 	eng.manager.storeStatusMessage(eng.ec.Tenant, eng.ec.TaskID, eng.ec.ContextID, message)
 }
 
+// statusPersistResult is the outcome of applying a status update under taskMu.
+type statusPersistResult struct {
+	initial               *protocol.Task
+	previousStatusMessage *protocol.Message
+	snapshot              *protocol.Task
+	yieldOutcome          sendOutcome
+	alreadyTerminal       protocol.TaskState // set when the write was rejected
+}
+
 // handleStatus persists a status update and then broadcasts it. The first task
 // event materializes the task (§3.2 lazy creation). A terminal state closes
 // the fan-out subscribers but the channel keeps being drained.
@@ -688,98 +556,125 @@ func (eng *engine) handleStatus(event *protocol.TaskStatusUpdateEvent) {
 	final := isFinalState(event.Status.State)
 	suspended := !final && isSuspendedState(event.Status.State)
 	event.Final = final
-	yielding := false
-	if suspended {
-		// Establish the handoff before the suspended state can become visible in
-		// the store. A polling client may otherwise observe INPUT_REQUIRED and
-		// still be rejected as a concurrent execution. If cancellation claimed
-		// the slot first, keep this round active so its close rule can persist
-		// CANCELED rather than swallowing the accepted cancellation.
-		yielding = m.beginExecutionYield(eng.ec.Tenant, eng.ec.TaskID, eng.exec)
-	}
 
-	// Persist first (§3.6), under the task lock.
-	m.taskMu.Lock()
-	taskKey := newScopedID(eng.ec.Tenant, eng.ec.TaskID)
-	task, exists := m.tasks[taskKey]
-	if exists && isFinalState(task.Status.State) {
-		// Terminal states are immutable: never write over one, whoever set it.
-		m.taskMu.Unlock()
-		if yielding {
-			m.abortExecutionYield(eng.ec.Tenant, eng.ec.TaskID, eng.exec)
-		}
+	// Establish the handoff before the suspended state can become visible in
+	// the store. A polling client may otherwise observe INPUT_REQUIRED and
+	// still be rejected as a concurrent execution. If cancellation claimed
+	// the slot first, keep this round active so its close rule can persist
+	// CANCELED rather than swallowing the accepted cancellation.
+	yielding := suspended && m.runs.beginYield(eng.ec.Tenant, eng.ec.TaskID, eng.exec)
+
+	// Persist first (§3.6), then publish.
+	persisted, ok := eng.persistStatusUpdate(event, yielding)
+	if !ok {
+		eng.abortYieldIf(yielding)
 		log.Warnf("memory TaskManager: discarding status %s for task %s already in terminal state %s",
-			event.Status.State, eng.ec.TaskID, task.Status.State)
+			event.Status.State, eng.ec.TaskID, persisted.alreadyTerminal)
 		eng.stopReason = engineStopTerminal
 		return
 	}
-	var initial *protocol.Task
-	if !eng.taskWritten {
-		if exists {
-			initial = copyTask(task)
-		} else {
-			initial = protocol.NewTask(eng.ec.TaskID, eng.ec.ContextID)
-		}
-	}
-	var previousStatusMessage *protocol.Message
-	if !exists {
-		task = eng.newTask(event.Status)
-		m.tasks[taskKey] = task
-	} else {
-		previousStatusMessage = task.Status.Message
-		task.Status = event.Status
-	}
-	eng.taskWritten = true
-	snapshot := eng.immediateSnapshotLocked(task)
-	var yieldOutcome sendOutcome
-	if yielding {
-		// The round is about to yield ownership: keep its own copy as the unary
-		// result, since the shared entry may belong to a continuation before
-		// finish() runs.
-		yieldOutcome.task = copyTask(task)
-	}
-	m.taskMu.Unlock()
-	if initial != nil {
-		eng.sendToPipe(protocol.NewStreamResponseTask(initial))
+	if persisted.initial != nil {
+		eng.sendToPipe(protocol.NewStreamResponseTask(persisted.initial))
 	}
 	if err := eng.persistInlinePushConfig(); err != nil {
-		if yielding {
-			m.abortExecutionYield(eng.ec.Tenant, eng.ec.TaskID, eng.exec)
-		}
+		eng.abortYieldIf(yielding)
 		eng.violate(err.Error())
 		return
 	}
 
 	// The old status message has now been superseded. Move it to history before
 	// publishing the new status; the new/current message remains only on Status.
-	eng.rollStatusMessage(previousStatusMessage)
+	eng.rollStatusMessage(persisted.previousStatusMessage)
 
 	response := protocol.NewStreamResponseStatusUpdate(event)
 	if yielding {
-		eng.finalOutcome = yieldOutcome
-		eng.stopReason = engineStopYield
-		// Queue automatic push before exposing the suspend state. A full bounded
-		// queue may delay publication, but a client can never observe a state it
-		// cannot yet continue. The handoff starts before enqueue so a client that
-		// polls the persisted task also waits instead of being rejected. It also
-		// serializes task-subscriber fan-out with a continuation round.
-		m.dispatchPush(eng.ec.Tenant, eng.ec.TaskID, response)
-		eng.broadcastWithoutPush(response, snapshot)
-		eng.closePipe()
-		m.deregisterExecution(eng.ec.Tenant, eng.ec.TaskID, eng.exec)
+		eng.completeStatusYield(response, persisted.snapshot, persisted.yieldOutcome)
 		return
 	}
 
-	// Then broadcast: any subscriber that sees this event is guaranteed to
-	// find the store at least as fresh via GetTask.
-	eng.broadcast(response, snapshot)
-
+	// Any subscriber that sees this event is guaranteed to find the store at
+	// least as fresh via GetTask.
+	eng.broadcast(response, persisted.snapshot)
 	if final {
-		eng.stopReason = engineStopTerminal
-		m.cleanSubscribers(eng.ec.Tenant, eng.ec.TaskID)
-		// Nothing can follow a terminal frame: end the response stream here
-		// instead of trusting the MessageProcessor to close its channel promptly.
-		eng.closePipe()
+		eng.completeStatusTerminal()
+	}
+}
+
+// persistStatusUpdate writes the status under taskMu. ok is false when the task
+// is already terminal (immutable); the caller aborts any yield and stops.
+func (eng *engine) persistStatusUpdate(
+	event *protocol.TaskStatusUpdateEvent,
+	yielding bool,
+) (statusPersistResult, bool) {
+	m := eng.manager
+	m.taskMu.Lock()
+	defer m.taskMu.Unlock()
+
+	taskKey := newScopedID(eng.ec.Tenant, eng.ec.TaskID)
+	task, exists := m.tasks[taskKey]
+	if exists && isFinalState(task.Status.State) {
+		return statusPersistResult{alreadyTerminal: task.Status.State}, false
+	}
+
+	var result statusPersistResult
+	if !eng.taskWritten {
+		if exists {
+			result.initial = copyTask(task)
+		} else {
+			result.initial = protocol.NewTask(eng.ec.TaskID, eng.ec.ContextID)
+		}
+	}
+
+	if !exists {
+		task = eng.newTask(event.Status)
+		m.tasks[taskKey] = task
+	} else {
+		result.previousStatusMessage = task.Status.Message
+		task.Status = event.Status
+	}
+
+	eng.taskWritten = true
+	result.snapshot = eng.immediateSnapshotLocked(task)
+	if yielding {
+		// Keep a private copy as the unary result: the shared entry may belong
+		// to a continuation before finish() runs.
+		result.yieldOutcome.task = copyTask(task)
+	}
+
+	return result, true
+}
+
+// completeStatusYield publishes a suspend frame and frees the execution slot.
+// Push is queued before local observers see the state so a client can never
+// observe a suspend it cannot yet continue; the handoff also serializes
+// subscriber fan-out with a continuation round.
+func (eng *engine) completeStatusYield(
+	response protocol.StreamResponse,
+	snapshot *protocol.Task,
+	outcome sendOutcome,
+) {
+	eng.finalOutcome = outcome
+	eng.stopReason = engineStopYield
+	m := eng.manager
+	m.dispatchPush(eng.ec.Tenant, eng.ec.TaskID, response)
+	eng.broadcastWithoutPush(response, snapshot)
+	eng.closePipe()
+	m.runs.deregister(eng.ec.Tenant, eng.ec.TaskID, eng.exec)
+}
+
+// completeStatusTerminal ends the round after a terminal status frame.
+func (eng *engine) completeStatusTerminal() {
+	eng.stopReason = engineStopTerminal
+	eng.manager.cleanSubscribers(eng.ec.Tenant, eng.ec.TaskID)
+	// Nothing can follow a terminal frame: end the response stream here
+	// instead of trusting the MessageProcessor to close its channel promptly.
+	eng.closePipe()
+}
+
+// abortYieldIf rolls back a suspend handoff when the status commit path fails.
+func (eng *engine) abortYieldIf(yielding bool) {
+	if yielding {
+		eng.manager.runs.abortYield(eng.ec.Tenant, eng.ec.TaskID, eng.exec)
 	}
 }
 
@@ -1024,7 +919,7 @@ func (eng *engine) finish() {
 		eng.pipe.Close()
 	}
 	eng.exec.cancel() // release the detached ctx resources
-	m.deregisterExecution(eng.ec.Tenant, eng.ec.TaskID, eng.exec)
+	m.runs.deregister(eng.ec.Tenant, eng.ec.TaskID, eng.exec)
 	close(eng.done)
 }
 

--- a/taskmanager/memory/memory_engine.go
+++ b/taskmanager/memory/memory_engine.go
@@ -74,6 +74,7 @@ const (
 	engineStopTerminal
 	engineStopViolation
 	engineStopYield
+	engineStopMessage
 )
 
 func (reason engineStopReason) description() string {
@@ -84,6 +85,8 @@ func (reason engineStopReason) description() string {
 		return "a contract violation"
 	case engineStopYield:
 		return "the round yielded (suspended task)"
+	case engineStopMessage:
+		return "a direct Message response"
 	default:
 		return "an unknown stop reason"
 	}
@@ -99,6 +102,9 @@ type engine struct {
 	exec    *execution
 	// pipe is the message/stream response channel; nil for unary requests.
 	pipe *taskSubscriber
+	// historyLength shapes only the operation-local Task framing sent on pipe.
+	// It is a private copy so callers may safely reuse or mutate their request.
+	historyLength *int
 
 	// Drain lifecycle. Only run() and its callees access these fields.
 	stopReason engineStopReason
@@ -388,6 +394,10 @@ func (m *TaskManager) startExecution(
 		immediateResult:   make(chan sendOutcome, 1),
 		done:              make(chan struct{}),
 	}
+	if requested := historyLengthFromConfig(request.Configuration); requested != nil {
+		value := *requested
+		eng.historyLength = &value
+	}
 	go func() {
 		defer m.runs.engineDone()
 		eng.run(events)
@@ -494,6 +504,13 @@ func (eng *engine) handleMessage(message *protocol.Message) {
 	if exists {
 		m.notifySubscribers(eng.ec.Tenant, eng.ec.TaskID, response)
 	}
+	// The first valid event selects the response shape. Once a round returns a
+	// direct Message, the wire response is complete; keep draining the processor
+	// channel, but never let later events switch the round into Task mode.
+	if !eng.taskWritten {
+		eng.stopReason = engineStopMessage
+		eng.closePipe()
+	}
 }
 
 // storeStatusMessage stores a stamped copy without mutating the processor's
@@ -573,9 +590,7 @@ func (eng *engine) handleStatus(event *protocol.TaskStatusUpdateEvent) {
 		eng.stopReason = engineStopTerminal
 		return
 	}
-	if persisted.initial != nil {
-		eng.sendToPipe(protocol.NewStreamResponseTask(persisted.initial))
-	}
+	eng.sendInitialTask(persisted.initial)
 	if err := eng.persistInlinePushConfig(); err != nil {
 		eng.abortYieldIf(yielding)
 		eng.violate(err.Error())
@@ -724,9 +739,7 @@ func (eng *engine) handleArtifact(event *protocol.TaskArtifactUpdateEvent) {
 	eng.taskWritten = true
 	snapshot := eng.immediateSnapshotLocked(task)
 	m.taskMu.Unlock()
-	if initial != nil {
-		eng.sendToPipe(protocol.NewStreamResponseTask(initial))
-	}
+	eng.sendInitialTask(initial)
 	if err := eng.persistInlinePushConfig(); err != nil {
 		eng.violate(err.Error())
 		return
@@ -808,6 +821,17 @@ func (eng *engine) sendToPipe(response protocol.StreamResponse) {
 	}
 }
 
+// sendInitialTask shapes and sends the operation-local pre-update Task frame.
+// The snapshot is private to this response, so filling History does not mutate
+// the stored Task or create another task event.
+func (eng *engine) sendInitialTask(task *protocol.Task) {
+	if task == nil || eng.pipe == nil {
+		return
+	}
+	eng.manager.fillTaskHistory(eng.ec.Tenant, task, eng.historyLength)
+	eng.sendToPipe(protocol.NewStreamResponseTask(task))
+}
+
 // closePipe ends the message/stream response stream, if any. Subscriber close
 // is CAS-guarded, so calling it from more than one place is safe.
 func (eng *engine) closePipe() {
@@ -843,9 +867,7 @@ func (eng *engine) violate(reason string) {
 	snapshot := eng.immediateSnapshotLocked(task)
 	m.taskMu.Unlock()
 
-	if initial != nil {
-		eng.sendToPipe(protocol.NewStreamResponseTask(initial))
-	}
+	eng.sendInitialTask(initial)
 	eng.broadcast(protocol.NewStreamResponseStatusUpdate(event), snapshot)
 	m.cleanSubscribers(eng.ec.Tenant, eng.ec.TaskID)
 	eng.closePipe()
@@ -910,9 +932,7 @@ func (eng *engine) finish() {
 	}
 	m.taskMu.Unlock()
 
-	if initial != nil {
-		eng.sendToPipe(protocol.NewStreamResponseTask(initial))
-	}
+	eng.sendInitialTask(initial)
 	if closing != nil {
 		response := protocol.NewStreamResponseStatusUpdate(closing)
 		eng.sendToPipe(response)

--- a/taskmanager/memory/memory_engine.go
+++ b/taskmanager/memory/memory_engine.go
@@ -344,7 +344,10 @@ func (m *TaskManager) startExecution(
 	if withPipe {
 		exec.pipe = newTaskSubscriber(
 			taskID,
-			m.options.TaskSubscriberBufSize,
+			// The operation-local initial Task is framing, not a processor event.
+			// Reserve one extra slot so it cannot consume the configured capacity
+			// that was previously available to the first real update.
+			m.options.TaskSubscriberBufSize+1,
 			m.options.TaskSubscriberBlockingSend,
 		)
 	}
@@ -710,6 +713,14 @@ func (eng *engine) handleStatus(event *protocol.TaskStatusUpdateEvent) {
 		eng.stopReason = engineStopTerminal
 		return
 	}
+	var initial *protocol.Task
+	if !eng.taskWritten {
+		if exists {
+			initial = copyTask(task)
+		} else {
+			initial = protocol.NewTask(eng.ec.TaskID, eng.ec.ContextID)
+		}
+	}
 	var previousStatusMessage *protocol.Message
 	if !exists {
 		task = eng.newTask(event.Status)
@@ -728,6 +739,9 @@ func (eng *engine) handleStatus(event *protocol.TaskStatusUpdateEvent) {
 		yieldOutcome.task = copyTask(task)
 	}
 	m.taskMu.Unlock()
+	if initial != nil {
+		eng.sendToPipe(protocol.NewStreamResponseTask(initial))
+	}
 	if err := eng.persistInlinePushConfig(); err != nil {
 		if yielding {
 			m.abortExecutionYield(eng.ec.Tenant, eng.ec.TaskID, eng.exec)
@@ -786,6 +800,14 @@ func (eng *engine) handleArtifact(event *protocol.TaskArtifactUpdateEvent) {
 		eng.stopReason = engineStopTerminal
 		return
 	}
+	var initial *protocol.Task
+	if !eng.taskWritten {
+		if exists {
+			initial = copyTask(task)
+		} else {
+			initial = protocol.NewTask(eng.ec.TaskID, eng.ec.ContextID)
+		}
+	}
 	if !exists {
 		task = eng.newTask(protocol.TaskStatus{
 			State:     protocol.TaskStateSubmitted,
@@ -802,6 +824,9 @@ func (eng *engine) handleArtifact(event *protocol.TaskArtifactUpdateEvent) {
 	eng.taskWritten = true
 	snapshot := eng.immediateSnapshotLocked(task)
 	m.taskMu.Unlock()
+	if initial != nil {
+		eng.sendToPipe(protocol.NewStreamResponseTask(initial))
+	}
 	if err := eng.persistInlinePushConfig(); err != nil {
 		eng.violate(err.Error())
 		return
@@ -906,6 +931,10 @@ func (eng *engine) violate(reason string) {
 		m.taskMu.Unlock()
 		return
 	}
+	var initial *protocol.Task
+	if !eng.taskWritten {
+		initial = copyTask(task)
+	}
 	task.Status = event.Status
 	eng.taskWritten = true
 	// The framework-written FAILED is a task event (§3.1): offer it as the
@@ -914,6 +943,9 @@ func (eng *engine) violate(reason string) {
 	snapshot := eng.immediateSnapshotLocked(task)
 	m.taskMu.Unlock()
 
+	if initial != nil {
+		eng.sendToPipe(protocol.NewStreamResponseTask(initial))
+	}
 	eng.broadcast(protocol.NewStreamResponseStatusUpdate(event), snapshot)
 	m.cleanSubscribers(eng.ec.Tenant, eng.ec.TaskID)
 	eng.closePipe()
@@ -936,6 +968,7 @@ func (eng *engine) finish() {
 	}
 
 	var closing *protocol.TaskStatusUpdateEvent
+	var initial *protocol.Task
 
 	m.taskMu.Lock()
 	task, exists := m.tasks[newScopedID(eng.ec.Tenant, eng.ec.TaskID)]
@@ -947,6 +980,9 @@ func (eng *engine) finish() {
 			// emitted completed/failed after the cancel, that persist already
 			// happened in handleStatus and wins (§3.3) — this branch is then
 			// never reached because the task is terminal.
+			if !eng.taskWritten {
+				initial = copyTask(task)
+			}
 			closing = eng.statusEvent(protocol.TaskStateCanceled, nil)
 			task.Status = closing.Status
 		case !eng.taskWritten:
@@ -974,6 +1010,9 @@ func (eng *engine) finish() {
 	}
 	m.taskMu.Unlock()
 
+	if initial != nil {
+		eng.sendToPipe(protocol.NewStreamResponseTask(initial))
+	}
 	if closing != nil {
 		response := protocol.NewStreamResponseStatusUpdate(closing)
 		eng.sendToPipe(response)

--- a/taskmanager/memory/memory_engine.go
+++ b/taskmanager/memory/memory_engine.go
@@ -659,6 +659,11 @@ func (eng *engine) completeStatusYield(
 	m.dispatchPush(eng.ec.Tenant, eng.ec.TaskID, response)
 	eng.broadcastWithoutPush(response, snapshot)
 	eng.closePipe()
+	// This round no longer owns the task after publishing its suspend frame.
+	// Cancel its processor context before removing it from the registry: Close
+	// cannot discover a yielded execution once the slot is released, but still
+	// waits for its drain engine to finish.
+	eng.exec.cancel()
 	m.runs.deregister(eng.ec.Tenant, eng.ec.TaskID, eng.exec)
 }
 

--- a/taskmanager/memory/memory_engine_test.go
+++ b/taskmanager/memory/memory_engine_test.go
@@ -613,17 +613,18 @@ func TestEngine_ForeignMessageEventFailsTask(t *testing.T) {
 	}
 }
 
-// §3.1: a continuation round that only emits Messages answers with the last
-// Message; the suspended task stays untouched.
-func TestEngine_ContinuationMessageOnlyReturnsMessage(t *testing.T) {
+// A continuation whose first event is a direct Message answers with that
+// Message and discards later task events; the suspended task stays untouched.
+func TestEngine_ContinuationDirectMessageDiscardsLaterTaskEvent(t *testing.T) {
 	var round atomic.Int32
 	processor := funcExecutor(
 		func(ctx context.Context, ec *taskmanager.ExecContext) (<-chan protocol.StreamEvent, error) {
-			out := make(chan protocol.StreamEvent, 1)
+			out := make(chan protocol.StreamEvent, 2)
 			if round.Add(1) == 1 {
 				out <- statusUpdate(protocol.TaskStateInputRequired, agentReply("need more input"))
 			} else {
 				out <- agentReply("just a clarification")
+				out <- statusUpdate(protocol.TaskStateCompleted, nil)
 			}
 			close(out)
 			return out, nil
@@ -678,7 +679,10 @@ func TestOnSendMessageStream_OrderAndPersistBeforeBroadcast(t *testing.T) {
 		})
 	manager := newTestManager(t, processor)
 
-	ch, err := manager.OnSendMessageStream(context.Background(), userParams("stream"))
+	one := 1
+	params := userParams("stream")
+	params.Configuration = &protocol.SendMessageConfiguration{HistoryLength: &one}
+	ch, err := manager.OnSendMessageStream(context.Background(), params)
 	if err != nil {
 		t.Fatalf("OnSendMessageStream failed: %v", err)
 	}
@@ -690,6 +694,15 @@ func TestOnSendMessageStream_OrderAndPersistBeforeBroadcast(t *testing.T) {
 	}
 	if initial.ID == "" || initial.ContextID == "" {
 		t.Errorf("Expected stamped IDs, got taskID=%q contextID=%q", initial.ID, initial.ContextID)
+	}
+	manager.taskMu.RLock()
+	storedHistory := len(manager.tasks[newScopedID("", initial.ID)].History)
+	manager.taskMu.RUnlock()
+	if storedHistory != 0 {
+		t.Fatalf("Initial Task history must not be written into storage, got %d entries", storedHistory)
+	}
+	if len(initial.History) != 1 || textOfMessage(initial.History[0]) != "stream" {
+		t.Fatalf("Expected historyLength=1 on the initial Task, got %+v", initial.History)
 	}
 	// The initial snapshot is operation-local, but the triggering update is
 	// persisted before either response frame is published.
@@ -976,6 +989,31 @@ func TestOnSendMessageStream_PureMessage(t *testing.T) {
 	manager.taskMu.RUnlock()
 	if taskCount != 0 {
 		t.Errorf("Expected no task after a pure-message stream, got %d", taskCount)
+	}
+}
+
+// The first valid event fixes the response shape. Once a direct Message has
+// been sent, later task events are drained rather than switching wire modes.
+func TestOnSendMessageStream_DirectMessageDoesNotSwitchToTask(t *testing.T) {
+	manager := newTestManager(t, eventsExecutor(
+		agentReply("direct"),
+		agentReply("ignored"),
+		statusUpdate(protocol.TaskStateCompleted, nil),
+	))
+
+	ch, err := manager.OnSendMessageStream(context.Background(), userParams("hello"))
+	if err != nil {
+		t.Fatalf("OnSendMessageStream failed: %v", err)
+	}
+	events := collectStream(t, ch)
+	if len(events) != 1 || events[0].GetMessage() == nil || textOfMessage(*events[0].GetMessage()) != "direct" {
+		t.Fatalf("Expected exactly the first direct Message, got %+v", events)
+	}
+	manager.taskMu.RLock()
+	taskCount := len(manager.tasks)
+	manager.taskMu.RUnlock()
+	if taskCount != 0 {
+		t.Fatalf("A task event after a direct Message must be discarded, got %d tasks", taskCount)
 	}
 }
 
@@ -1342,6 +1380,8 @@ func TestEngine_StatusMessageDedupByID(t *testing.T) {
 			h := taskmanager.NewTaskHandle(ctx, ec)
 			go func() {
 				defer h.Close()
+				// Select task mode before emitting the task-attached reply.
+				h.UpdateTaskState(protocol.TaskStateWorking, nil)
 				h.Reply(&reply)
 				h.UpdateTaskState(protocol.TaskStateWorking, &status)
 				// Supersedes status, causing the same-MessageID copy above to roll.

--- a/taskmanager/memory/memory_engine_test.go
+++ b/taskmanager/memory/memory_engine_test.go
@@ -686,43 +686,278 @@ func TestOnSendMessageStream_OrderAndPersistBeforeBroadcast(t *testing.T) {
 	}
 
 	first := recvEvent(t, ch)
-	working := first.GetStatusUpdate()
+	initial := first.GetTask()
+	if initial == nil || initial.Status.State != protocol.TaskStateSubmitted {
+		t.Fatalf("Expected the initial SUBMITTED Task first, got %+v", first)
+	}
+	if initial.ID == "" || initial.ContextID == "" {
+		t.Errorf("Expected stamped IDs, got taskID=%q contextID=%q", initial.ID, initial.ContextID)
+	}
+	// The initial snapshot is operation-local, but the triggering update is
+	// persisted before either response frame is published.
+	if state, ok := storedTaskState(manager, initial.ID); !ok || state != protocol.TaskStateWorking {
+		t.Errorf("Expected the store at WORKING when the initial Task is received, got exists=%v state=%s", ok, state)
+	}
+
+	second := recvEvent(t, ch)
+	working := second.GetStatusUpdate()
 	if working == nil || working.Status.State != protocol.TaskStateWorking {
-		t.Fatalf("Expected the WORKING status first, got %+v", first)
-	}
-	if working.TaskID == "" || working.ContextID == "" {
-		t.Errorf("Expected stamped IDs, got taskID=%q contextID=%q", working.TaskID, working.ContextID)
-	}
-	// The producer is gated, so the store must reflect exactly this event:
-	// persisted before broadcast.
-	if state, ok := storedTaskState(manager, working.TaskID); !ok || state != protocol.TaskStateWorking {
-		t.Errorf("Expected the store at WORKING when the event is received, got exists=%v state=%s", ok, state)
+		t.Fatalf("Expected the WORKING status second, got %+v", second)
 	}
 	close(gate)
 
-	second := recvEvent(t, ch)
-	artifact := second.GetArtifactUpdate()
+	third := recvEvent(t, ch)
+	artifact := third.GetArtifactUpdate()
 	if artifact == nil || artifact.Artifact.ArtifactID != "art-1" {
-		t.Fatalf("Expected the artifact event second, got %+v", second)
+		t.Fatalf("Expected the artifact event third, got %+v", third)
 	}
 	manager.taskMu.RLock()
-	artifactCount := len(manager.tasks[newScopedID("", working.TaskID)].Artifacts)
+	artifactCount := len(manager.tasks[newScopedID("", initial.ID)].Artifacts)
 	manager.taskMu.RUnlock()
 	if artifactCount != 1 {
 		t.Errorf("Expected 1 persisted artifact when the event is received, got %d", artifactCount)
 	}
 
-	third := recvEvent(t, ch)
-	completed := third.GetStatusUpdate()
+	fourth := recvEvent(t, ch)
+	completed := fourth.GetStatusUpdate()
 	if completed == nil || completed.Status.State != protocol.TaskStateCompleted {
-		t.Fatalf("Expected the COMPLETED status third, got %+v", third)
+		t.Fatalf("Expected the COMPLETED status fourth, got %+v", fourth)
 	}
-	if state, _ := storedTaskState(manager, working.TaskID); state != protocol.TaskStateCompleted {
+	if state, _ := storedTaskState(manager, initial.ID); state != protocol.TaskStateCompleted {
 		t.Errorf("Expected the store at COMPLETED when the event is received, got %s", state)
 	}
 
 	if rest := collectStream(t, ch); len(rest) != 0 {
 		t.Errorf("Expected the stream to close after the terminal event, got %d more events", len(rest))
+	}
+}
+
+// An artifact can be the first task event, but the response stream still starts
+// with the operation-local SUBMITTED Task that existed before the artifact was
+// applied.
+func TestOnSendMessageStream_ArtifactFirstStartsWithTask(t *testing.T) {
+	manager := newTestManager(t, eventsExecutor(
+		artifactEvent("art-1", "chunk one"),
+		statusUpdate(protocol.TaskStateCompleted, nil),
+	))
+
+	ch, err := manager.OnSendMessageStream(context.Background(), userParams("stream artifact"))
+	if err != nil {
+		t.Fatalf("OnSendMessageStream failed: %v", err)
+	}
+
+	first := recvEvent(t, ch)
+	initial := first.GetTask()
+	if initial == nil || initial.Status.State != protocol.TaskStateSubmitted {
+		t.Fatalf("Expected the initial SUBMITTED Task first, got %+v", first)
+	}
+	if len(initial.Artifacts) != 0 {
+		t.Fatalf("Initial Task must be the pre-update snapshot, got artifacts %+v", initial.Artifacts)
+	}
+	if _, ok := storedTaskState(manager, initial.ID); !ok {
+		t.Fatal("Expected the artifact-created task persisted before delivery")
+	}
+	manager.taskMu.RLock()
+	artifactCount := len(manager.tasks[newScopedID("", initial.ID)].Artifacts)
+	manager.taskMu.RUnlock()
+	if artifactCount != 1 {
+		t.Fatalf("Expected the artifact persisted before the initial Task frame, got %d", artifactCount)
+	}
+
+	second := recvEvent(t, ch)
+	if artifact := second.GetArtifactUpdate(); artifact == nil || artifact.Artifact.ArtifactID != "art-1" {
+		t.Fatalf("Expected the artifact update second, got %+v", second)
+	}
+	third := recvEvent(t, ch)
+	if completed := third.GetStatusUpdate(); completed == nil || completed.Status.State != protocol.TaskStateCompleted {
+		t.Fatalf("Expected COMPLETED third, got %+v", third)
+	}
+	if rest := collectStream(t, ch); len(rest) != 0 {
+		t.Fatalf("Expected the stream to close after COMPLETED, got %d more events", len(rest))
+	}
+}
+
+// The configured subscriber capacity predates the operation-local initial
+// Task. Even with a one-slot, non-blocking configuration, that framing Task
+// must not displace the processor's first real status update.
+func TestOnSendMessageStream_BufferOneKeepsFirstStatusUpdate(t *testing.T) {
+	manager := newTestManager(t,
+		eventsExecutor(statusUpdate(protocol.TaskStateCompleted, nil)),
+		WithTaskSubscriberBufferSize(1),
+	)
+
+	ch, err := manager.OnSendMessageStream(context.Background(), userParams("complete"))
+	if err != nil {
+		t.Fatalf("OnSendMessageStream failed: %v", err)
+	}
+	// Do not consume until the engine has finished. This deterministically fills
+	// the request pipe before the real update is sent.
+	eventually(t, func() bool { return liveExecutionCount(manager) == 0 }, "execution did not finish")
+	events := collectStream(t, ch)
+	if len(events) != 2 {
+		t.Fatalf("Expected initial Task and terminal update, got %+v", events)
+	}
+	if task := events[0].GetTask(); task == nil || task.Status.State != protocol.TaskStateSubmitted {
+		t.Fatalf("Expected the initial SUBMITTED Task first, got %+v", events[0])
+	}
+	if update := events[1].GetStatusUpdate(); update == nil || update.Status.State != protocol.TaskStateCompleted {
+		t.Fatalf("Expected COMPLETED second, got %+v", events[1])
+	}
+}
+
+// The extra framing slot applies equally when an artifact is the first task
+// event. The later close-rule update may still be dropped under the caller's
+// original one-event capacity; the framing Task must only preserve that capacity.
+func TestOnSendMessageStream_BufferOneKeepsFirstArtifactUpdate(t *testing.T) {
+	manager := newTestManager(t,
+		eventsExecutor(artifactEvent("art-1", "chunk")),
+		WithTaskSubscriberBufferSize(1),
+	)
+
+	ch, err := manager.OnSendMessageStream(context.Background(), userParams("artifact"))
+	if err != nil {
+		t.Fatalf("OnSendMessageStream failed: %v", err)
+	}
+	eventually(t, func() bool { return liveExecutionCount(manager) == 0 }, "execution did not finish")
+	events := collectStream(t, ch)
+	if len(events) != 2 {
+		t.Fatalf("Expected initial Task and artifact update, got %+v", events)
+	}
+	if task := events[0].GetTask(); task == nil || task.Status.State != protocol.TaskStateSubmitted {
+		t.Fatalf("Expected the initial SUBMITTED Task first, got %+v", events[0])
+	}
+	if update := events[1].GetArtifactUpdate(); update == nil || update.Artifact.ArtifactID != "art-1" {
+		t.Fatalf("Expected artifact update second, got %+v", events[1])
+	}
+}
+
+// A continuation starts from the task state persisted by the previous round,
+// not from a snapshot that already contains this round's first update.
+func TestOnSendMessageStream_ContinuationStatusStartsWithPreviousTask(t *testing.T) {
+	var round atomic.Int32
+	manager := newTestManager(t, funcExecutor(
+		func(ctx context.Context, ec *taskmanager.ExecContext) (<-chan protocol.StreamEvent, error) {
+			if round.Add(1) == 1 {
+				return eventsExecutor(statusUpdate(protocol.TaskStateInputRequired, nil))(ctx, ec)
+			}
+			return eventsExecutor(statusUpdate(protocol.TaskStateCompleted, nil))(ctx, ec)
+		}))
+
+	first, err := manager.OnSendMessage(context.Background(), userParams("start"))
+	if err != nil {
+		t.Fatalf("First OnSendMessage failed: %v", err)
+	}
+	taskID := first.GetTask().ID
+	followUp := userParams("continue")
+	followUp.Message.TaskID = &taskID
+	ch, err := manager.OnSendMessageStream(context.Background(), followUp)
+	if err != nil {
+		t.Fatalf("Continuation failed: %v", err)
+	}
+
+	initialFrame := recvEvent(t, ch)
+	initial := initialFrame.GetTask()
+	if initial == nil || initial.ID != taskID || initial.Status.State != protocol.TaskStateInputRequired {
+		t.Fatalf("Expected the previous INPUT_REQUIRED Task first, got %+v", initial)
+	}
+	completedFrame := recvEvent(t, ch)
+	completed := completedFrame.GetStatusUpdate()
+	if completed == nil || completed.Status.State != protocol.TaskStateCompleted {
+		t.Fatalf("Expected COMPLETED after the initial Task, got %+v", completed)
+	}
+	if rest := collectStream(t, ch); len(rest) != 0 {
+		t.Fatalf("Expected the stream to close after COMPLETED, got %d more events", len(rest))
+	}
+}
+
+// A framework-generated failure can be the continuation's first task event.
+// The request stream must expose the pre-failure Task before FAILED.
+func TestOnSendMessageStream_ContinuationViolationStartsWithTask(t *testing.T) {
+	var round atomic.Int32
+	manager := newTestManager(t, funcExecutor(
+		func(ctx context.Context, ec *taskmanager.ExecContext) (<-chan protocol.StreamEvent, error) {
+			if round.Add(1) == 1 {
+				return eventsExecutor(statusUpdate(protocol.TaskStateInputRequired, nil))(ctx, ec)
+			}
+			return eventsExecutor(&protocol.Task{ID: "forbidden"})(ctx, ec)
+		}))
+
+	first, err := manager.OnSendMessage(context.Background(), userParams("start"))
+	if err != nil {
+		t.Fatalf("First OnSendMessage failed: %v", err)
+	}
+	taskID := first.GetTask().ID
+	followUp := userParams("continue")
+	followUp.Message.TaskID = &taskID
+	ch, err := manager.OnSendMessageStream(context.Background(), followUp)
+	if err != nil {
+		t.Fatalf("Continuation failed: %v", err)
+	}
+
+	initialFrame := recvEvent(t, ch)
+	initial := initialFrame.GetTask()
+	if initial == nil || initial.ID != taskID || initial.Status.State != protocol.TaskStateInputRequired {
+		t.Fatalf("Expected the pre-violation INPUT_REQUIRED Task, got %+v", initial)
+	}
+	failedFrame := recvEvent(t, ch)
+	failed := failedFrame.GetStatusUpdate()
+	if failed == nil || failed.Status.State != protocol.TaskStateFailed {
+		t.Fatalf("Expected FAILED after the initial Task, got %+v", failed)
+	}
+	if rest := collectStream(t, ch); len(rest) != 0 {
+		t.Fatalf("Expected the stream to close after FAILED, got %d more events", len(rest))
+	}
+}
+
+// Cancellation can close a continuation before its processor emits any event.
+// finish must publish the pre-cancel Task before its synthetic CANCELED update.
+func TestOnSendMessageStream_ContinuationCancelBeforeEventStartsWithTask(t *testing.T) {
+	var round atomic.Int32
+	started := make(chan string, 1)
+	manager := newTestManager(t, funcExecutor(
+		func(ctx context.Context, ec *taskmanager.ExecContext) (<-chan protocol.StreamEvent, error) {
+			if round.Add(1) == 1 {
+				return eventsExecutor(statusUpdate(protocol.TaskStateInputRequired, nil))(ctx, ec)
+			}
+			out := make(chan protocol.StreamEvent)
+			started <- ec.TaskID
+			go func() {
+				<-ctx.Done()
+				close(out)
+			}()
+			return out, nil
+		}))
+
+	first, err := manager.OnSendMessage(context.Background(), userParams("start"))
+	if err != nil {
+		t.Fatalf("First OnSendMessage failed: %v", err)
+	}
+	taskID := first.GetTask().ID
+	followUp := userParams("continue")
+	followUp.Message.TaskID = &taskID
+	ch, err := manager.OnSendMessageStream(context.Background(), followUp)
+	if err != nil {
+		t.Fatalf("Continuation failed: %v", err)
+	}
+	if got := <-started; got != taskID {
+		t.Fatalf("Continuation started for task %s, want %s", got, taskID)
+	}
+	if _, err := manager.OnCancelTask(context.Background(), protocol.TaskIDParams{ID: taskID}); err != nil {
+		t.Fatalf("OnCancelTask failed: %v", err)
+	}
+
+	initialFrame := recvEvent(t, ch)
+	initial := initialFrame.GetTask()
+	if initial == nil || initial.ID != taskID || initial.Status.State != protocol.TaskStateInputRequired {
+		t.Fatalf("Expected the pre-cancel INPUT_REQUIRED Task, got %+v", initial)
+	}
+	canceledFrame := recvEvent(t, ch)
+	canceled := canceledFrame.GetStatusUpdate()
+	if canceled == nil || canceled.Status.State != protocol.TaskStateCanceled {
+		t.Fatalf("Expected CANCELED after the initial Task, got %+v", canceled)
+	}
+	if rest := collectStream(t, ch); len(rest) != 0 {
+		t.Fatalf("Expected the stream to close after CANCELED, got %d more events", len(rest))
 	}
 }
 
@@ -1339,7 +1574,11 @@ func TestOnSendMessage_ConcurrentContinuationRejected(t *testing.T) {
 		t.Fatalf("OnSendMessageStream failed: %v", err)
 	}
 	first := recvEvent(t, pipe)
-	taskID := first.GetStatusUpdate().TaskID
+	initial := first.GetTask()
+	if initial == nil {
+		t.Fatalf("Expected the initial Task first, got %+v", first)
+	}
+	taskID := initial.ID
 
 	followUp := userParams("again")
 	followUp.Message.TaskID = &taskID
@@ -1385,7 +1624,11 @@ func TestOnCancelTask_LiveButTerminalNotCancelable(t *testing.T) {
 		t.Fatalf("OnSendMessageStream failed: %v", err)
 	}
 	first := recvEvent(t, pipe)
-	taskID := first.GetStatusUpdate().TaskID
+	initial := first.GetTask()
+	if initial == nil {
+		t.Fatalf("Expected the initial Task first, got %+v", first)
+	}
+	taskID := initial.ID
 	waitTaskState(t, manager, taskID, protocol.TaskStateCompleted)
 
 	_, err = manager.OnCancelTask(context.Background(), protocol.TaskIDParams{ID: taskID})
@@ -1554,7 +1797,11 @@ func TestOnSendMessageStream_DisconnectKeepsRunning(t *testing.T) {
 		t.Fatalf("OnSendMessageStream failed: %v", err)
 	}
 	first := recvEvent(t, pipe)
-	taskID := first.GetStatusUpdate().TaskID
+	initial := first.GetTask()
+	if initial == nil {
+		t.Fatalf("Expected the initial Task first, got %+v", first)
+	}
+	taskID := initial.ID
 	cancel() // client disconnects; the pipe is abandoned from here on
 	close(disconnected)
 

--- a/taskmanager/memory/memory_engine_test.go
+++ b/taskmanager/memory/memory_engine_test.go
@@ -194,9 +194,7 @@ func seedTask(m *TaskManager, task protocol.Task) {
 
 // liveExecutionCount reports how many executions are still registered.
 func liveExecutionCount(m *TaskManager) int {
-	m.execMu.Lock()
-	defer m.execMu.Unlock()
-	return len(m.executions)
+	return m.runs.len()
 }
 
 // =============================================================================

--- a/taskmanager/memory/memory_options.go
+++ b/taskmanager/memory/memory_options.go
@@ -33,7 +33,8 @@ type TaskManagerOptions struct {
 	// EnableCleanup enables automatic cleanup of expired conversations and tasks.
 	EnableCleanup bool
 
-	// TaskSubscriberBufSize is the buffer size for task subscribers.
+	// TaskSubscriberBufSize is the buffer size for task update events. A
+	// SendStreamingMessage response pipe reserves one additional framing slot.
 	TaskSubscriberBufSize int
 
 	// TaskSubscriberBlockingSend enables blocking send for task subscribers.
@@ -96,7 +97,9 @@ func WithTaskTTL(ttl time.Duration) TaskManagerOption {
 	}
 }
 
-// WithTaskSubscriberBufferSize sets the buffer size for task subscriber channels.
+// WithTaskSubscriberBufferSize sets the buffer size for task update events. A
+// SendStreamingMessage response pipe reserves one additional framing slot for
+// its initial Task.
 func WithTaskSubscriberBufferSize(size int) TaskManagerOption {
 	return func(opts *TaskManagerOptions) {
 		if size > 0 {

--- a/taskmanager/memory/memory_regression_test.go
+++ b/taskmanager/memory/memory_regression_test.go
@@ -181,26 +181,26 @@ func TestClaimCancelSlot_BlocksConcurrentRegistration(t *testing.T) {
 	manager := newTestManager(t, echoExecutor())
 	const taskID = "task-claim-slot"
 
-	live, sentinel, yieldDone := manager.claimCancelSlot("", taskID)
+	live, sentinel, yieldDone := manager.runs.claimCancelSlot("", taskID)
 	if live != nil || sentinel == nil {
 		t.Fatalf("expected to claim the free slot, got live=%v sentinel=%v", live, sentinel)
 	}
 	if yieldDone != nil {
 		t.Fatal("free slot unexpectedly reported a yield handoff")
 	}
-	if err := manager.registerExecution(context.Background(), "", taskID, &execution{cancel: func() {}}); err == nil {
+	if err := manager.runs.register(context.Background(), "", taskID, &execution{cancel: func() {}}); err == nil {
 		t.Fatal("registration must be rejected while a cancel sentinel holds the slot")
 	}
-	manager.deregisterExecution("", taskID, sentinel)
+	manager.runs.deregister("", taskID, sentinel)
 
 	exec := &execution{cancel: func() {}}
-	if err := manager.registerExecution(context.Background(), "", taskID, exec); err != nil {
+	if err := manager.runs.register(context.Background(), "", taskID, exec); err != nil {
 		t.Fatalf("registration after sentinel release failed: %v", err)
 	}
-	manager.releaseExecution("", taskID, exec)
+	manager.runs.release("", taskID, exec)
 }
 
-// Cancellation and suspend handoff use execMu as their linearization point.
+// Cancellation and suspend handoff use the execution registry as their linearization point.
 // Whichever operation acquires it first must keep ownership of the execution:
 // cancel prevents yielding, while yield makes cancel wait for the handoff.
 func TestCancelYieldLinearization(t *testing.T) {
@@ -209,21 +209,21 @@ func TestCancelYieldLinearization(t *testing.T) {
 		const taskID = "task-cancel-wins-yield"
 		var cancelCalls atomic.Int32
 		exec := &execution{cancel: func() { cancelCalls.Add(1) }}
-		if err := manager.registerExecution(context.Background(), "", taskID, exec); err != nil {
+		if err := manager.runs.register(context.Background(), "", taskID, exec); err != nil {
 			t.Fatalf("register execution: %v", err)
 		}
 		var releaseOnce sync.Once
-		release := func() { releaseOnce.Do(func() { manager.releaseExecution("", taskID, exec) }) }
+		release := func() { releaseOnce.Do(func() { manager.runs.release("", taskID, exec) }) }
 		defer release()
 
-		yieldDone, accepted := manager.requestExecutionCancel("", taskID, exec)
+		yieldDone, accepted := manager.runs.requestCancel("", taskID, exec)
 		if !accepted || yieldDone != nil {
 			t.Fatalf("cancel result: accepted=%v yieldDone=%v, want accepted with no handoff", accepted, yieldDone)
 		}
 		if got := cancelCalls.Load(); got != 1 {
 			t.Fatalf("execution cancel calls = %d, want 1", got)
 		}
-		if manager.beginExecutionYield("", taskID, exec) {
+		if manager.runs.beginYield("", taskID, exec) {
 			t.Fatal("suspend handoff started after cancellation had already won")
 		}
 
@@ -235,18 +235,18 @@ func TestCancelYieldLinearization(t *testing.T) {
 		const taskID = "task-yield-wins-cancel"
 		var cancelCalls atomic.Int32
 		exec := &execution{cancel: func() { cancelCalls.Add(1) }}
-		if err := manager.registerExecution(context.Background(), "", taskID, exec); err != nil {
+		if err := manager.runs.register(context.Background(), "", taskID, exec); err != nil {
 			t.Fatalf("register execution: %v", err)
 		}
 		var releaseOnce sync.Once
-		release := func() { releaseOnce.Do(func() { manager.releaseExecution("", taskID, exec) }) }
+		release := func() { releaseOnce.Do(func() { manager.runs.release("", taskID, exec) }) }
 		defer release()
-		if !manager.beginExecutionYield("", taskID, exec) {
+		if !manager.runs.beginYield("", taskID, exec) {
 			t.Fatal("suspend handoff did not start")
 		}
 		handoff := exec.yieldDone
 
-		yieldDone, accepted := manager.requestExecutionCancel("", taskID, exec)
+		yieldDone, accepted := manager.runs.requestCancel("", taskID, exec)
 		if accepted || yieldDone != handoff {
 			t.Fatalf("cancel result: accepted=%v yieldDone=%v, want existing handoff %v",
 				accepted, yieldDone, handoff)

--- a/taskmanager/memory/memory_regression_test.go
+++ b/taskmanager/memory/memory_regression_test.go
@@ -487,13 +487,17 @@ func TestClose_CancelsYieldedDrainingEngine(t *testing.T) {
 	}
 	waitClosed(t, pipe)
 
-	closeDone := make(chan error, 1)
-	go func() { closeDone <- manager.Close() }()
+	// The suspend path itself must cancel the yielded round. Waiting before
+	// Close removes the race where Close could find the not-yet-deregistered
+	// execution and make an implementation without yield-time cancellation pass.
 	select {
 	case <-sawCancel:
 	case <-time.After(2 * time.Second):
-		t.Fatal("yielded processor did not observe context cancellation")
+		t.Fatal("suspend did not cancel the yielded processor context")
 	}
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- manager.Close() }()
 	select {
 	case err := <-closeDone:
 		if err != nil {

--- a/taskmanager/memory/memory_regression_test.go
+++ b/taskmanager/memory/memory_regression_test.go
@@ -294,12 +294,17 @@ func TestCancelBeforeSuspendClosePersistsCanceled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OnSendMessageStream: %v", err)
 	}
+	initialEvent := recvEvent(t, stream)
+	initial := initialEvent.GetTask()
+	if initial == nil || initial.Status.State != protocol.TaskStateSubmitted {
+		t.Fatalf("first stream event = %+v, want initial SUBMITTED Task", initialEvent)
+	}
 	workingEvent := recvEvent(t, stream)
 	working := workingEvent.GetStatusUpdate()
 	if working == nil || working.Status.State != protocol.TaskStateWorking {
-		t.Fatalf("first stream event = %+v, want WORKING", working)
+		t.Fatalf("second stream event = %+v, want WORKING", workingEvent)
 	}
-	taskID := working.TaskID
+	taskID := initial.ID
 
 	cancelSnapshot, err := manager.OnCancelTask(context.Background(), protocol.TaskIDParams{ID: taskID})
 	if err != nil {

--- a/taskmanager/memory/memory_regression_test.go
+++ b/taskmanager/memory/memory_regression_test.go
@@ -460,6 +460,117 @@ func TestClose_WaitsForDetachedEngines(t *testing.T) {
 	}
 }
 
+// A suspended round has released its registry slot, so Close cannot discover
+// and cancel it later. Publishing the suspend frame must therefore cancel the
+// processor context before deregistration, allowing its drain engine to exit.
+func TestClose_CancelsYieldedDrainingEngine(t *testing.T) {
+	sawCancel := make(chan struct{})
+	processor := funcExecutor(
+		func(ctx context.Context, ec *taskmanager.ExecContext) (<-chan protocol.StreamEvent, error) {
+			out := make(chan protocol.StreamEvent, 1)
+			go func() {
+				defer close(out)
+				out <- statusUpdate(protocol.TaskStateInputRequired, agentReply("need more"))
+				<-ctx.Done()
+				close(sawCancel)
+			}()
+			return out, nil
+		})
+	manager, err := NewTaskManager(processor)
+	if err != nil {
+		t.Fatalf("NewTaskManager failed: %v", err)
+	}
+
+	pipe, err := manager.OnSendMessageStream(context.Background(), userParams("go"))
+	if err != nil {
+		t.Fatalf("OnSendMessageStream failed: %v", err)
+	}
+	waitClosed(t, pipe)
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- manager.Close() }()
+	select {
+	case <-sawCancel:
+	case <-time.After(2 * time.Second):
+		t.Fatal("yielded processor did not observe context cancellation")
+	}
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("Close failed: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close blocked waiting for a yielded drain engine")
+	}
+}
+
+// Close marks the manager closed before sweeping subscribers. A resubscribe
+// racing with the later engine wait must be rejected rather than appended
+// after the sweep and left behind when Close returns.
+func TestClose_RejectsResubscribeDuringEngineWait(t *testing.T) {
+	sawCancel := make(chan struct{})
+	releaseProcessor := make(chan struct{})
+	processor := funcExecutor(
+		func(ctx context.Context, ec *taskmanager.ExecContext) (<-chan protocol.StreamEvent, error) {
+			out := make(chan protocol.StreamEvent, 1)
+			out <- workingEvent()
+			go func() {
+				defer close(out)
+				<-ctx.Done()
+				close(sawCancel)
+				<-releaseProcessor
+			}()
+			return out, nil
+		})
+	manager, err := NewTaskManager(processor)
+	if err != nil {
+		t.Fatalf("NewTaskManager failed: %v", err)
+	}
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseProcessor) }) }
+	defer release()
+
+	pipe, err := manager.OnSendMessageStream(context.Background(), userParams("go"))
+	if err != nil {
+		t.Fatalf("OnSendMessageStream failed: %v", err)
+	}
+	initialEvent := recvEvent(t, pipe)
+	initial := initialEvent.GetTask()
+	if initial == nil {
+		t.Fatal("stream did not begin with a Task")
+	}
+	recvEvent(t, pipe) // WORKING
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- manager.Close() }()
+	select {
+	case <-sawCancel:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close did not reach the engine wait")
+	}
+
+	resubscribe, err := manager.OnResubscribe(context.Background(), protocol.TaskIDParams{ID: initial.ID})
+	if err == nil || resubscribe != nil {
+		t.Fatalf("resubscribe during Close = (%v, %v), want rejection", resubscribe, err)
+	}
+
+	release()
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("Close failed: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close did not finish after the processor exited")
+	}
+
+	manager.taskMu.RLock()
+	defer manager.taskMu.RUnlock()
+	if len(manager.subscribers) != 0 {
+		t.Fatalf("Close left %d subscriber entries", len(manager.subscribers))
+	}
+}
+
 // A resubscribe stream is dropped (removed and closed) when its client goes
 // away, so a suspended task cannot accumulate dead subscribers forever.
 func TestResubscribe_ClientDisconnectDropsSubscriber(t *testing.T) {

--- a/taskmanager/memory/push_dispatch_test.go
+++ b/taskmanager/memory/push_dispatch_test.go
@@ -648,6 +648,11 @@ func TestSuspendWaitsForPushCapacityBeforeHandoff(t *testing.T) { //nolint:gocyc
 	if !yielding {
 		t.Fatal("input-required became visible before the suspend handoff barrier")
 	}
+	initialEvent := recvEvent(t, stream)
+	initial := initialEvent.GetTask()
+	if initial == nil || initial.ID != taskID || initial.Status.State != protocol.TaskStateSubmitted {
+		t.Fatalf("request stream first event = %+v, want initial SUBMITTED Task", initialEvent)
+	}
 
 	type continuationResult struct {
 		response *protocol.SendMessageResponse
@@ -671,7 +676,7 @@ func TestSuspendWaitsForPushCapacityBeforeHandoff(t *testing.T) { //nolint:gocyc
 	}
 	select {
 	case event, ok := <-stream:
-		t.Fatalf("request stream published suspend before push enqueue completed: event=%+v open=%v",
+		t.Fatalf("request stream published update before push enqueue completed: event=%+v open=%v",
 			event, ok)
 	case <-time.After(50 * time.Millisecond):
 	}

--- a/taskmanager/memory/push_dispatch_test.go
+++ b/taskmanager/memory/push_dispatch_test.go
@@ -306,7 +306,7 @@ func TestInlinePushConfigRegistration(t *testing.T) {
 		if stored {
 			t.Fatalf("rejected continuation stored incoming message %s", followUp.Message.MessageID)
 		}
-		if live := manager.liveExecution("", suspended.ID); live != nil {
+		if live := manager.runs.live("", suspended.ID); live != nil {
 			t.Fatal("rejected continuation did not release its execution slot")
 		}
 	})
@@ -641,10 +641,8 @@ func TestSuspendWaitsForPushCapacityBeforeHandoff(t *testing.T) { //nolint:gocyc
 		state, ok := storedTaskState(manager, taskID)
 		return ok && state == protocol.TaskStateInputRequired
 	}, "task must persist input-required before publication")
-	manager.execMu.Lock()
-	exec := manager.executions[newScopedID("", taskID)]
+	exec := manager.runs.live("", taskID)
 	yielding := exec != nil && exec.yieldDone != nil
-	manager.execMu.Unlock()
 	if !yielding {
 		t.Fatal("input-required became visible before the suspend handoff barrier")
 	}

--- a/taskmanager/memory/tenant_isolation_test.go
+++ b/taskmanager/memory/tenant_isolation_test.go
@@ -102,14 +102,14 @@ func TestTaskManagerTenantDataIsolation(t *testing.T) {
 
 	liveA := &execution{cancel: func() {}}
 	liveB := &execution{cancel: func() {}}
-	if err := manager.registerExecution(ctx, "tenant-a", taskID, liveA); err != nil {
+	if err := manager.runs.register(ctx, "tenant-a", taskID, liveA); err != nil {
 		t.Fatalf("register tenant-a execution: %v", err)
 	}
-	if err := manager.registerExecution(ctx, "tenant-b", taskID, liveB); err != nil {
+	if err := manager.runs.register(ctx, "tenant-b", taskID, liveB); err != nil {
 		t.Fatalf("register tenant-b execution with the same task ID: %v", err)
 	}
-	manager.releaseExecution("tenant-a", taskID, liveA)
-	manager.releaseExecution("tenant-b", taskID, liveB)
+	manager.runs.release("tenant-a", taskID, liveA)
+	manager.runs.release("tenant-b", taskID, liveB)
 }
 
 func TestTaskManagerProcessorCannotMutateTenantScope(t *testing.T) {

--- a/taskmanager/redis/redis_cross_node_test.go
+++ b/taskmanager/redis/redis_cross_node_test.go
@@ -9,6 +9,7 @@ package redis
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"net"
 	"strings"
@@ -368,6 +369,43 @@ func TestTaskEventsUseStreamByDefault(t *testing.T) {
 	}
 	if got, err := mgr.client.XLen(context.Background(), streamKey("", task.ID)).Result(); err != nil || got != 2 {
 		t.Fatalf("default event stream length = %d, want 2: %v", got, err)
+	}
+}
+
+func TestSendStreamingInitialTaskDoesNotEnterJournal(t *testing.T) {
+	mgr, _ := setupTest(t, scriptedExecutor(
+		statusEvent(protocol.TaskStateWorking, agentReply("working")),
+		statusEvent(protocol.TaskStateCompleted, agentReply("done")),
+	))
+	stream, err := mgr.OnSendMessageStream(context.Background(), sendParams("go", "ctx-stream-journal"))
+	if err != nil {
+		t.Fatalf("OnSendMessageStream: %v", err)
+	}
+	frames := collectStream(t, stream)
+	if len(frames) != 3 || frames[0].GetTask() == nil || frames[1].GetStatusUpdate() == nil ||
+		frames[2].GetStatusUpdate() == nil {
+		t.Fatalf("stream frames = %+v, want Task then two status updates", frames)
+	}
+	taskID := frames[0].GetTask().ID
+	if got, err := mgr.client.XLen(context.Background(), streamKey("", taskID)).Result(); err != nil || got != 2 {
+		t.Fatalf("journal length = %d, want only two processor updates: %v", got, err)
+	}
+	entries, err := mgr.client.XRange(context.Background(), streamKey("", taskID), "-", "+").Result()
+	if err != nil {
+		t.Fatalf("read journal: %v", err)
+	}
+	for _, entry := range entries {
+		payload, ok := entry.Values[streamField].(string)
+		if !ok {
+			t.Fatalf("journal payload = %#v, want string", entry.Values[streamField])
+		}
+		var event protocol.StreamResponse
+		if err := json.Unmarshal([]byte(payload), &event); err != nil {
+			t.Fatalf("decode journal event: %v", err)
+		}
+		if event.GetTask() != nil {
+			t.Fatalf("synthetic initial Task was journaled: %+v", event.Result)
+		}
 	}
 }
 
@@ -1342,47 +1380,59 @@ func TestCrossNode_PersistenceFailureReturnsBeforeProcessorCloses(t *testing.T) 
 // The streaming response has no asynchronous error return, so a persistence
 // failure must at least close it immediately while the processor is drained.
 func TestCrossNode_PersistenceFailureClosesStreamBeforeProcessorCloses(t *testing.T) {
-	release := make(chan struct{})
-	processorDone := make(chan struct{})
-	var releaseOnce sync.Once
-	releaseProcessor := func() { releaseOnce.Do(func() { close(release) }) }
-	defer releaseProcessor()
-	processor := executorFunc(func(context.Context, *taskmanager.ExecContext) (<-chan protocol.StreamEvent, error) {
-		out := make(chan protocol.StreamEvent)
-		go func() {
-			defer close(processorDone)
-			defer close(out)
-			out <- statusEvent(protocol.TaskStateCompleted, agentReply("uncommitted"))
-			<-release
-		}()
-		return out, nil
-	})
-	manager, _ := setupTest(t, processor)
-	task := storedTask(t, manager, "task-stream-failure", "ctx-stream-failure", protocol.TaskStateWorking)
-	if err := manager.client.Set(context.Background(), streamKey("", task.ID), "not-a-stream", 0).Err(); err != nil {
-		t.Fatalf("seed wrong-type stream key: %v", err)
+	tests := []struct {
+		name  string
+		event protocol.StreamEvent
+	}{
+		{name: "status", event: statusEvent(protocol.TaskStateCompleted, agentReply("uncommitted"))},
+		{name: "artifact", event: artifactEvent("uncommitted", "content")},
 	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			release := make(chan struct{})
+			processorDone := make(chan struct{})
+			var releaseOnce sync.Once
+			releaseProcessor := func() { releaseOnce.Do(func() { close(release) }) }
+			defer releaseProcessor()
+			processor := executorFunc(func(context.Context, *taskmanager.ExecContext) (<-chan protocol.StreamEvent, error) {
+				out := make(chan protocol.StreamEvent)
+				go func() {
+					defer close(processorDone)
+					defer close(out)
+					out <- test.event
+					<-release
+				}()
+				return out, nil
+			})
+			manager, _ := setupTest(t, processor)
+			task := storedTask(t, manager, "task-stream-failure-"+test.name,
+				"ctx-stream-failure-"+test.name, protocol.TaskStateWorking)
+			if err := manager.client.Set(context.Background(), streamKey("", task.ID), "not-a-stream", 0).Err(); err != nil {
+				t.Fatalf("seed wrong-type stream key: %v", err)
+			}
 
-	params := sendParams("continue", task.ContextID)
-	params.Message.TaskID = &task.ID
-	stream, err := manager.OnSendMessageStream(context.Background(), params)
-	if err != nil {
-		t.Fatalf("OnSendMessageStream: %v", err)
+			params := sendParams("continue", task.ContextID)
+			params.Message.TaskID = &task.ID
+			stream, err := manager.OnSendMessageStream(context.Background(), params)
+			if err != nil {
+				t.Fatalf("OnSendMessageStream: %v", err)
+			}
+			select {
+			case frame, ok := <-stream:
+				if ok {
+					t.Fatalf("uncommitted event reached stream: %+v", frame)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("persistence failure left the response stream open")
+			}
+			select {
+			case <-processorDone:
+				t.Fatal("processor closed before the response stream")
+			default:
+			}
+			releaseProcessor()
+		})
 	}
-	select {
-	case frame, ok := <-stream:
-		if ok {
-			t.Fatalf("uncommitted event reached stream: %+v", frame)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("persistence failure left the response stream open")
-	}
-	select {
-	case <-processorDone:
-		t.Fatal("processor closed before the response stream")
-	default:
-	}
-	releaseProcessor()
 }
 
 // A superseded status message moves to history only after the new status and

--- a/taskmanager/redis/redis_engine.go
+++ b/taskmanager/redis/redis_engine.go
@@ -75,6 +75,7 @@ const (
 	engineDrainTerminal
 	engineDrainViolation
 	engineDrainYielded
+	engineDrainMessage
 )
 
 // sendOutcome is a message-or-task result candidate for message/send: the
@@ -128,6 +129,9 @@ type execution struct {
 
 	// pipe is the message/stream request pipe; nil for message/send.
 	pipe *taskSubscriber
+	// historyLength shapes only the operation-local Task framing sent on pipe.
+	// It is a private copy so callers may safely reuse or mutate their request.
+	historyLength *int
 
 	// immediateResult carries the immediate result (first persisted task
 	// snapshot or first Message) for returnImmediately=true. Buffered so the
@@ -316,6 +320,10 @@ func (m *TaskManager) prepareExecution(
 		PushConfig:          pushConfig,
 	}
 	ex.inlinePushPending = pending
+	if requested := historyLengthFromConfig(request.Configuration); requested != nil {
+		value := *requested
+		ex.historyLength = &value
+	}
 
 	processorEC := *ex.ec
 	if ex.ec.PushConfig != nil {
@@ -424,6 +432,10 @@ func (ex *execution) run(events <-chan protocol.StreamEvent) {
 				log.Warnf("RedisTaskManager: discarding %T for task %s emitted after the round yielded (suspended task)",
 					event, ex.ec.TaskID)
 				continue
+			case engineDrainMessage:
+				log.Warnf("RedisTaskManager: discarding %T for task %s emitted after a direct Message response",
+					event, ex.ec.TaskID)
+				continue
 			}
 			mode = ex.handleEvent(event)
 		case <-leaseTicker.C:
@@ -480,7 +492,17 @@ func (ex *execution) handleEvent(event protocol.StreamEvent) int {
 			ex.violate("processor emitted event for foreign task")
 			return engineDrainViolation
 		}
+		direct := !ex.taskTouched
 		ex.processMessageEvent(ev)
+		if ex.runErr != nil {
+			return engineConsuming
+		}
+		// The first valid event selects the response shape. Once a round returns
+		// a direct Message, end its wire response and only drain later events.
+		if direct {
+			ex.closePipe()
+			return engineDrainMessage
+		}
 		return engineConsuming
 	case *protocol.TaskStatusUpdateEvent:
 		if ev == nil {
@@ -747,11 +769,7 @@ func (ex *execution) processStatusEvent(ev *protocol.TaskStatusUpdateEvent) {
 		ex.failRun(fmt.Errorf("failed to store task %s status %s: %w", ev.TaskID, status.State, err))
 		return
 	}
-	if initial != nil && ex.pipe != nil {
-		if err := ex.pipe.Send(protocol.NewStreamResponseTask(initial)); err != nil {
-			log.Warnf("RedisTaskManager: failed to send initial Task for task %s: %v", ex.ec.TaskID, err)
-		}
-	}
+	ex.sendInitialTask(initial)
 	// The old status message is durably superseded only after the Task/event
 	// commit succeeds. Moving it earlier would leave failed updates reflected in
 	// conversation history while the stored Task still carried the same message.
@@ -828,11 +846,7 @@ func (ex *execution) processArtifactEvent(ev *protocol.TaskArtifactUpdateEvent) 
 		ex.failRun(fmt.Errorf("failed to store task %s artifact: %w", ev.TaskID, err))
 		return
 	}
-	if initial != nil && ex.pipe != nil {
-		if err := ex.pipe.Send(protocol.NewStreamResponseTask(initial)); err != nil {
-			log.Warnf("RedisTaskManager: failed to send initial Task for task %s: %v", ex.ec.TaskID, err)
-		}
-	}
+	ex.sendInitialTask(initial)
 	if err := ex.persistInlinePushConfig(); err != nil {
 		log.Errorf("RedisTaskManager: failed to persist inline push config for task %s: %v", ex.ec.TaskID, err)
 		ex.failTask("failed to persist inline push config")
@@ -873,6 +887,19 @@ func (ex *execution) newTask(taskID, contextID string, status protocol.TaskStatu
 func (ex *execution) closePipe() {
 	if ex.pipe != nil {
 		ex.pipe.Close()
+	}
+}
+
+// sendInitialTask shapes and sends the operation-local pre-update Task frame.
+// The snapshot is private to this response, so filling History does not mutate
+// the stored Task or create another Redis journal event.
+func (ex *execution) sendInitialTask(task *protocol.Task) {
+	if task == nil || ex.pipe == nil {
+		return
+	}
+	ex.manager.fillTaskHistory(context.Background(), ex.ec.Tenant, task, ex.historyLength)
+	if err := ex.pipe.Send(protocol.NewStreamResponseTask(task)); err != nil {
+		log.Warnf("RedisTaskManager: failed to send initial Task for task %s: %v", ex.ec.TaskID, err)
 	}
 }
 

--- a/taskmanager/redis/redis_engine.go
+++ b/taskmanager/redis/redis_engine.go
@@ -210,7 +210,11 @@ func (m *TaskManager) prepareExecution(
 		done:            make(chan struct{}),
 	}
 	if streaming {
-		ex.pipe = newTaskSubscriber(taskID, m.options.TaskSubscriberBufSize, m.options.TaskSubscriberBlockingSend)
+		// Reserve one framing slot for the synthetic initial Task. The configured
+		// capacity remains available to processor updates, including when the
+		// request pipe uses non-blocking sends.
+		ex.pipe = newTaskSubscriber(taskID, m.options.TaskSubscriberBufSize+1,
+			m.options.TaskSubscriberBlockingSend)
 		ex.live.pipe = ex.pipe
 	}
 
@@ -702,6 +706,14 @@ func (ex *execution) processStatusEvent(ev *protocol.TaskStatusUpdateEvent) {
 		Message:   ev.Status.Message,
 		Timestamp: timestamp,
 	}
+	var initial *protocol.Task
+	if !ex.taskTouched {
+		if ex.task == nil {
+			initial = protocol.NewTask(ex.ec.TaskID, ex.ec.ContextID)
+		} else {
+			initial = copyTask(ex.task)
+		}
+	}
 	var previousStatusMessage *protocol.Message
 	allowCreate := ex.task == nil
 	if allowCreate {
@@ -734,6 +746,11 @@ func (ex *execution) processStatusEvent(ev *protocol.TaskStatusUpdateEvent) {
 		}
 		ex.failRun(fmt.Errorf("failed to store task %s status %s: %w", ev.TaskID, status.State, err))
 		return
+	}
+	if initial != nil && ex.pipe != nil {
+		if err := ex.pipe.Send(protocol.NewStreamResponseTask(initial)); err != nil {
+			log.Warnf("RedisTaskManager: failed to send initial Task for task %s: %v", ex.ec.TaskID, err)
+		}
 	}
 	// The old status message is durably superseded only after the Task/event
 	// commit succeeds. Moving it earlier would leave failed updates reflected in
@@ -783,6 +800,14 @@ func (ex *execution) processArtifactEvent(ev *protocol.TaskArtifactUpdateEvent) 
 			ex.ec.TaskID, ex.task.Status.State)
 		return
 	}
+	var initial *protocol.Task
+	if !ex.taskTouched {
+		if ex.task == nil {
+			initial = protocol.NewTask(ex.ec.TaskID, ex.ec.ContextID)
+		} else {
+			initial = copyTask(ex.task)
+		}
+	}
 	allowCreate := ex.task == nil
 	if allowCreate {
 		ex.task = ex.newTask(ev.TaskID, ev.ContextID, protocol.TaskStatus{
@@ -802,6 +827,11 @@ func (ex *execution) processArtifactEvent(ev *protocol.TaskArtifactUpdateEvent) 
 	if err := ex.manager.commitTaskEvent(context.Background(), ex.ec.Tenant, ex.task, response, allowCreate); err != nil {
 		ex.failRun(fmt.Errorf("failed to store task %s artifact: %w", ev.TaskID, err))
 		return
+	}
+	if initial != nil && ex.pipe != nil {
+		if err := ex.pipe.Send(protocol.NewStreamResponseTask(initial)); err != nil {
+			log.Warnf("RedisTaskManager: failed to send initial Task for task %s: %v", ex.ec.TaskID, err)
+		}
 	}
 	if err := ex.persistInlinePushConfig(); err != nil {
 		log.Errorf("RedisTaskManager: failed to persist inline push config for task %s: %v", ex.ec.TaskID, err)

--- a/taskmanager/redis/redis_engine_test.go
+++ b/taskmanager/redis/redis_engine_test.go
@@ -191,7 +191,16 @@ func TestOnSendMessage_ConcurrentContinuationRejected(t *testing.T) {
 		t.Fatalf("OnSendMessageStream failed: %v", err)
 	}
 	first := recvEvent(t, pipe)
-	taskID := first.GetStatusUpdate().TaskID
+	task := first.GetTask()
+	if task == nil {
+		t.Fatalf("first stream frame = %+v, want Task", first.Result)
+	}
+	taskID := task.ID
+	second := recvEvent(t, pipe)
+	if update := second.GetStatusUpdate(); update == nil ||
+		update.Status.State != protocol.TaskStateWorking {
+		t.Fatalf("second stream frame = %+v, want WORKING", update)
+	}
 
 	// Second live run on the same task must be rejected atomically.
 	followUp := sendParams("again", "ctx-concurrent")
@@ -242,7 +251,16 @@ func TestOnCancelTask_LiveButTerminalNotCancelable(t *testing.T) {
 		t.Fatalf("OnSendMessageStream failed: %v", err)
 	}
 	first := recvEvent(t, pipe)
-	taskID := first.GetStatusUpdate().TaskID
+	task := first.GetTask()
+	if task == nil {
+		t.Fatalf("first stream frame = %+v, want Task", first.Result)
+	}
+	taskID := task.ID
+	second := recvEvent(t, pipe)
+	if update := second.GetStatusUpdate(); update == nil ||
+		update.Status.State != protocol.TaskStateCompleted {
+		t.Fatalf("second stream frame = %+v, want COMPLETED", update)
+	}
 	waitTaskState(t, m, taskID, protocol.TaskStateCompleted)
 
 	// The round is still live (channel not yet closed) but the stored state is
@@ -494,7 +512,16 @@ func TestOnSendMessageStream_DisconnectKeepsRunning(t *testing.T) {
 		t.Fatalf("OnSendMessageStream failed: %v", err)
 	}
 	first := recvEvent(t, pipe)
-	taskID := first.GetStatusUpdate().TaskID
+	task := first.GetTask()
+	if task == nil {
+		t.Fatalf("first stream frame = %+v, want Task", first.Result)
+	}
+	taskID := task.ID
+	second := recvEvent(t, pipe)
+	if update := second.GetStatusUpdate(); update == nil ||
+		update.Status.State != protocol.TaskStateWorking {
+		t.Fatalf("second stream frame = %+v, want WORKING", update)
+	}
 	cancel() // client disconnects; the pipe is abandoned from here on
 	close(disconnected)
 

--- a/taskmanager/redis/redis_manager_test.go
+++ b/taskmanager/redis/redis_manager_test.go
@@ -458,19 +458,20 @@ func TestInputRequiredContinuation(t *testing.T) {
 	}
 }
 
-// §3.1: a continuation round that only emits Messages answers with the last
-// Message; the suspended task stays untouched.
-func TestContinuationMessageOnlyReturnsMessage(t *testing.T) {
+// A continuation whose first event is a direct Message answers with that
+// Message and discards later task events; the suspended task stays untouched.
+func TestContinuationDirectMessageDiscardsLaterTaskEvent(t *testing.T) {
 	var round int
 	processor := executorFunc(func(
 		ctx context.Context, ec *taskmanager.ExecContext,
 	) (<-chan protocol.StreamEvent, error) {
 		round++
-		out := make(chan protocol.StreamEvent, 1)
+		out := make(chan protocol.StreamEvent, 2)
 		if round == 1 {
 			out <- statusEvent(protocol.TaskStateInputRequired, agentReply("need more"))
 		} else {
 			out <- agentReply("just a clarification")
+			out <- statusEvent(protocol.TaskStateCompleted, nil)
 		}
 		close(out)
 		return out, nil
@@ -681,7 +682,10 @@ func TestOnSendMessageStreamOrderAndPersistence(t *testing.T) {
 	})
 	m, _ := setupTest(t, processor)
 
-	ch, err := m.OnSendMessageStream(context.Background(), sendParams("stream it", "ctx-stream"))
+	one := 1
+	params := sendParams("stream it", "ctx-stream")
+	params.Configuration = &protocol.SendMessageConfiguration{HistoryLength: &one}
+	ch, err := m.OnSendMessageStream(context.Background(), params)
 	if err != nil {
 		t.Fatalf("OnSendMessageStream failed: %v", err)
 	}
@@ -692,6 +696,16 @@ func TestOnSendMessageStreamOrderAndPersistence(t *testing.T) {
 	initial := frame1.GetTask()
 	if initial == nil || initial.Status.State != protocol.TaskStateSubmitted {
 		t.Fatalf("frame 1: expected submitted Task, got %+v", frame1.Result)
+	}
+	storedInitial, err := m.getTaskInternal(context.Background(), "", initial.ID)
+	if err != nil {
+		t.Fatalf("getTaskInternal failed: %v", err)
+	}
+	if len(storedInitial.History) != 0 {
+		t.Fatalf("initial Task history must not be written into Redis, got %d entries", len(storedInitial.History))
+	}
+	if len(initial.History) != 1 || textOfMessage(initial.History[0]) != "stream it" {
+		t.Fatalf("frame 1: historyLength=1 was not applied: %+v", initial.History)
 	}
 
 	// Frame 2: working. Persist-before-broadcast means the store must already
@@ -831,6 +845,31 @@ func TestOnSendMessageStreamPureMessage(t *testing.T) {
 	for _, key := range mr.Keys() {
 		if strings.HasPrefix(key, taskPrefix) {
 			t.Errorf("pure-message stream must not create a task, found %s", key)
+		}
+	}
+}
+
+// The first valid event fixes the response shape. Once a direct Message has
+// been sent, later task events are drained rather than switching wire modes.
+func TestOnSendMessageStreamDirectMessageDoesNotSwitchToTask(t *testing.T) {
+	m, mr := setupTest(t, scriptedExecutor(
+		agentReply("direct"),
+		agentReply("ignored"),
+		statusEvent(protocol.TaskStateCompleted, nil),
+	))
+
+	ch, err := m.OnSendMessageStream(context.Background(), sendParams("hello", "ctx-direct-mode"))
+	if err != nil {
+		t.Fatalf("OnSendMessageStream failed: %v", err)
+	}
+	frames := collectStream(t, ch)
+	if len(frames) != 1 || frames[0].GetMessage() == nil ||
+		textOfMessage(*frames[0].GetMessage()) != "direct" {
+		t.Fatalf("expected exactly the first direct Message, got %+v", frames)
+	}
+	for _, key := range mr.Keys() {
+		if strings.HasPrefix(key, taskPrefix) {
+			t.Fatalf("task event after direct Message must be discarded, found %s", key)
 		}
 	}
 }

--- a/taskmanager/redis/redis_manager_test.go
+++ b/taskmanager/redis/redis_manager_test.go
@@ -686,16 +686,28 @@ func TestOnSendMessageStreamOrderAndPersistence(t *testing.T) {
 		t.Fatalf("OnSendMessageStream failed: %v", err)
 	}
 
-	// Frame 1: working. Persist-before-broadcast means the store must already
-	// reflect the state when the frame is delivered.
+	// Frame 1: the protocol-level initial Task snapshot. The first processor
+	// update is already persisted before either task frame is delivered.
 	frame1 := <-ch
-	statusUpdate := frame1.GetStatusUpdate()
+	initial := frame1.GetTask()
+	if initial == nil || initial.Status.State != protocol.TaskStateSubmitted {
+		t.Fatalf("frame 1: expected submitted Task, got %+v", frame1.Result)
+	}
+
+	// Frame 2: working. Persist-before-broadcast means the store must already
+	// reflect the state when the frame is delivered.
+	frame2 := <-ch
+	statusUpdate := frame2.GetStatusUpdate()
 	if statusUpdate == nil || statusUpdate.Status.State != protocol.TaskStateWorking {
-		t.Fatalf("frame 1: expected working status, got %+v", frame1.Result)
+		t.Fatalf("frame 2: expected working status, got %+v", frame2.Result)
 	}
 	taskID := statusUpdate.TaskID
 	if taskID == "" || statusUpdate.ContextID != "ctx-stream" {
-		t.Fatalf("frame 1: expected stamped IDs, got %+v", statusUpdate)
+		t.Fatalf("frame 2: expected stamped IDs, got %+v", statusUpdate)
+	}
+	if initial.ID != taskID || initial.ContextID != statusUpdate.ContextID {
+		t.Fatalf("initial Task IDs = %s/%s, want %s/%s",
+			initial.ID, initial.ContextID, taskID, statusUpdate.ContextID)
 	}
 	stored, err := m.getTaskInternal(context.Background(), "", taskID)
 	if err != nil {
@@ -706,11 +718,11 @@ func TestOnSendMessageStreamOrderAndPersistence(t *testing.T) {
 	}
 	step <- struct{}{}
 
-	// Frame 2: artifact, persisted before delivery.
-	frame2 := <-ch
-	artifactUpdate := frame2.GetArtifactUpdate()
+	// Frame 3: artifact, persisted before delivery.
+	frame3 := <-ch
+	artifactUpdate := frame3.GetArtifactUpdate()
 	if artifactUpdate == nil || artifactUpdate.Artifact.ArtifactID != "artifact-1" {
-		t.Fatalf("frame 2: expected artifact update, got %+v", frame2.Result)
+		t.Fatalf("frame 3: expected artifact update, got %+v", frame3.Result)
 	}
 	stored, err = m.getTaskInternal(context.Background(), "", taskID)
 	if err != nil {
@@ -721,11 +733,11 @@ func TestOnSendMessageStreamOrderAndPersistence(t *testing.T) {
 	}
 	step <- struct{}{}
 
-	// Frame 3: completed, then the pipe closes.
-	frame3 := <-ch
-	statusUpdate = frame3.GetStatusUpdate()
+	// Frame 4: completed, then the pipe closes.
+	frame4 := <-ch
+	statusUpdate = frame4.GetStatusUpdate()
 	if statusUpdate == nil || statusUpdate.Status.State != protocol.TaskStateCompleted {
-		t.Fatalf("frame 3: expected completed status, got %+v", frame3.Result)
+		t.Fatalf("frame 4: expected completed status, got %+v", frame4.Result)
 	}
 	stored, err = m.getTaskInternal(context.Background(), "", taskID)
 	if err != nil {
@@ -736,6 +748,68 @@ func TestOnSendMessageStreamOrderAndPersistence(t *testing.T) {
 	}
 	if _, ok := <-ch; ok {
 		t.Error("expected stream closed after engine end")
+	}
+}
+
+func TestOnSendMessageStreamArtifactFirstStartsWithTask(t *testing.T) {
+	m, _ := setupTest(t, scriptedExecutor(
+		artifactEvent("artifact-first", "chunk"),
+		statusEvent(protocol.TaskStateCompleted, nil),
+	))
+
+	stream, err := m.OnSendMessageStream(context.Background(), sendParams("stream it", "ctx-artifact-first"))
+	if err != nil {
+		t.Fatalf("OnSendMessageStream failed: %v", err)
+	}
+	frames := collectStream(t, stream)
+	if len(frames) != 3 {
+		t.Fatalf("frames = %d, want Task, artifact, completed status: %+v", len(frames), frames)
+	}
+	initial := frames[0].GetTask()
+	if initial == nil || initial.Status.State != protocol.TaskStateSubmitted ||
+		initial.ContextID != "ctx-artifact-first" {
+		t.Fatalf("first frame = %+v, want submitted Task", frames[0].Result)
+	}
+	artifact := frames[1].GetArtifactUpdate()
+	if artifact == nil || artifact.TaskID != initial.ID || artifact.Artifact.ArtifactID != "artifact-first" {
+		t.Fatalf("second frame = %+v, want artifact for %s", frames[1].Result, initial.ID)
+	}
+	completed := frames[2].GetStatusUpdate()
+	if completed == nil || completed.TaskID != initial.ID || completed.Status.State != protocol.TaskStateCompleted {
+		t.Fatalf("third frame = %+v, want completed status for %s", frames[2].Result, initial.ID)
+	}
+}
+
+func TestOnSendMessageStreamContinuationStartsWithCurrentTask(t *testing.T) {
+	m, _ := setupTest(t, scriptedExecutor(statusEvent(protocol.TaskStateCompleted, nil)))
+	task := storedTask(t, m, "task-continuation-stream", "ctx-continuation-stream", protocol.TaskStateInputRequired)
+	task.Artifacts = []protocol.Artifact{{
+		ArtifactID: "existing-artifact",
+		Parts:      []*protocol.Part{protocol.NewTextPart("existing")},
+	}}
+	if err := m.storeTask(context.Background(), "", task); err != nil {
+		t.Fatalf("storeTask with artifact failed: %v", err)
+	}
+
+	params := sendParams("continue", "")
+	params.Message.TaskID = &task.ID
+	stream, err := m.OnSendMessageStream(context.Background(), params)
+	if err != nil {
+		t.Fatalf("OnSendMessageStream continuation failed: %v", err)
+	}
+	frames := collectStream(t, stream)
+	if len(frames) != 2 {
+		t.Fatalf("frames = %d, want current Task then completed status: %+v", len(frames), frames)
+	}
+	initial := frames[0].GetTask()
+	if initial == nil || initial.ID != task.ID || initial.ContextID != task.ContextID ||
+		initial.Status.State != protocol.TaskStateInputRequired || len(initial.Artifacts) != 1 ||
+		initial.Artifacts[0].ArtifactID != "existing-artifact" {
+		t.Fatalf("first frame = %+v, want pre-update continuation Task", frames[0].Result)
+	}
+	completed := frames[1].GetStatusUpdate()
+	if completed == nil || completed.Status.State != protocol.TaskStateCompleted {
+		t.Fatalf("second frame = %+v, want completed status", frames[1].Result)
 	}
 }
 
@@ -793,6 +867,44 @@ func TestOnSendMessageStreamBlockingSend(t *testing.T) {
 		if states[i] != want[i] {
 			t.Errorf("frame %d = %s, want %s (order must match emission)", i, states[i], want[i])
 		}
+	}
+}
+
+func TestOnSendMessageStreamNonBlockingBufferReservesInitialTaskSlot(t *testing.T) {
+	taskID := make(chan string, 1)
+	processor := executorFunc(func(
+		_ context.Context, ec *taskmanager.ExecContext,
+	) (<-chan protocol.StreamEvent, error) {
+		taskID <- ec.TaskID
+		out := make(chan protocol.StreamEvent, 1)
+		out <- statusEvent(protocol.TaskStateCompleted, nil)
+		close(out)
+		return out, nil
+	})
+	m, _ := setupTest(t, processor,
+		WithTaskSubscriberBufferSize(1),
+		WithTaskSubscriberBlockingSend(false),
+	)
+
+	stream, err := m.OnSendMessageStream(context.Background(), sendParams("go", "ctx-nonblocking-buffer"))
+	if err != nil {
+		t.Fatalf("OnSendMessageStream failed: %v", err)
+	}
+	id := <-taskID
+	// Do not consume the response until the terminal event has been committed
+	// and the pipe closed. This makes the capacity requirement deterministic.
+	waitTaskState(t, m, id, protocol.TaskStateCompleted)
+	frames := collectStream(t, stream)
+	if len(frames) != 2 {
+		t.Fatalf("frames = %d, want initial Task and completed status: %+v", len(frames), frames)
+	}
+	initial := frames[0].GetTask()
+	if initial == nil || initial.ID != id || initial.Status.State != protocol.TaskStateSubmitted {
+		t.Fatalf("first frame = %+v, want submitted Task for %s", frames[0].Result, id)
+	}
+	completed := frames[1].GetStatusUpdate()
+	if completed == nil || completed.TaskID != id || completed.Status.State != protocol.TaskStateCompleted {
+		t.Fatalf("second frame = %+v, want completed status for %s", frames[1].Result, id)
 	}
 }
 
@@ -889,7 +1001,15 @@ func TestOnCancelTaskLiveExecution(t *testing.T) {
 		t.Fatalf("OnSendMessageStream failed: %v", err)
 	}
 	frame := <-ch
-	taskID := frame.GetStatusUpdate().TaskID
+	task := frame.GetTask()
+	if task == nil {
+		t.Fatalf("first stream frame = %+v, want Task", frame.Result)
+	}
+	taskID := task.ID
+	frame = <-ch
+	if su := frame.GetStatusUpdate(); su == nil || su.Status.State != protocol.TaskStateWorking {
+		t.Fatalf("expected WORKING after initial Task, got %+v", frame.Result)
+	}
 
 	snapshot, err := m.OnCancelTask(context.Background(), protocol.TaskIDParams{ID: taskID})
 	if err != nil {
@@ -940,7 +1060,15 @@ func TestOnCancelTaskCompletedWins(t *testing.T) {
 		t.Fatalf("OnSendMessageStream failed: %v", err)
 	}
 	frame := <-ch
-	taskID := frame.GetStatusUpdate().TaskID
+	task := frame.GetTask()
+	if task == nil {
+		t.Fatalf("first stream frame = %+v, want Task", frame.Result)
+	}
+	taskID := task.ID
+	frame = <-ch
+	if su := frame.GetStatusUpdate(); su == nil || su.Status.State != protocol.TaskStateWorking {
+		t.Fatalf("expected WORKING after initial Task, got %+v", frame.Result)
+	}
 
 	if _, err := m.OnCancelTask(context.Background(), protocol.TaskIDParams{ID: taskID}); err != nil {
 		t.Fatalf("OnCancelTask failed: %v", err)
@@ -1119,7 +1247,15 @@ func TestOnResubscribeReceivesLiveEvents(t *testing.T) {
 		t.Fatalf("OnSendMessageStream failed: %v", err)
 	}
 	frame := <-ch
-	taskID := frame.GetStatusUpdate().TaskID
+	task := frame.GetTask()
+	if task == nil {
+		t.Fatalf("first stream frame = %+v, want Task", frame.Result)
+	}
+	taskID := task.ID
+	frame = <-ch
+	if su := frame.GetStatusUpdate(); su == nil || su.Status.State != protocol.TaskStateWorking {
+		t.Fatalf("expected WORKING after initial Task, got %+v", frame.Result)
+	}
 
 	sub, err := m.OnResubscribe(context.Background(), protocol.TaskIDParams{ID: taskID})
 	if err != nil {

--- a/taskmanager/redis/redis_options.go
+++ b/taskmanager/redis/redis_options.go
@@ -21,7 +21,8 @@ type TaskManagerOptions struct {
 	// MaxHistoryLength is the maximum number of messages to keep in conversation history.
 	MaxHistoryLength int
 
-	// TaskSubscriberBufSize is the buffer size for message/stream response pipes.
+	// TaskSubscriberBufSize is the buffer size for task update events. A
+	// SendStreamingMessage response pipe reserves one additional framing slot.
 	TaskSubscriberBufSize int
 
 	// TaskSubscriberBlockingSend enables blocking send for message/stream
@@ -71,7 +72,9 @@ func WithMaxHistoryLength(length int) TaskManagerOption {
 	}
 }
 
-// WithTaskSubscriberBufferSize sets the buffer size for message/stream response pipes.
+// WithTaskSubscriberBufferSize sets the buffer size for task update events. A
+// SendStreamingMessage response pipe reserves one additional framing slot for
+// its initial Task.
 func WithTaskSubscriberBufferSize(size int) TaskManagerOption {
 	return func(opts *TaskManagerOptions) {
 		if size > 0 {

--- a/taskmanager/redis/redis_push_dispatch_test.go
+++ b/taskmanager/redis/redis_push_dispatch_test.go
@@ -244,6 +244,66 @@ func TestRedisPushRegisteredConfigDelivered(t *testing.T) {
 	}
 }
 
+func TestRedisStreamingInitialTaskIsNotPushed(t *testing.T) {
+	sender := &recordingSender{}
+	m, _ := setupTest(t, scriptedExecutor(
+		statusEvent(protocol.TaskStateCompleted, agentReply("done")),
+	), WithPushNotifications(push.Config{Sender: sender}))
+	defer m.Close()
+
+	task := storedTask(t, m, "task-stream-push", "ctx-stream-push", protocol.TaskStateWorking)
+	if _, err := m.OnPushNotificationSet(context.Background(), protocol.TaskPushNotificationConfig{
+		TaskID: task.ID,
+		ID:     "stream-hook",
+		URL:    "https://example.com/stream-hook",
+	}); err != nil {
+		t.Fatalf("OnPushNotificationSet: %v", err)
+	}
+	params := sendParams("continue", task.ContextID)
+	params.Message.TaskID = &task.ID
+	stream, err := m.OnSendMessageStream(context.Background(), params)
+	if err != nil {
+		t.Fatalf("OnSendMessageStream: %v", err)
+	}
+	frames := collectStream(t, stream)
+	if len(frames) != 2 || frames[0].GetTask() == nil || frames[1].GetStatusUpdate() == nil {
+		t.Fatalf("stream frames = %+v, want Task then completed status", frames)
+	}
+
+	// Queue a recognizable sentinel for the same task/config. Dispatcher FIFO
+	// ordering for one registration guarantees every earlier delivery is
+	// recorded before the sentinel, without relying on timing.
+	sentinel := agentReply("push-sentinel")
+	m.dispatchPush("", task.ID, protocol.NewStreamResponseMessage(sentinel))
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		calls := sender.snapshot()
+		if len(calls) > 0 {
+			last := calls[len(calls)-1].event.GetMessage()
+			if last != nil && last.Parts[0].TextContent() == "push-sentinel" {
+				break
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	calls := sender.snapshot()
+	if len(calls) == 0 || calls[len(calls)-1].event.GetMessage() == nil ||
+		calls[len(calls)-1].event.GetMessage().Parts[0].TextContent() != "push-sentinel" {
+		t.Fatalf("sentinel push was not delivered: %+v", calls)
+	}
+	beforeSentinel := calls[:len(calls)-1]
+	if len(beforeSentinel) != 1 {
+		t.Fatalf("push deliveries before sentinel = %d, want only the real status update", len(beforeSentinel))
+	}
+	if beforeSentinel[0].event.GetTask() != nil {
+		t.Fatalf("synthetic initial Task was pushed: %+v", beforeSentinel[0].event.Result)
+	}
+	if update := beforeSentinel[0].event.GetStatusUpdate(); update == nil ||
+		update.Status.State != protocol.TaskStateCompleted {
+		t.Fatalf("push event = %+v, want completed status", beforeSentinel[0].event.Result)
+	}
+}
+
 func TestRedisPushQueuedGenerationInvalidatedAcrossManagers(t *testing.T) {
 	started := make(chan struct{})
 	release := make(chan struct{})
@@ -412,6 +472,11 @@ func TestRedisPushBackpressureSerializesSuspendContinuation(t *testing.T) { //no
 	manager.cancelMu.RUnlock()
 	if !yielding {
 		t.Fatal("input-required became visible before the suspend handoff barrier")
+	}
+	initial := recvEvent(t, stream)
+	if task := initial.GetTask(); task == nil || task.ID != taskID ||
+		task.Status.State != protocol.TaskStateSubmitted {
+		t.Fatalf("initial stream event = %+v, want submitted Task", initial.Result)
 	}
 
 	type continuationResult struct {

--- a/taskmanager/redis/redis_regression_test.go
+++ b/taskmanager/redis/redis_regression_test.go
@@ -143,6 +143,10 @@ func TestCancelWinsConcurrentSuspendPersistsCanceled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OnSendMessageStream: %v", err)
 	}
+	initial := recvEvent(t, stream)
+	if task := initial.GetTask(); task == nil || task.Status.State != protocol.TaskStateSubmitted {
+		t.Fatalf("first stream frame = %+v, want submitted Task", initial.Result)
+	}
 	firstEvent := recvEvent(t, stream)
 	working := firstEvent.GetStatusUpdate()
 	if working == nil || working.Status.State != protocol.TaskStateWorking {
@@ -264,6 +268,10 @@ func TestCancel_TransientStorageErrorDoesNotCancelRun(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OnSendMessageStream failed: %v", err)
 	}
+	initial := recvEvent(t, pipe)
+	if initial.GetTask() == nil {
+		t.Fatalf("first stream frame = %+v, want Task", initial.Result)
+	}
 	event := recvEvent(t, pipe)
 	su := event.GetStatusUpdate()
 	if su == nil {
@@ -304,6 +312,10 @@ func TestClose_PersistsCanceledBeforeClientClose(t *testing.T) {
 	pipe, err := manager.OnSendMessageStream(context.Background(), sendParams("start", ""))
 	if err != nil {
 		t.Fatalf("OnSendMessageStream failed: %v", err)
+	}
+	initial := recvEvent(t, pipe)
+	if initial.GetTask() == nil {
+		t.Fatalf("first stream frame = %+v, want Task", initial.Result)
 	}
 	event := recvEvent(t, pipe)
 	su := event.GetStatusUpdate()

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -435,9 +435,11 @@ func TestE2E_MessageAPI_Resubscribe(t *testing.T) {
 
 	first, ok := <-firstChan
 	require.True(t, ok, "Should have received a first stream event")
-	firstStatus := first.GetStatusUpdate()
-	require.NotNil(t, firstStatus, "First event should be a status update")
-	taskID := firstStatus.TaskID
+	firstTask := first.GetTask()
+	require.NotNil(t, firstTask, "First event should be a Task")
+	require.Equal(t, protocol.TaskStateSubmitted, firstTask.Status.State,
+		"The initial Task should describe the pre-update state")
+	taskID := firstTask.ID
 	require.NotEmpty(t, taskID, "Server should have assigned a task ID")
 
 	// Resubscribe to streaming message events using the new API
@@ -458,7 +460,9 @@ func TestE2E_MessageAPI_Resubscribe(t *testing.T) {
 }
 
 func checkStreamingEvents(t *testing.T, events []protocol.StreamResponse) {
-	require.NotEmpty(t, events, "Should have received events")
+	require.GreaterOrEqual(t, len(events), 2, "Should have received an initial Task and updates")
+	require.NotNil(t, events[0].GetTask(), "First event should be a Task")
+	require.NotNil(t, events[1].GetStatusUpdate(), "Initial Task should be followed by the first status update")
 
 	hasWorkingStatus := false
 	hasArtifact := false
@@ -635,7 +639,9 @@ func TestE2E_StreamDisconnect_BlockingSendDoesNotWedge(t *testing.T) {
 
 	first, ok := <-eventChan
 	require.True(t, ok, "should receive a first event")
-	taskID := first.GetStatusUpdate().TaskID
+	firstTask := first.GetTask()
+	require.NotNil(t, firstTask, "first event should be a Task")
+	taskID := firstTask.ID
 	require.NotEmpty(t, taskID)
 	cancelStream() // client disconnects here; buffer(1) will fill server-side
 


### PR DESCRIPTION
## Summary

- make the first valid processor event select the response shape for Memory and Redis: a `Message` completes a direct response, while a status or artifact starts a Task lifecycle
- start every task-producing `SendStreamingMessage` response with a manager-derived, pre-update `Task` snapshot
- apply the request's `historyLength` to the initial Task without mutating the stored Task
- keep Task ownership in the framework: processors emit messages and lifecycle updates, never `*protocol.Task`
- keep the framing Task local to the current request stream so push delivery, `SubscribeToTask`, and the Redis event journal continue to carry only lifecycle updates
- reserve one request-pipe slot for Task framing so the configured processor-update capacity is preserved
- harden Memory execution admission, suspend handoff, cancellation, shutdown, and resubscription races
- document the response-mode, framing, history, and Memory yield-cancellation contracts in English and Chinese

## Root cause

Memory and Redis lazily materialized and persisted a Task from the first status or artifact event, but streamed that update directly. A2A 1.0 requires a task-lifecycle stream to begin with a Task, followed by status or artifact updates. It also requires a direct-response stream to contain exactly one Message.

The initial framing snapshots added by the first version of this change did not apply `configuration.historyLength`, and retaining managers still allowed a processor to emit a Message and later switch the same response into Task mode.

The Memory manager also released a suspended execution from its live registry before its processor context could be canceled during shutdown. `Close` could then wait for the detached drain engine without being able to signal it. A separate race allowed a resubscription to register after shutdown had already swept the subscriber map.

## Wire behavior

| First valid processor event | Current request stream |
| --- | --- |
| `Message` | exactly that Message; later processor events are drained and discarded |
| status/artifact for a new task | `Task(SUBMITTED)`, then the triggering update |
| status/artifact for a continuation | persisted pre-update Task snapshot, then the current-round update |

After Task mode has been selected, existing task-attached Message events remain supported and lifecycle updates continue in processor order.

Retaining managers persist the triggering update before delivering either response frame, but the first wire frame represents the Task state before that update. Its `history` is shaped from the conversation using the request's `historyLength`; filling it does not modify the stored Task. The framing Task is not journaled, pushed, or broadcast to task subscribers.

## Memory lifecycle hardening

- after publishing an `input-required` or `auth-required` frame, Memory cancels that yielded old round's processor context before releasing its execution slot, then continues draining the event channel until the processor closes it
- yield-time context cancellation is round teardown, not task cancellation: the Task remains suspended rather than becoming `CANCELED`
- `Close` rejects new executions, cancels discoverable live executions, closes their response pipes, and waits for drain engines before returning
- resubscription is rejected once shutdown begins, including the window while `Close` is waiting for processors
- shutdown remains cooperative: processors must honor context cancellation and close their event channels

## Compatibility

- no public Go API signatures change
- processors that previously emitted a direct Message and then task events now receive direct-response semantics: the first Message is returned and later events are discarded
- task-first rounds may continue to emit task-attached Messages
- Message-only responses, push payloads, normal task-subscription framing, and Redis journal entries keep their protocol shapes
- compat/v0 JSON-RPC converts the initial Task snapshot to a legacy `task` stream event

## Validation

- root module: `GOWORK=off go test ./...`
- root module with race detector: `GOWORK=off go test -race ./...`
- Memory response-mode, framing, history, shutdown, yield, continuation, cancellation, and resubscribe race regressions repeated under the race detector
- Redis nested module: `GOWORK=off go test ./...`
- Redis nested module with race detector: `GOWORK=off go test -race ./...`
- `GOWORK=off go vet ./...`
- production-code `golangci-lint` with the same test-file exclusion as CI
- `GOWORK=off go mod tidy -diff`
- docs: `mkdocs build --strict`
- `git diff --check`
