### PR TITLE
taskmanager/redis: cancel yielded processor contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Redis TaskManager
 
+- Publishing `input-required` or `auth-required` now cancels the yielded old round's processor context before its execution slot is released. This is round teardown rather than task cancellation: the Task stays suspended while the manager drains the processor channel, and shutdown can wait for that drain even after the execution slot has been reused.
 - **`SubscribeToTask` now uses Redis Streams on every Redis TaskManager.** Task events are journaled by default so a reconnect may land on any replica sharing Redis without configuration. `WithCrossNodeResubscribe` remains as a deprecated no-op for source compatibility.
 - **Redis 5.0 or newer is required.** Deployments must allow the Stream commands (`XADD`, `XRANGE`, and `XREVRANGE`), sorted-set commands (`ZADD`, `ZSCORE`, `ZINCRBY`, `ZCARD`, and `ZREMRANGEBYRANK`), and Lua commands used by the TaskManager. Upgrade all replicas together because older nodes do not write the event journal required by Stream-only subscribers.
 - Stream subscriptions use a size-one local response pipe, stop when their Task expires, and retry transient Redis read failures with bounded backoff instead of retaining stale subscribers indefinitely. Live executions renew their Task lease while silent, and event writes are idempotent across ambiguous Redis command retries.

--- a/docs/mkdocs/en/server.md
+++ b/docs/mkdocs/en/server.md
@@ -165,7 +165,7 @@ the request.
   | `submitted` / `working` | **`FAILED`** — "processor finished without terminal state" (a bug signal) |
   | cancellation was requested | **`CANCELED`** |
 
-- **Suspend yields the round** — emitting `input-required`/`auth-required` releases the task immediately so a continuation can start; anything the old round emits afterwards is discarded. Memory also cancels the yielded old round's `ctx` after publishing the suspend frame and before releasing the slot. This is a round-teardown signal, not `CancelTask`: the Task remains suspended. Close the old round's channel promptly and deliver completion from the continuation round.
+- **Suspend yields the round** — emitting `input-required`/`auth-required` releases the task immediately so a continuation can start; anything the old round emits afterwards is discarded. Memory and Redis also cancel the yielded old round's `ctx` after publishing the suspend frame and before releasing the slot. This is a round-teardown signal, not `CancelTask`: the Task remains suspended. Close the old round's channel promptly and deliver completion from the continuation round.
 - **Contract violations fail fast** — emitting an event for a foreign `taskId`,
   a `*protocol.Task` snapshot (framework-only in v1.0), or an invalid status
   marks an already-materialized task `FAILED` and discards the rest.
@@ -182,7 +182,7 @@ the request.
   the processor because there is no retained task to retrieve or resubscribe
   to.
 - In memory and Redis managers, `CancelTask` and manager shutdown cancel active processor work. The polite reaction is to **stop emitting and close** — the framework persists `CANCELED`. A terminal event emitted *after* the cancel still wins.
-- Memory additionally cancels a yielded round's `ctx` after publishing `input-required`/`auth-required`. This signal only tears down the old round; it does **not** mark the suspended Task `CANCELED`.
+- Memory and Redis additionally cancel a yielded round's `ctx` after publishing `input-required`/`auth-required`. This signal only tears down the old round; it does **not** mark the suspended Task `CANCELED`.
 - `CancelTask` **returns the snapshot at the moment cancellation was requested**
   (possibly still `working`); the terminal `CANCELED` lands when the round winds
   down. Canceling an already-terminal task returns `-32002`.

--- a/docs/mkdocs/zh/server.md
+++ b/docs/mkdocs/zh/server.md
@@ -143,7 +143,7 @@ Task 和会话历史；[TaskManager 实现](#taskmanager)中的 stateless manage
   | 停在 `submitted` / `working` | 标记为 `FAILED`，错误信息是 `"processor finished without terminal state"` |
   | 收到取消且没有发出终态 | 标记为 `CANCELED` |
 
-- **挂起会立刻让出任务。** 发出 `input-required` / `auth-required` 后，框架允许续跑轮次开始。旧轮次之后再发出的事件会被丢弃；Memory 还会在发布挂起帧后、释放执行槽前取消旧轮次 `ctx`。这是轮次清理信号，不等于 `CancelTask`，Task 仍保持挂起。旧轮次应尽快关闭 channel，完成结果由续跑轮次交付。
+- **挂起会立刻让出任务。** 发出 `input-required` / `auth-required` 后，框架允许续跑轮次开始。旧轮次之后再发出的事件会被丢弃；Memory 与 Redis 还会在发布挂起帧后、释放执行槽前取消旧轮次 `ctx`。这是轮次清理信号，不等于 `CancelTask`，Task 仍保持挂起。旧轮次应尽快关闭 channel，完成结果由续跑轮次交付。
 - **违反事件契约会失败。** 例如给别的 `taskId` 发事件、发 `*protocol.Task` 快照、发没有状态的 status，都会让本轮任务失败，并丢弃后续事件。
 - **挂起必须有可留存的状态。** stateless 会拒绝 `input-required` / `auth-required`，因为它无法接受这些状态要求的后续 continuation。
 
@@ -155,7 +155,7 @@ stateless manager 的轮次与请求绑定：client 断开或 manager 停机时�
 
 对于 memory 与 Redis，client 调 `CancelTask` 或 manager / server 停机会取消正在执行的 processor `ctx`。收到任务取消后，推荐做法是停止继续发送普通进度，尽快关闭 channel；如果你需要收尾，也可以发出自己的终态事件，框架会尊重它。
 
-Memory 还会在发布 `input-required` / `auth-required` 后取消已让出的旧轮次 `ctx`。该信号只用于结束旧轮次，不会把保持挂起的 Task 标成 `CANCELED`。
+Memory 与 Redis 还会在发布 `input-required` / `auth-required` 后取消已让出的旧轮次 `ctx`。该信号只用于结束旧轮次，不会把保持挂起的 Task 标成 `CANCELED`。
 
 `CancelTask` 返回的是“发起取消那一刻”的任务快照，所以它可能仍然是 `working`。最终是否落成 `CANCELED`，要等 processor 停下并关闭 channel。已经终态的任务不能取消，会返回 `-32002`。
 

--- a/taskmanager/interface.go
+++ b/taskmanager/interface.go
@@ -114,10 +114,11 @@ type ExecContext struct {
 // suspend frame; the channel itself is still drained until closed.
 //
 // For retaining managers, CancelTask and manager shutdown cancel active work.
-// The Memory manager also cancels a yielded round's ctx after publishing its
-// input-required/auth-required frame and before releasing the task slot. That is
-// round teardown, not task cancellation: the suspended Task stays unchanged and
-// the processor must close its channel promptly. A client disconnect does NOT
+// The Memory and Redis managers also cancel a yielded round's ctx after
+// publishing its input-required/auth-required frame and before releasing the
+// task slot. That is round teardown, not task cancellation: the suspended
+// Task stays unchanged and the processor must close its channel promptly. A
+// client disconnect does NOT
 // cancel retaining work, whose results remain retrievable (GetTask /
 // SubscribeToTask). A stateless manager cancels ctx on disconnect and discards
 // its request-local task. The framework always drains the channel until it is

--- a/taskmanager/redis/redis_engine.go
+++ b/taskmanager/redis/redis_engine.go
@@ -793,6 +793,11 @@ func (ex *execution) processStatusEvent(ev *protocol.TaskStatusUpdateEvent) {
 		ex.offerImmediateTask()
 		ex.broadcastWithoutPush(response)
 		ex.closePipe()
+		// The suspended round no longer owns the task after publishing its
+		// final frame. Cancel its processor context before removing it from the
+		// registry: Close cannot discover the execution once the slot is released,
+		// but still waits for its drain engine to finish.
+		ex.live.cancel()
 		ex.manager.deregisterExecution(ex.ec.Tenant, ex.ec.TaskID, ex.live)
 		return
 	}

--- a/taskmanager/redis/redis_regression_test.go
+++ b/taskmanager/redis/redis_regression_test.go
@@ -52,6 +52,70 @@ func pollTaskState(t *testing.T, m *TaskManager, taskID string, want protocol.Ta
 	t.Fatalf("task %s never reached %s (last seen %s)", taskID, want, last)
 }
 
+// A suspended round releases its execution slot before its processor channel
+// necessarily closes. Cancel the yielded round itself so Close can wait for a
+// cooperative drain engine even though that execution is no longer discoverable.
+func TestSuspend_CancelsYieldedRoundAndCloseWaitsForDrain(t *testing.T) {
+	sawCancel := make(chan struct{})
+	releaseDrain := make(chan struct{})
+	processor := executorFunc(func(
+		ctx context.Context, _ *taskmanager.ExecContext,
+	) (<-chan protocol.StreamEvent, error) {
+		out := make(chan protocol.StreamEvent, 1)
+		go func() {
+			defer close(out)
+			out <- statusEvent(protocol.TaskStateInputRequired, agentReply("need more"))
+			<-ctx.Done()
+			close(sawCancel)
+			<-releaseDrain
+		}()
+		return out, nil
+	})
+	manager, _ := setupTest(t, processor)
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseDrain) }) }
+	defer release()
+
+	stream, err := manager.OnSendMessageStream(context.Background(), sendParams("go", "ctx-yield-close"))
+	if err != nil {
+		t.Fatalf("OnSendMessageStream failed: %v", err)
+	}
+	waitStreamClosed(t, stream)
+
+	// This must happen before Close. Otherwise Close could win the small window
+	// before deregistration and hide the missing yield-time cancellation.
+	select {
+	case <-sawCancel:
+	case <-time.After(2 * time.Second):
+		t.Fatal("suspend did not cancel the yielded processor context")
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for liveExecutionCount(manager) != 0 && time.Now().Before(deadline) {
+		time.Sleep(2 * time.Millisecond)
+	}
+	if got := liveExecutionCount(manager); got != 0 {
+		t.Fatalf("yielded execution was not released: %d live", got)
+	}
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- manager.Close() }()
+	select {
+	case err := <-closeDone:
+		t.Fatalf("Close returned before the yielded drain engine finished: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	release()
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("Close failed: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close blocked after the yielded drain engine finished")
+	}
+}
+
 // A terminal state persisted by a no-live cancel must survive a yielded
 // round's late events: once round 1 suspends (yielding ownership), whatever it
 // emits afterwards is discarded instead of overwriting the store.


### PR DESCRIPTION
## Summary

- cancel a yielded Redis processor context after publishing its suspend frame and before releasing the execution slot
- keep the suspended Task unchanged: yield-time context cancellation tears down the old round and does not request Task cancellation
- preserve the existing persist, push, response, and continuation-handoff ordering
- document the Redis-specific context lifecycle in the public interface and English and Chinese guides
- add a deterministic regression proving both yield-time cancellation and `Close` waiting for the detached drain engine

## Root cause

When a Redis round emitted `input-required` or `auth-required`, the manager published the suspend event, closed the current response pipe, and removed the execution from the live registry. The drain engine still remained in `engineWg` until the processor closed its event channel.

If that processor was waiting for `ctx.Done()` before closing, manager shutdown could no longer signal it: `Close` cancels executions still present in the registry and then waits for every drain engine. The yielded execution was absent from the registry but still counted by the WaitGroup, so `Close` could block indefinitely.

## Fix

The yield path now follows this order:

1. persist the suspended Task and event
2. dispatch push and publish the suspend response
3. close the current request pipe
4. cancel the yielded old round's processor context
5. release the execution slot for continuation
6. keep draining until the processor closes its channel

The direct `cancel` call does not set `cancelRequested`, and the engine is already marked yielded. Therefore the close rule does not turn the suspended Task into `CANCELED`.

This PR is intentionally separate from #145's stream-framing changes and is based directly on `v2`.

## Compatibility

- no public Go API signatures change
- processors now observe `ctx.Done()` immediately after Redis publishes a suspend frame
- the suspended Task remains `input-required` or `auth-required`
- continuation admission, push delivery, Redis journal entries, and subscription framing are unchanged
- processors must close their event channel after observing the teardown signal; shutdown remains cooperative

## Validation

- targeted regression repeated 100 times under the race detector
- root module: `GOWORK=off go test ./...`
- root module with race detector: `GOWORK=off go test -race ./...`
- Redis nested module: `GOWORK=off go test ./...`
- Redis nested module with race detector: `GOWORK=off go test -race ./...`
- root and Redis `go vet ./...`
- root and Redis production-code `golangci-lint`
- root and Redis `go mod tidy -diff`
- docs: `mkdocs build --strict`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved task suspension cleanup by promptly canceling the active processing round after suspension events are published.
  - Ensured suspended tasks remain suspended rather than being marked canceled.
  - Improved shutdown reliability by waiting for pending event processing to finish before closing.

- **Documentation**
  - Clarified round lifecycle, cancellation behavior, channel handling, and differences between suspension cleanup and explicit task cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->