### PR TITLE
examples: add Go/Python multi-tenant interoperability demo

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -627,6 +627,43 @@ func (c *A2AClient) GetAgentCard(
 		newPathURL.String(), oldPathURL.String(), err)
 }
 
+// GetTenantAgentCard retrieves the public agent card for a tenant.
+// It first uses the tenant query parameter and then falls back to a
+// tenant-prefixed path.
+func (c *A2AClient) GetTenantAgentCard(
+	ctx context.Context,
+	tenant string,
+	opts ...RequestOption,
+) (*server.AgentCard, error) {
+	if tenant == "" {
+		return nil, fmt.Errorf("a2aClient.GetTenantAgentCard: tenant is required")
+	}
+
+	queryURL := *c.baseURL
+	queryURL.Path = path.Join(queryURL.Path, protocol.AgentCardPath)
+	query := queryURL.Query()
+	query.Set("tenant", tenant)
+	queryURL.RawQuery = query.Encode()
+	card, queryErr := c.getAgentCardFromURL(ctx, queryURL.String(), opts...)
+	if queryErr == nil {
+		return card, nil
+	}
+
+	pathURL := *c.baseURL
+	baseEscapedPath := pathURL.EscapedPath()
+	pathURL.Path = path.Join(pathURL.Path, tenant, protocol.AgentCardPath)
+	pathURL.RawPath = path.Join(baseEscapedPath, url.PathEscape(tenant), protocol.AgentCardPath)
+	card, pathErr := c.getAgentCardFromURL(ctx, pathURL.String(), opts...)
+	if pathErr == nil {
+		return card, nil
+	}
+	return nil, fmt.Errorf(
+		"a2aClient.GetTenantAgentCard: query endpoint failed: %v; tenant path failed: %w",
+		queryErr,
+		pathErr,
+	)
+}
+
 // getAgentCardFromURL is a helper function that fetches the agent card from a specific URL.
 func (c *A2AClient) getAgentCardFromURL(
 	ctx context.Context,

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -924,6 +924,55 @@ func TestA2AClient_GetAgentCard(t *testing.T) {
 	})
 }
 
+func TestA2AClient_GetTenantAgentCard(t *testing.T) {
+	t.Run("Query Parameter", func(t *testing.T) {
+		cardServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, protocol.AgentCardPath, r.URL.Path)
+			assert.Equal(t, "tenant-a", r.URL.Query().Get("tenant"))
+			assert.Equal(t, "test-value", r.Header.Get("X-Custom-Header"))
+			require.NoError(t, json.NewEncoder(w).Encode(server.AgentCard{Name: "Tenant A"}))
+		}))
+		defer cardServer.Close()
+
+		client, err := NewA2AClient(cardServer.URL)
+		require.NoError(t, err)
+		card, err := client.GetTenantAgentCard(
+			context.Background(),
+			"tenant-a",
+			WithRequestHeader("X-Custom-Header", "test-value"),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "Tenant A", card.Name)
+	})
+
+	t.Run("Tenant Path Fallback", func(t *testing.T) {
+		cardServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == protocol.AgentCardPath {
+				assert.Equal(t, "tenant/a", r.URL.Query().Get("tenant"))
+				http.NotFound(w, r)
+				return
+			}
+			assert.Equal(t, "/tenant%2Fa"+protocol.AgentCardPath, r.URL.EscapedPath())
+			require.NoError(t, json.NewEncoder(w).Encode(server.AgentCard{Name: "Tenant A/B"}))
+		}))
+		defer cardServer.Close()
+
+		client, err := NewA2AClient(cardServer.URL)
+		require.NoError(t, err)
+		card, err := client.GetTenantAgentCard(context.Background(), "tenant/a")
+		require.NoError(t, err)
+		assert.Equal(t, "Tenant A/B", card.Name)
+	})
+
+	t.Run("Empty Tenant", func(t *testing.T) {
+		client, err := NewA2AClient("http://localhost:8080/")
+		require.NoError(t, err)
+		card, err := client.GetTenantAgentCard(context.Background(), "")
+		require.Error(t, err)
+		assert.Nil(t, card)
+	})
+}
+
 // boolPtr returns a pointer to a bool value.
 func boolPtr(b bool) *bool {
 	return &b

--- a/examples/python-interop/.gitignore
+++ b/examples/python-interop/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+__pycache__/
+*.py[cod]
+/uv.lock

--- a/examples/python-interop/README.md
+++ b/examples/python-interop/README.md
@@ -1,0 +1,91 @@
+# Go/Python Multi-Tenant Interoperability
+
+This example uses the official Python [`a2a-sdk`](https://github.com/a2aproject/a2a-python) together with `trpc-a2a-go`. The `server` and `client` directories each provide both Go and Python implementations, so either language can run against the other.
+
+The dependency is pinned to `a2a-sdk[http-server]==1.1.2` in `pyproject.toml`. Python 3.10 or newer and Go 1.20 or newer are required.
+
+## What it demonstrates
+
+- Two tenants, `tenant-a` and `tenant-b`, share one server process and one JSON-RPC endpoint.
+- The clients intentionally reuse the same context ID and message ID for both tenants.
+- New tasks and task continuations use `SendStreamingMessage`; both clients print every status and artifact update.
+- Each tenant can create, continue, get, list, subscribe to, and cancel its own tasks.
+- Cross-tenant `GetTask` and `CancelTask` requests return task-not-found instead of exposing another tenant's task.
+- The Python task store resolves ownership from the request tenant, and the Python cancellation path verifies tenant ownership before looking up an active task.
+- Both clients understand the Go tenant-card URL (`/.well-known/agent-card.json?tenant=tenant-a`) and the Python tenant-card URL (`/tenant-a/.well-known/agent-card.json`).
+
+## Main paths
+
+The ordinary and continuation paths are streaming-first. The clients accept a full `Task` frame or a lifecycle update carrying the task ID, then fetch the aggregated result with `GetTask`:
+
+```text
+SendStreamingMessage -> Task or taskId-bearing update -> Status/Artifact updates -> terminal/interrupted Status -> GetTask
+```
+
+The cancellable path demonstrates the asynchronous lifecycle used by `examples/basic`:
+
+```text
+SendMessage(returnImmediately=true) -> SubscribeToTask -> Task -> CancelTask -> CANCELED update -> GetTask
+```
+
+After each tenant's positive path, the clients use `GetTask` and `ListTasks` to verify the stored result. They then repeat cross-tenant `GetTask` and `CancelTask` calls and require task-not-found, proving that identical client-supplied IDs do not cross the tenant boundary.
+
+## Layout
+
+```text
+python-interop/
+├── client/
+│   ├── main.go
+│   └── main.py
+├── server/
+│   ├── main.go
+│   └── main.py
+├── pyproject.toml
+└── uv.lock
+```
+
+## Install the Python SDK
+
+From the repository root:
+
+```bash
+uv sync --project examples/python-interop
+```
+
+## Run Go server with Python client
+
+Start the Go server:
+
+```bash
+cd examples
+GOWORK=off go run ./python-interop/server
+```
+
+In another shell, from the repository root, run the official Python SDK client:
+
+```bash
+uv run --project examples/python-interop python examples/python-interop/client/main.py
+```
+
+## Run Python server with Go client
+
+Start the official Python SDK server from the repository root:
+
+```bash
+uv run --project examples/python-interop python examples/python-interop/server/main.py
+```
+
+In another shell:
+
+```bash
+cd examples
+GOWORK=off go run ./python-interop/client
+```
+
+Use `--port` for the Python server, `-port` for the Go server, and `--agent` or `-agent` for the corresponding clients when changing the default `http://localhost:8080/` address.
+
+The same-language combinations also work and are useful for comparison: Go server with Go client, or Python server with Python client.
+
+## Security boundary
+
+This example focuses on resource isolation after a tenant has been selected. In production, do not trust an arbitrary tenant value from the request body; authenticate the caller and derive or authorize the tenant before dispatching the A2A request.

--- a/examples/python-interop/client/main.go
+++ b/examples/python-interop/client/main.go
@@ -1,0 +1,294 @@
+// Tencent is pleased to support the open source community by making trpc-a2a-go available.
+//
+// Copyright (C) 2025 Tencent. All rights reserved.
+//
+// trpc-a2a-go is licensed under the Apache License Version 2.0.
+
+// Package main implements the Go client for the Python SDK interoperability example.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+	"time"
+
+	"trpc.group/trpc-go/trpc-a2a-go/v2/client"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
+)
+
+const (
+	tenantA = "tenant-a"
+	tenantB = "tenant-b"
+)
+
+var agentURL = flag.String("agent", "http://localhost:8080/", "Go or Python A2A server URL")
+
+func main() {
+	flag.Parse()
+
+	c, err := client.NewA2AClient(*agentURL, client.WithTimeout(10*time.Second))
+	if err != nil {
+		panic(fmt.Errorf("create client: %w", err))
+	}
+	ctx := context.Background()
+	sharedContextID := protocol.GenerateContextID()
+	sharedMessageID := protocol.GenerateMessageID()
+	tasks := make(map[string]*protocol.Task, 2)
+
+	fmt.Println("=== Go client -> A2A server ===")
+	fmt.Printf("  server          : %s\n", *agentURL)
+	fmt.Printf("  shared contextId: %s\n", sharedContextID)
+	fmt.Printf("  shared messageId: %s\n\n", sharedMessageID)
+
+	for _, tenant := range []string{tenantA, tenantB} {
+		card, err := c.GetTenantAgentCard(ctx, tenant)
+		if err != nil {
+			panic(fmt.Errorf("get %s agent card: %w", tenant, err))
+		}
+		fmt.Printf("--- %s ---\n", tenant)
+		fmt.Printf("  name       : %s\n", card.Name)
+		fmt.Printf("  description: %s\n", card.Description)
+		for _, iface := range card.SupportedInterfaces {
+			fmt.Printf("  interface  : binding=%s url=%s tenant=%s\n",
+				iface.ProtocolBinding, iface.URL, iface.Tenant)
+		}
+
+		fmt.Println("\n  [send]")
+		sendText := fmt.Sprintf("hello from Go for %s", tenant)
+		fmt.Printf("  input     : %q\n", sendText)
+		task, err := streamTask(ctx, c, protocol.SendMessageParams{
+			Tenant: tenant,
+			Message: userMessage(
+				sendText,
+				sharedMessageID,
+				sharedContextID,
+			),
+		})
+		if err != nil {
+			panic(fmt.Errorf("send to %s: %w", tenant, err))
+		}
+		if task.Status.State != protocol.TaskStateCompleted {
+			panic(fmt.Errorf("%s task state is %s", tenant, task.Status.State))
+		}
+		tasks[tenant] = task
+		fmt.Printf("  completed : task=%s result=%q\n", task.ID, firstArtifactText(task))
+
+		fmt.Println("\n  [input-required]")
+		fmt.Printf("  input     : %q\n", "profile")
+		pending, err := streamTask(ctx, c, protocol.SendMessageParams{
+			Tenant:  tenant,
+			Message: userMessage("profile", protocol.GenerateMessageID(), protocol.GenerateContextID()),
+		})
+		if err != nil {
+			panic(fmt.Errorf("start %s continuation: %w", tenant, err))
+		}
+		if pending.Status.State != protocol.TaskStateInputRequired {
+			panic(fmt.Errorf("%s profile task state is %s", tenant, pending.Status.State))
+		}
+
+		fmt.Printf("  input     : %q (continue task=%s)\n", "Ada", pending.ID)
+		followUp := userMessage("Ada", protocol.GenerateMessageID(), pending.ContextID)
+		followUp.TaskID = &pending.ID
+		completed, err := streamTask(ctx, c, protocol.SendMessageParams{Tenant: tenant, Message: followUp})
+		if err != nil {
+			panic(fmt.Errorf("continue %s task: %w", tenant, err))
+		}
+		if completed.ID != pending.ID || completed.Status.State != protocol.TaskStateCompleted {
+			panic(fmt.Errorf("%s continuation did not complete task %s", tenant, pending.ID))
+		}
+		fmt.Printf("  continued : task=%s result=%q\n", completed.ID, firstArtifactText(completed))
+
+		fmt.Println("\n  [get/list]")
+		historyLength := 10
+		stored, err := c.GetTasks(ctx, protocol.TaskQueryParams{
+			Tenant:        tenant,
+			ID:            task.ID,
+			HistoryLength: &historyLength,
+		})
+		if err != nil {
+			panic(fmt.Errorf("get %s task: %w", tenant, err))
+		}
+		includeArtifacts := true
+		listed, err := c.ListTasks(ctx, protocol.ListTasksParams{
+			Tenant:           tenant,
+			ContextID:        sharedContextID,
+			IncludeArtifacts: &includeArtifacts,
+		})
+		if err != nil {
+			panic(fmt.Errorf("list %s tasks: %w", tenant, err))
+		}
+		if len(listed.Tasks) != 1 || listed.Tasks[0].ID != task.ID {
+			panic(fmt.Errorf("%s list leaked tenant data: %+v", tenant, listed.Tasks))
+		}
+		fmt.Printf("  get/list  : task=%s history=%d scopedTasks=%d\n\n",
+			stored.ID, len(stored.History), len(listed.Tasks))
+	}
+
+	fmt.Println("--- tenant isolation ---")
+	if err := expectTaskNotFound(ctx, c, tenantB, tasks[tenantA].ID); err != nil {
+		panic(err)
+	}
+	fmt.Printf("  %s cannot read %s task %s\n", tenantB, tenantA, tasks[tenantA].ID)
+	if err := expectTaskNotFound(ctx, c, tenantA, tasks[tenantB].ID); err != nil {
+		panic(err)
+	}
+	fmt.Printf("  %s cannot read %s task %s\n\n", tenantA, tenantB, tasks[tenantB].ID)
+
+	fmt.Println("--- cancellation ---")
+	returnImmediately := true
+	running, err := sendAsyncTask(ctx, c, protocol.SendMessageParams{
+		Tenant:  tenantA,
+		Message: userMessage("wait", protocol.GenerateMessageID(), protocol.GenerateContextID()),
+		Configuration: &protocol.SendMessageConfiguration{
+			ReturnImmediately: &returnImmediately,
+		},
+	})
+	if err != nil {
+		panic(fmt.Errorf("start cancellable task: %w", err))
+	}
+	subscription, err := c.ResubscribeTask(ctx, protocol.TaskIDParams{Tenant: tenantA, ID: running.ID})
+	if err != nil {
+		panic(fmt.Errorf("subscribe cancellable task: %w", err))
+	}
+	first, ok := <-subscription
+	if !ok || first.GetTask() == nil {
+		panic(fmt.Errorf("subscription must start with Task, got %+v", first))
+	}
+	subscriptionPath := []string{describeStreamEvent(first)}
+	if _, err := c.CancelTasks(ctx, protocol.TaskIDParams{Tenant: tenantB, ID: running.ID}); !isTaskNotFound(err) {
+		panic(fmt.Errorf("cross-tenant cancel returned %v, want task-not-found", err))
+	}
+	if _, err := c.CancelTasks(ctx, protocol.TaskIDParams{Tenant: tenantA, ID: running.ID}); err != nil {
+		panic(fmt.Errorf("cancel own task: %w", err))
+	}
+	sawCanceled := false
+	for event := range subscription {
+		subscriptionPath = append(subscriptionPath, describeStreamEvent(event))
+		if update := event.GetStatusUpdate(); update != nil && update.Status.State == protocol.TaskStateCanceled {
+			sawCanceled = true
+		}
+	}
+	if !sawCanceled {
+		panic(fmt.Errorf("subscription for task %s closed without CANCELED", running.ID))
+	}
+	canceled, err := c.GetTasks(ctx, protocol.TaskQueryParams{Tenant: tenantA, ID: running.ID})
+	if err != nil {
+		panic(fmt.Errorf("get canceled task: %w", err))
+	}
+	fmt.Printf("  subscription: %s\n", strings.Join(subscriptionPath, " -> "))
+	fmt.Printf("  %s canceled own task=%s state=%s; %s could not cancel it\n",
+		tenantA, canceled.ID, shortState(canceled.Status.State), tenantB)
+
+	fmt.Println("\n=== interoperability and tenant isolation verified ===")
+}
+
+func sendAsyncTask(
+	ctx context.Context,
+	c *client.A2AClient,
+	params protocol.SendMessageParams,
+) (*protocol.Task, error) {
+	response, err := c.SendMessage(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	task := response.GetTask()
+	if task == nil {
+		return nil, fmt.Errorf("expected task response, got %+v", response)
+	}
+	return task, nil
+}
+
+func streamTask(
+	ctx context.Context,
+	c *client.A2AClient,
+	params protocol.SendMessageParams,
+) (*protocol.Task, error) {
+	events, err := c.StreamMessage(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+
+	var taskID string
+	var path []string
+	for event := range events {
+		switch {
+		case event.GetTask() != nil:
+			taskID = event.GetTask().ID
+		case event.GetStatusUpdate() != nil:
+			taskID = event.GetStatusUpdate().TaskID
+		case event.GetArtifactUpdate() != nil:
+			taskID = event.GetArtifactUpdate().TaskID
+		}
+		path = append(path, describeStreamEvent(event))
+	}
+	if taskID == "" {
+		return nil, fmt.Errorf("stream closed without a task ID")
+	}
+	fmt.Printf("  stream    : %s\n", strings.Join(path, " -> "))
+
+	historyLength := 10
+	return c.GetTasks(ctx, protocol.TaskQueryParams{
+		Tenant:        params.Tenant,
+		ID:            taskID,
+		HistoryLength: &historyLength,
+	})
+}
+
+func describeStreamEvent(event protocol.StreamResponse) string {
+	switch {
+	case event.GetTask() != nil:
+		return fmt.Sprintf("Task(%s)", shortState(event.GetTask().Status.State))
+	case event.GetStatusUpdate() != nil:
+		return fmt.Sprintf("Status(%s)", shortState(event.GetStatusUpdate().Status.State))
+	case event.GetArtifactUpdate() != nil:
+		return fmt.Sprintf("Artifact(%s)", event.GetArtifactUpdate().Artifact.ArtifactID)
+	case event.GetMessage() != nil:
+		return "Message"
+	default:
+		return "Unknown"
+	}
+}
+
+func shortState(state protocol.TaskState) string {
+	return strings.TrimPrefix(string(state), "TASK_STATE_")
+}
+
+func userMessage(text, messageID, contextID string) protocol.Message {
+	message := protocol.NewMessage(
+		protocol.MessageRoleUser,
+		[]*protocol.Part{protocol.NewTextPart(text)},
+	)
+	message.MessageID = messageID
+	message.ContextID = &contextID
+	return message
+}
+
+func expectTaskNotFound(ctx context.Context, c *client.A2AClient, tenant, taskID string) error {
+	_, err := c.GetTasks(ctx, protocol.TaskQueryParams{Tenant: tenant, ID: taskID})
+	if !isTaskNotFound(err) {
+		return fmt.Errorf("%s read task %s or received an unexpected error: %v", tenant, taskID, err)
+	}
+	return nil
+}
+
+func isTaskNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	text := strings.ToLower(err.Error())
+	return strings.Contains(text, "-32001") || strings.Contains(text, "task not found") || strings.Contains(text, "http status 404")
+}
+
+func firstArtifactText(task *protocol.Task) string {
+	if len(task.Artifacts) == 0 {
+		return ""
+	}
+	for _, part := range task.Artifacts[0].Parts {
+		if text := part.TextContent(); text != "" {
+			return text
+		}
+	}
+	return ""
+}

--- a/examples/python-interop/client/main.py
+++ b/examples/python-interop/client/main.py
@@ -1,0 +1,339 @@
+"""Official Python SDK client for the Go/Python interoperability example."""
+
+import argparse
+import asyncio
+import uuid
+
+import httpx
+from a2a.client import (
+    A2ACardResolver,
+    A2AClientError,
+    AgentCardResolutionError,
+    Client,
+    ClientConfig,
+    ClientFactory,
+)
+from a2a.types import (
+    AgentCard,
+    CancelTaskRequest,
+    GetTaskRequest,
+    ListTasksRequest,
+    Message,
+    Part,
+    Role,
+    SendMessageConfiguration,
+    SendMessageRequest,
+    SubscribeToTaskRequest,
+    Task,
+    TaskState,
+    StreamResponse,
+)
+from a2a.utils.errors import TaskNotFoundError
+
+TENANTS = ("tenant-a", "tenant-b")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--agent", default="http://localhost:8080/")
+    args = parser.parse_args()
+    asyncio.run(run(args.agent))
+
+
+async def run(agent_url: str) -> None:
+    base_url = agent_url.rstrip("/") + "/"
+    shared_context_id = str(uuid.uuid4())
+    shared_message_id = str(uuid.uuid4())
+
+    async with httpx.AsyncClient(timeout=10) as http:
+        streaming_factory = ClientFactory(
+            ClientConfig(
+                streaming=True,
+                httpx_client=http,
+                supported_protocol_bindings=["JSONRPC"],
+            )
+        )
+        unary_factory = ClientFactory(
+            ClientConfig(
+                streaming=False,
+                httpx_client=http,
+                supported_protocol_bindings=["JSONRPC"],
+            )
+        )
+        clients: dict[str, Client] = {}
+        unary_clients: dict[str, Client] = {}
+        cards: dict[str, AgentCard] = {}
+        for tenant in TENANTS:
+            card = await resolve_tenant_card(http, base_url, tenant)
+            clients[tenant] = streaming_factory.create(card)
+            unary_clients[tenant] = unary_factory.create(card)
+            cards[tenant] = card
+
+        print("=== Python client -> A2A server ===")
+        print(f"  server          : {base_url}")
+        print(f"  shared contextId: {shared_context_id}")
+        print(f"  shared messageId: {shared_message_id}\n")
+
+        tasks: dict[str, Task] = {}
+        for tenant in TENANTS:
+            client = clients[tenant]
+            card = cards[tenant]
+            print(f"--- {tenant} ---")
+            print(f"  name       : {card.name}")
+            print(f"  description: {card.description}")
+            for iface in card.supported_interfaces:
+                print(
+                    "  interface  : "
+                    f"binding={iface.protocol_binding} "
+                    f"url={iface.url} "
+                    f"tenant={iface.tenant}"
+                )
+
+            print("\n  [send]")
+            send_text = f"hello from Python for {tenant}"
+            print(f"  input     : {send_text!r}")
+            task = await stream_task(
+                client,
+                SendMessageRequest(
+                    message=user_message(
+                        send_text,
+                        message_id=shared_message_id,
+                        context_id=shared_context_id,
+                    )
+                ),
+            )
+            if task.status.state != TaskState.TASK_STATE_COMPLETED:
+                raise RuntimeError(
+                    f"{tenant} task state is {TaskState.Name(task.status.state)}"
+                )
+            tasks[tenant] = task
+            print(f"  completed : task={task.id} result={first_artifact_text(task)!r}")
+
+            print("\n  [input-required]")
+            print(f"  input     : {'profile'!r}")
+            pending = await stream_task(
+                client,
+                SendMessageRequest(message=user_message("profile")),
+            )
+            if pending.status.state != TaskState.TASK_STATE_INPUT_REQUIRED:
+                raise RuntimeError(
+                    f"{tenant} profile task state is "
+                    f"{TaskState.Name(pending.status.state)}"
+                )
+            print(f"  input     : {'Ada'!r} (continue task={pending.id})")
+            completed = await stream_task(
+                client,
+                SendMessageRequest(
+                    message=user_message(
+                        "Ada",
+                        context_id=pending.context_id,
+                        task_id=pending.id,
+                    )
+                ),
+            )
+            if (
+                completed.id != pending.id
+                or completed.status.state != TaskState.TASK_STATE_COMPLETED
+            ):
+                raise RuntimeError(
+                    f"{tenant} continuation did not complete task {pending.id}"
+                )
+            print(
+                f"  continued : task={completed.id} "
+                f"result={first_artifact_text(completed)!r}"
+            )
+
+            print("\n  [get/list]")
+            stored = await client.get_task(
+                GetTaskRequest(id=task.id, history_length=10)
+            )
+            listed = await client.list_tasks(
+                ListTasksRequest(
+                    context_id=shared_context_id,
+                    include_artifacts=True,
+                )
+            )
+            if len(listed.tasks) != 1 or listed.tasks[0].id != task.id:
+                raise RuntimeError(
+                    f"{tenant} list leaked tenant data: {list(listed.tasks)!r}"
+                )
+            print(
+                f"  get/list  : task={stored.id} history={len(stored.history)} "
+                f"scopedTasks={len(listed.tasks)}\n"
+            )
+
+        print("--- tenant isolation ---")
+        await expect_task_not_found(clients["tenant-b"], tasks["tenant-a"].id)
+        print(f"  tenant-b cannot read tenant-a task {tasks['tenant-a'].id}")
+        await expect_task_not_found(clients["tenant-a"], tasks["tenant-b"].id)
+        print(f"  tenant-a cannot read tenant-b task {tasks['tenant-b'].id}\n")
+
+        print("--- cancellation ---")
+        running = await send_async_task(
+            unary_clients["tenant-a"],
+            SendMessageRequest(
+                message=user_message("wait"),
+                configuration=SendMessageConfiguration(return_immediately=True),
+            ),
+        )
+        subscription = clients["tenant-a"].subscribe(
+            SubscribeToTaskRequest(id=running.id)
+        )
+        first = await anext(subscription)
+        if not first.HasField("task"):
+            raise RuntimeError(f"subscription must start with Task, got {first!r}")
+        subscription_path = [describe_stream_event(first)]
+
+        await expect_cancel_not_found(unary_clients["tenant-b"], running.id)
+        await unary_clients["tenant-a"].cancel_task(
+            CancelTaskRequest(id=running.id)
+        )
+        saw_canceled = False
+        async for event in subscription:
+            subscription_path.append(describe_stream_event(event))
+            if (
+                event.HasField("status_update")
+                and event.status_update.status.state
+                == TaskState.TASK_STATE_CANCELED
+            ):
+                saw_canceled = True
+        if not saw_canceled:
+            raise RuntimeError(
+                f"subscription for task {running.id} closed without CANCELED"
+            )
+        canceled = await clients["tenant-a"].get_task(
+            GetTaskRequest(id=running.id)
+        )
+        print(f"  subscription: {' -> '.join(subscription_path)}")
+        print(
+            f"  tenant-a canceled own task={canceled.id} "
+            f"state={short_state(canceled.status.state)}; "
+            "tenant-b could not cancel it"
+        )
+
+        print("\n=== interoperability and tenant isolation verified ===")
+
+
+def user_message(
+    text: str,
+    message_id: str | None = None,
+    context_id: str | None = None,
+    task_id: str | None = None,
+) -> Message:
+    return Message(
+        role=Role.ROLE_USER,
+        message_id=message_id or str(uuid.uuid4()),
+        context_id=context_id or str(uuid.uuid4()),
+        task_id=task_id,
+        parts=[Part(text=text)],
+    )
+
+
+async def resolve_tenant_card(
+    http: httpx.AsyncClient,
+    base_url: str,
+    tenant: str,
+) -> AgentCard:
+    """Resolve either the Python path card or the Go query card."""
+    path_resolver = A2ACardResolver(http, f"{base_url}{tenant}")
+    try:
+        card = await path_resolver.get_agent_card()
+    except AgentCardResolutionError as error:
+        if error.status_code not in (400, 404):
+            raise
+        query_resolver = A2ACardResolver(http, base_url)
+        card = await query_resolver.get_agent_card(
+            http_kwargs={"params": {"tenant": tenant}}
+        )
+    return card
+
+
+async def send_async_task(client: Client, request: SendMessageRequest) -> Task:
+    events = [event async for event in client.send_message(request)]
+    if len(events) != 1 or not events[0].HasField("task"):
+        raise RuntimeError(f"expected one task response, got {events!r}")
+    return events[0].task
+
+
+async def stream_task(client: Client, request: SendMessageRequest) -> Task:
+    path: list[str] = []
+    task_id = ""
+    async for event in client.send_message(request):
+        if event.HasField("task"):
+            task_id = event.task.id
+        elif event.HasField("status_update"):
+            task_id = event.status_update.task_id
+        elif event.HasField("artifact_update"):
+            task_id = event.artifact_update.task_id
+        path.append(describe_stream_event(event))
+    if not task_id:
+        raise RuntimeError("stream closed without a task ID")
+    print(f"  stream    : {' -> '.join(path)}")
+    return await client.get_task(GetTaskRequest(id=task_id, history_length=10))
+
+
+def describe_stream_event(event: StreamResponse) -> str:
+    if event.HasField("task"):
+        return f"Task({short_state(event.task.status.state)})"
+    if event.HasField("status_update"):
+        return f"Status({short_state(event.status_update.status.state)})"
+    if event.HasField("artifact_update"):
+        return f"Artifact({event.artifact_update.artifact.artifact_id})"
+    if event.HasField("message"):
+        return "Message"
+    return "Unknown"
+
+
+def short_state(state: TaskState) -> str:
+    return TaskState.Name(state).removeprefix("TASK_STATE_")
+
+
+def first_artifact_text(task: Task) -> str:
+    if not task.artifacts:
+        return ""
+    return next((part.text for part in task.artifacts[0].parts if part.text), "")
+
+
+async def expect_task_not_found(client: Client, task_id: str) -> None:
+    try:
+        await client.get_task(GetTaskRequest(id=task_id))
+    except TaskNotFoundError:
+        return
+    except A2AClientError as error:
+        if is_wrapped_http_404(error):
+            return
+        raise
+    except httpx.HTTPStatusError as error:
+        # The Go JSON-RPC server maps TaskNotFound to HTTP 404, which is raised
+        # by the official Python transport before it decodes the JSON-RPC body.
+        if error.response.status_code == 404:
+            return
+        raise
+    raise RuntimeError(f"cross-tenant task {task_id} was visible")
+
+
+async def expect_cancel_not_found(client: Client, task_id: str) -> None:
+    try:
+        await client.cancel_task(CancelTaskRequest(id=task_id))
+    except TaskNotFoundError:
+        return
+    except A2AClientError as error:
+        if is_wrapped_http_404(error):
+            return
+        raise
+    except httpx.HTTPStatusError as error:
+        if error.response.status_code == 404:
+            return
+        raise
+    raise RuntimeError(f"cross-tenant task {task_id} was cancelable")
+
+
+def is_wrapped_http_404(error: A2AClientError) -> bool:
+    cause = error.__cause__
+    return (
+        isinstance(cause, httpx.HTTPStatusError) and cause.response.status_code == 404
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python-interop/pyproject.toml
+++ b/examples/python-interop/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "trpc-a2a-go-python-interop-example"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "a2a-sdk[http-server]==1.1.2",
+    "uvicorn>=0.35.0,<1.0.0",
+]
+
+[tool.uv]
+package = false

--- a/examples/python-interop/server/main.go
+++ b/examples/python-interop/server/main.go
@@ -1,0 +1,231 @@
+// Tencent is pleased to support the open source community by making trpc-a2a-go available.
+//
+// Copyright (C) 2025 Tencent. All rights reserved.
+//
+// trpc-a2a-go is licensed under the Apache License Version 2.0.
+
+// Package main implements the Go side of the Python SDK interoperability example.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"trpc.group/trpc-go/trpc-a2a-go/v2/log"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/server"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager/memory"
+)
+
+const (
+	tenantA = "tenant-a"
+	tenantB = "tenant-b"
+)
+
+var (
+	host = flag.String("host", "localhost", "Host to listen on")
+	port = flag.Int("port", 8080, "Port to listen on")
+)
+
+func main() {
+	flag.Parse()
+
+	manager, err := memory.NewTaskManager(&tenantProcessor{})
+	if err != nil {
+		log.Fatalf("Create task manager: %v", err)
+	}
+	endpoint := fmt.Sprintf("http://%s:%d/", *host, *port)
+	srv, err := server.NewA2AServer(
+		manager,
+		// Default card for /.well-known/agent-card.json when "?tenant=" is absent.
+		server.WithAgentCard(defaultCard(endpoint)),
+		server.WithTenantCard(tenantA, tenantCard("Go Tenant A Agent", tenantA, endpoint)),
+		server.WithTenantCard(tenantB, tenantCard("Go Tenant B Agent", tenantB, endpoint)),
+	)
+	if err != nil {
+		log.Fatalf("Create server: %v", err)
+	}
+
+	address := fmt.Sprintf("%s:%d", *host, *port)
+	go func() {
+		log.Infof("Go multi-tenant A2A server listening on %s", address)
+		if err := srv.Start(address); err != nil {
+			log.Fatalf("Server failed: %v", err)
+		}
+	}()
+
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
+	<-signals
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.Stop(ctx); err != nil {
+		log.Errorf("Server shutdown failed: %v", err)
+	}
+}
+
+type tenantProcessor struct{}
+
+func (p *tenantProcessor) ProcessMessage(
+	ctx context.Context,
+	ec *taskmanager.ExecContext,
+) (<-chan protocol.StreamEvent, error) {
+	if ec.Tenant != tenantA && ec.Tenant != tenantB {
+		return nil, fmt.Errorf("unknown tenant %q", ec.Tenant)
+	}
+	if ec.Task != nil {
+		return completeContinuation(ctx, ec), nil
+	}
+
+	switch extractText(ec.Message) {
+	case "profile":
+		return requireProfileInput(ctx, ec), nil
+	case "wait":
+		return runUntilCanceled(ctx, ec), nil
+	default:
+		return completeSimple(ctx, ec), nil
+	}
+}
+
+func requireProfileInput(ctx context.Context, ec *taskmanager.ExecContext) <-chan protocol.StreamEvent {
+	handle := taskmanager.NewTaskHandle(ctx, ec)
+	defer handle.Close()
+	_ = handle.UpdateTaskState(protocol.TaskStateSubmitted, nil)
+	_ = handle.UpdateTaskState(
+		protocol.TaskStateInputRequired,
+		protocol.NewAgentText(fmt.Sprintf("[%s] What name should I use?", ec.Tenant)),
+	)
+	return handle.Events()
+}
+
+func runUntilCanceled(ctx context.Context, ec *taskmanager.ExecContext) <-chan protocol.StreamEvent {
+	handle := taskmanager.NewTaskHandle(ctx, ec)
+	out := handle.Events()
+	go func() {
+		defer handle.Close()
+		_ = handle.UpdateTaskState(protocol.TaskStateSubmitted, nil)
+		_ = handle.UpdateTaskState(
+			protocol.TaskStateWorking,
+			protocol.NewAgentText(fmt.Sprintf("[%s] Waiting for cancellation", ec.Tenant)),
+		)
+
+		timer := time.NewTimer(30 * time.Second)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			_ = handle.UpdateTaskState(
+				protocol.TaskStateCompleted,
+				protocol.NewAgentText(fmt.Sprintf("[%s] Wait finished", ec.Tenant)),
+			)
+		}
+	}()
+	return out
+}
+
+func completeSimple(ctx context.Context, ec *taskmanager.ExecContext) <-chan protocol.StreamEvent {
+	handle := taskmanager.NewTaskHandle(ctx, ec)
+	defer handle.Close()
+
+	result := fmt.Sprintf("[%s] %s", ec.Tenant, strings.ToUpper(extractText(ec.Message)))
+	_ = handle.UpdateTaskState(protocol.TaskStateSubmitted, nil)
+	_ = handle.UpdateTaskState(protocol.TaskStateWorking, nil)
+	_ = handle.AddArtifact(protocol.Artifact{
+		ArtifactID: "result-" + handle.TaskID(),
+		Parts:      []*protocol.Part{protocol.NewTextPart(result)},
+	}, true)
+	_ = handle.UpdateTaskState(protocol.TaskStateCompleted, protocol.NewAgentText(result))
+	return handle.Events()
+}
+
+func completeContinuation(ctx context.Context, ec *taskmanager.ExecContext) <-chan protocol.StreamEvent {
+	handle := taskmanager.NewTaskHandle(ctx, ec)
+	defer handle.Close()
+
+	result := fmt.Sprintf("[%s] Hello, %s. Task %s is complete.", ec.Tenant, extractText(ec.Message), ec.Task.ID)
+	_ = handle.UpdateTaskState(protocol.TaskStateWorking, nil)
+	_ = handle.AddArtifact(protocol.Artifact{
+		ArtifactID: "profile-" + handle.TaskID(),
+		Parts:      []*protocol.Part{protocol.NewTextPart(result)},
+	}, true)
+	_ = handle.UpdateTaskState(protocol.TaskStateCompleted, protocol.NewAgentText(result))
+	return handle.Events()
+}
+
+func extractText(message protocol.Message) string {
+	var texts []string
+	for _, part := range message.Parts {
+		if text := part.TextContent(); text != "" {
+			texts = append(texts, text)
+		}
+	}
+	return strings.TrimSpace(strings.Join(texts, " "))
+}
+
+func defaultCard(endpoint string) protocol.AgentCard {
+	description := "Shared Go A2A agent for the Python interoperability example"
+	return protocol.AgentCard{
+		Name:        "Go Shared Agent",
+		Description: description,
+		SupportedInterfaces: []protocol.AgentInterface{{
+			URL:             endpoint,
+			ProtocolBinding: "JSONRPC",
+			ProtocolVersion: protocol.ProtocolVersionV1,
+		}},
+		Version: "1.0.0",
+		Capabilities: protocol.AgentCapabilities{
+			Streaming:              boolPtr(true),
+			PushNotifications:      boolPtr(false),
+			StateTransitionHistory: boolPtr(true),
+		},
+		DefaultInputModes:  []string{"text/plain"},
+		DefaultOutputModes: []string{"text/plain"},
+		Skills: []protocol.AgentSkill{{
+			ID:          "task-lifecycle",
+			Name:        "Task lifecycle",
+			Description: &description,
+			Tags:        []string{"tasks", "tenant", "interop"},
+			Examples:    []string{"hello", "profile", "wait"},
+		}},
+	}
+}
+
+func tenantCard(name, tenant, endpoint string) protocol.AgentCard {
+	description := fmt.Sprintf("A2A task lifecycle agent for %s", tenant)
+	return protocol.AgentCard{
+		Name:        name,
+		Description: description,
+		SupportedInterfaces: []protocol.AgentInterface{{
+			URL:             endpoint,
+			ProtocolBinding: "JSONRPC",
+			ProtocolVersion: protocol.ProtocolVersionV1,
+			Tenant:          tenant,
+		}},
+		Version: "1.0.0",
+		Capabilities: protocol.AgentCapabilities{
+			Streaming:              boolPtr(true),
+			PushNotifications:      boolPtr(false),
+			StateTransitionHistory: boolPtr(true),
+		},
+		DefaultInputModes:  []string{"text/plain"},
+		DefaultOutputModes: []string{"text/plain"},
+		Skills: []protocol.AgentSkill{{
+			ID:          "task-lifecycle-" + tenant,
+			Name:        "Task lifecycle",
+			Description: &description,
+			Tags:        []string{"tasks", "tenant", "interop"},
+			Examples:    []string{"hello", "profile", "wait"},
+		}},
+	}
+}
+
+func boolPtr(value bool) *bool { return &value }

--- a/examples/python-interop/server/main.py
+++ b/examples/python-interop/server/main.py
@@ -1,0 +1,227 @@
+"""Official Python SDK server for the Go/Python interoperability example."""
+
+import argparse
+import asyncio
+from collections.abc import AsyncGenerator
+
+import uvicorn
+from a2a.server.agent_execution import AgentExecutor, RequestContext
+from a2a.server.context import ServerCallContext
+from a2a.server.events import Event, EventQueue
+from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.server.routes import create_agent_card_routes, create_jsonrpc_routes
+from a2a.server.tasks import InMemoryTaskStore, TaskUpdater
+from a2a.types import (
+    AgentCapabilities,
+    AgentCard,
+    AgentInterface,
+    AgentSkill,
+    CancelTaskRequest,
+    Part,
+    SendMessageRequest,
+    Task,
+    TaskState,
+    TaskStatus,
+)
+from a2a.utils.errors import InvalidParamsError, TaskNotFoundError
+from starlette.applications import Starlette
+
+TENANTS = ("tenant-a", "tenant-b")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="localhost")
+    parser.add_argument("--port", default=8080, type=int)
+    args = parser.parse_args()
+    uvicorn.run(create_app(args.host, args.port), host=args.host, port=args.port)
+
+
+class TenantExecutor(AgentExecutor):
+    """Implements the same task lifecycle as the Go basic example."""
+
+    def __init__(self) -> None:
+        self._waiting: dict[tuple[str, str], asyncio.Event] = {}
+
+    async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
+        if context.tenant not in TENANTS:
+            raise InvalidParamsError(message=f"unknown tenant {context.tenant!r}")
+        if not context.message or not context.task_id or not context.context_id:
+            raise InvalidParamsError(message="message and task context required")
+
+        updater = TaskUpdater(
+            event_queue=event_queue,
+            task_id=context.task_id,
+            context_id=context.context_id,
+        )
+
+        if context.current_task is not None:
+            result = (
+                f"[{context.tenant}] Hello, {context.get_user_input()}. "
+                f"Task {context.task_id} is complete."
+            )
+            await updater.start_work()
+            await updater.add_artifact(
+                parts=[Part(text=result)],
+                name="profile",
+                last_chunk=True,
+            )
+            await updater.complete(updater.new_agent_message(parts=[Part(text=result)]))
+            return
+
+        await event_queue.enqueue_event(
+            Task(
+                id=context.task_id,
+                context_id=context.context_id,
+                status=TaskStatus(state=TaskState.TASK_STATE_SUBMITTED),
+                history=[context.message],
+            )
+        )
+
+        text = context.get_user_input().strip()
+        if text == "profile":
+            await updater.requires_input(
+                updater.new_agent_message(
+                    parts=[Part(text=f"[{context.tenant}] What name should I use?")]
+                )
+            )
+            return
+        if text == "wait":
+            await self._wait_for_cancel(context, updater)
+            return
+
+        result = f"[{context.tenant}] {text.upper()}"
+        await updater.start_work()
+        await updater.add_artifact(
+            parts=[Part(text=result)],
+            name="result",
+            last_chunk=True,
+        )
+        await updater.complete(updater.new_agent_message(parts=[Part(text=result)]))
+
+    async def _wait_for_cancel(
+        self, context: RequestContext, updater: TaskUpdater
+    ) -> None:
+        key = (context.tenant, context.task_id or "")
+        waiter = asyncio.Event()
+        self._waiting[key] = waiter
+        await updater.start_work(
+            updater.new_agent_message(
+                parts=[Part(text=f"[{context.tenant}] Waiting for cancellation")]
+            )
+        )
+        try:
+            await asyncio.wait_for(waiter.wait(), timeout=30)
+        except asyncio.TimeoutError:
+            result = f"[{context.tenant}] Wait finished"
+            await updater.add_artifact(
+                parts=[Part(text=result)],
+                name="wait",
+                last_chunk=True,
+            )
+            await updater.complete(updater.new_agent_message(parts=[Part(text=result)]))
+        finally:
+            self._waiting.pop(key, None)
+
+    async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
+        if not context.task_id or not context.context_id:
+            raise InvalidParamsError(message="task context required")
+        updater = TaskUpdater(
+            event_queue=event_queue,
+            task_id=context.task_id,
+            context_id=context.context_id,
+        )
+        await updater.cancel(
+            updater.new_agent_message(parts=[Part(text=f"[{context.tenant}] Canceled")])
+        )
+        waiter = self._waiting.get((context.tenant, context.task_id))
+        if waiter is not None:
+            waiter.set()
+
+
+class TenantRequestHandler(DefaultRequestHandler):
+    """Closes the active-task cancellation lookup over tenant ownership."""
+
+    async def on_message_send_stream(
+        self,
+        params: SendMessageRequest,
+        context: ServerCallContext,
+    ) -> AsyncGenerator[Event, None]:
+        if params.message.task_id:
+            task = await self.task_store.get(params.message.task_id, context)
+            if task is None:
+                raise TaskNotFoundError
+            yield task
+        async for event in super().on_message_send_stream(params, context):
+            yield event
+
+    async def on_cancel_task(
+        self,
+        params: CancelTaskRequest,
+        context: ServerCallContext,
+    ) -> Task | None:
+        if await self.task_store.get(params.id, context) is None:
+            raise TaskNotFoundError
+        return await super().on_cancel_task(params, context)
+
+
+def tenant_card(name: str, tenant: str, endpoint: str) -> AgentCard:
+    description = f"A2A task lifecycle agent for {tenant}"
+    return AgentCard(
+        name=name,
+        description=description,
+        supported_interfaces=[
+            AgentInterface(
+                url=endpoint,
+                protocol_binding="JSONRPC",
+                protocol_version="1.0",
+                tenant=tenant,
+            )
+        ],
+        version="1.0.0",
+        capabilities=AgentCapabilities(
+            streaming=True,
+            push_notifications=False,
+        ),
+        default_input_modes=["text/plain"],
+        default_output_modes=["text/plain"],
+        skills=[
+            AgentSkill(
+                id=f"task-lifecycle-{tenant}",
+                name="Task lifecycle",
+                description=description,
+                tags=["tasks", "tenant", "interop"],
+                examples=["hello", "profile", "wait"],
+            )
+        ],
+    )
+
+
+def create_app(host: str, port: int) -> Starlette:
+    endpoint = f"http://{host}:{port}/"
+    cards = {
+        "tenant-a": tenant_card("Python Tenant A Agent", "tenant-a", endpoint),
+        "tenant-b": tenant_card("Python Tenant B Agent", "tenant-b", endpoint),
+    }
+    handler = TenantRequestHandler(
+        agent_executor=TenantExecutor(),
+        # The official store defaults to user scope. Resolve ownership from
+        # tenant here so GetTask/ListTasks/CancelTask are actually isolated.
+        task_store=InMemoryTaskStore(owner_resolver=lambda context: context.tenant),
+        agent_card=cards["tenant-a"],
+    )
+    routes = [
+        *create_agent_card_routes(
+            cards["tenant-a"],
+            card_url="/tenant-a/.well-known/agent-card.json",
+        ),
+        *create_agent_card_routes(
+            cards["tenant-b"],
+            card_url="/tenant-b/.well-known/agent-card.json",
+        ),
+        *create_jsonrpc_routes(handler, rpc_url="/"),
+    ]
+    return Starlette(routes=routes)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- add Go and official Python SDK server/client implementations under `examples/python-interop`
- demonstrate streaming task creation, input-required continuation, GetTask, ListTasks, SubscribeToTask, and CancelTask
- run two tenants through shared context and message IDs while verifying cross-tenant reads and cancellation are rejected
- add `GetTenantAgentCard` with query-parameter lookup and tenant-path fallback for Go/Python server compatibility

## Compatibility

The stream clients resolve the task ID from a full Task, status update, or artifact update before fetching the aggregate task, so the example interoperates with both current Go server streams and the official Python SDK. TaskManager first-frame behavior is intentionally unchanged in this PR.

## Validation

- `GOWORK=off go test ./client`
- `GOWORK=off go test ./python-interop/server ./python-interop/client` from `examples`
- Python source compilation with the pinned `a2a-sdk[http-server]==1.1.2`
- Go server with Go client and Python client
- Python server with Go client and Python client


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tenant-specific agent-card retrieval with automatic URL fallback.
  * Added Go and Python interoperability examples demonstrating multi-tenant tasks, streaming, cancellation, and tenant isolation.

* **Documentation**
  * Added setup, usage, runtime, and tenant-routing guidance for the interoperability example.

* **Tests**
  * Added coverage for tenant parameters, custom headers, fallback behavior, and empty-tenant validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->