### PR TITLE
taskmanager: isolate retained state by owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
 
 - Publishing `input-required` or `auth-required` now cancels the yielded old round's processor context before its execution slot is released. This is round teardown rather than task cancellation: the Task stays suspended while the manager drains the processor channel. Shutdown rejects new resubscriptions once it begins and still waits cooperatively for processors to close their channels.
 
+### Retained task ownership
+
+- Memory and Redis TaskManagers now accept `WithOwnerResolver` to scope retained state by `(tenant, owner)`. Authentication middleware can install `auth.User` and derive the application owner through `auth.UserFromContext`; a nil resolver preserves tenant-wide sharing for compatibility.
+- Owner isolation covers task and conversation history, continuations, list/get/cancel, live execution slots, subscriptions and Redis Streams, and push configuration and delivery. Foreign owners see task-not-found, while resolver failures and empty owners are rejected before state access and surfaced as redacted internal errors.
+
 ### HTTP+JSON protocol binding
 
 - **The v2 client and server now implement the A2A v1.0 HTTP+JSON/REST binding.** It uses the standard operation routes, `application/a2a+json` request and response bodies, direct protocol objects instead of JSON-RPC envelopes, raw `StreamResponse` SSE data, and `google.rpc.Status` JSON errors. JSON-RPC remains the default for direct client construction and continues to use `application/json`.
@@ -31,6 +36,7 @@
 - **`SubscribeToTask` now uses Redis Streams on every Redis TaskManager.** Task events are journaled by default so a reconnect may land on any replica sharing Redis without configuration. `WithCrossNodeResubscribe` remains as a deprecated no-op for source compatibility.
 - **Redis 5.0 or newer is required.** Deployments must allow the Stream commands (`XADD`, `XRANGE`, and `XREVRANGE`), sorted-set commands (`ZADD`, `ZSCORE`, `ZINCRBY`, `ZCARD`, and `ZREMRANGEBYRANK`), and Lua commands used by the TaskManager. Upgrade all replicas together because older nodes do not write the event journal required by Stream-only subscribers.
 - Stream subscriptions use a size-one local response pipe, stop when their Task expires, and retry transient Redis read failures with bounded backoff instead of retaining stale subscribers indefinitely. Live executions renew their Task lease while silent, and event writes are idempotent across ambiguous Redis command retries.
+- Empty-tenant Redis data now lives under the reserved `tenant:~default:` namespace. This prerelease does not read the former unprefixed keys; drain active tasks before upgrading or migrate `task:*`, `msg:*`, `conv:*`, `taskidx:*`, `push:*`, `stream:*`, and `stream-dedupe:*` keys while preserving their TTLs and Redis Cluster hash-slot relationships.
 
 ## 2.0.0-alpha.3 (2026-07-22)
 

--- a/README.md
+++ b/README.md
@@ -123,39 +123,28 @@ An interactive `TaskHandle`-based chat example showcasing:
 - Long-running tasks started with `returnImmediately`
 - GetTask, SubscribeToTask, and CancelTask
 - Conversation grouping and message history through `contextId`
+- HTTP Basic authentication and per-user retained-task isolation
 
 See [examples/basic/README.md](examples/basic/README.md) for the REPL commands.
 
 ### 3. Authentication Examples ([examples/auth](examples/auth))
 
-Complete examples demonstrating authentication:
-- Server implementation with various authentication methods
-- Client examples showing how to connect with different auth methods
-- JWT, API key, and OAuth2 implementations
-- Command-line options for all authentication parameters
+This example chains the built-in API-key and JWT providers, derives the retained-task owner from the authenticated `auth.User`, and verifies both same-owner access and cross-owner denial for a completed Task. Use `examples/basic` for an interactive check across GetTask, SubscribeToTask, and CancelTask.
 
 ```bash
-# Start the authentication server with OAuth2 support enabled
+# Start the authentication server.
 cd examples/auth/server
-go run main.go --enable-oauth true
+go run .
 
-# Run client with JWT authentication
+# In another terminal, run as alice with an API key.
 cd examples/auth/client
-go run main.go --auth jwt --jwt-secret "your-secret-key"
+go run . -auth apikey -api-key alice-key
 
-# Run client with API key authentication
-go run main.go --auth apikey --api-key "test-api-key"
+# Or run as bob with the other API key.
+go run . -auth apikey -api-key bob-key
 
-# Run client with OAuth2 authentication
-go run main.go --auth oauth2 \
-  --oauth2-client-id "my-client-id" \
-  --oauth2-client-secret "my-client-secret"
-
-# Run client with JWT from a file
-go run main.go --auth jwt --jwt-secret-file "path/to/jwt-secret.key"
-
-# Specify custom message and session ID
-go run main.go --auth jwt --message "Custom message" --session-id "session123"
+# Or use the shared demo JWT secret.
+go run . -auth jwt
 ```
 
 ### 4. v0 Compatibility Example ([examples/compat](examples/compat))
@@ -334,6 +323,8 @@ if err := srv.Start(":8080"); err != nil {
 
 The Redis TaskManager is a separate module. Install it with
 `go get trpc.group/trpc-go/trpc-a2a-go/taskmanager/redis/v2@v2.0.0-alpha.3`.
+
+The A2A `tenant` selects an agent; it does not authorize end users. Memory and Redis keep tenant-wide retained-task sharing unless `WithOwnerResolver` is configured. After `server.WithAuthProvider` installs `auth.User`, derive the owner with `auth.UserFromContext`; see [Server: owner-scoped retained state](docs/mkdocs/en/server.md#owner-scoped-retained-state) and the runnable [basic example](examples/basic/README.md).
 
 ## Migrating from v0.x
 
@@ -540,7 +531,7 @@ client, err := client.NewA2AClient(
 )
 ```
 
-See the [examples/auth/client](examples/auth/client) directory for complete examples of using different authentication methods.
+See [examples/auth](examples/auth) for runnable JWT and API-key client/server wiring. The OAuth2 options above use the same client API with an external token endpoint.
 
 ### Push Notification Authentication
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -109,39 +109,28 @@ go run main.go
 - 通过 `returnImmediately` 启动长任务
 - GetTask、SubscribeToTask 与 CancelTask
 - 通过 `contextId` 组织会话并读取消息历史
+- HTTP Basic 鉴权与按用户隔离的留存 Task
 
 REPL 命令见 [examples/basic/README.md](examples/basic/README.md)。
 
 ### 3. 鉴权示例 ([examples/auth](examples/auth))
 
-演示鉴权的完整示例：
-- 支持多种鉴权方式的 server 实现
-- 展示如何用不同鉴权方式连接的 client 示例
-- JWT、API key 与 OAuth2 实现
-- 所有鉴权参数的命令行选项
+该示例链式组合内置 API key 和 JWT provider，从已鉴权的 `auth.User` 派生留存 Task 的 owner，并对已完成 Task 验证同 owner 可访问、跨 owner 被拒绝。GetTask、SubscribeToTask 和 CancelTask 的交互式跨 owner 验证见 `examples/basic`。
 
 ```bash
-# Start the authentication server with OAuth2 support enabled
+# 启动鉴权 server。
 cd examples/auth/server
-go run main.go --enable-oauth true
+go run .
 
-# Run client with JWT authentication
+# 在另一个终端中使用 alice 的 API key。
 cd examples/auth/client
-go run main.go --auth jwt --jwt-secret "your-secret-key"
+go run . -auth apikey -api-key alice-key
 
-# Run client with API key authentication
-go run main.go --auth apikey --api-key "test-api-key"
+# 或使用 bob 的 API key。
+go run . -auth apikey -api-key bob-key
 
-# Run client with OAuth2 authentication
-go run main.go --auth oauth2 \
-  --oauth2-client-id "my-client-id" \
-  --oauth2-client-secret "my-client-secret"
-
-# Run client with JWT from a file
-go run main.go --auth jwt --jwt-secret-file "path/to/jwt-secret.key"
-
-# Specify custom message and session ID
-go run main.go --auth jwt --message "Custom message" --session-id "session123"
+# 或使用共享的 demo JWT secret。
+go run . -auth jwt
 ```
 
 ### 4. v0 兼容示例 ([examples/compat](examples/compat))
@@ -317,6 +306,8 @@ if err := srv.Start(":8080"); err != nil {
 Redis TaskManager 作为独立 module 发布，请使用
 `go get trpc.group/trpc-go/trpc-a2a-go/taskmanager/redis/v2@v2.0.0-alpha.3` 安装。
 
+A2A 的 `tenant` 用于选择 agent，不负责最终用户授权。memory 和 Redis 默认保留 tenant 内共享的留存 Task，配置 `WithOwnerResolver` 后才会增加 owner 隔离。`server.WithAuthProvider` 写入 `auth.User` 后，可通过 `auth.UserFromContext` 派生 owner；详见[服务端：按 owner 隔离留存状态](docs/mkdocs/zh/server.md#按-owner-隔离留存状态)与可运行的 [basic 示例](examples/basic/README.md)。
+
 ## 从 v0.x 迁移
 
 v1.0（`/v2`）版本用上文所示的单一 event-stream 契约，替换了原来多结果返回的 `MessageProcessor` + `TaskHandler` 回调。熟悉的名字得以保留：你依然实现 `MessageProcessor.ProcessMessage`，原来的 `TaskHandler` 动词以 `TaskHandle` 兼容层的形式延续，因此 v0.x 的 processor 函数体只需极少改动即可迁移——包括完全同步的函数体，而它正是 v0.x 常见的写法。（wire 说明：v1.0 的 JSON-RPC 绑定将操作命名为 `SendMessage`、`SendStreamingMessage`、`GetTask`、`ListTasks`、`CancelTask`、`SubscribeToTask` 以及 `*TaskPushNotificationConfig` 的 CRUD；带斜杠的名字——`message/send`、`tasks/get`……——是 v0.2.x 的 wire，仍由 `compat/v0` 提供服务。本指南沿用迁移读者已经熟悉的 v0.x 名称来指代这些操作。）
@@ -489,7 +480,7 @@ client, err := client.NewA2AClient(
 )
 ```
 
-不同鉴权方式的完整示例见 [examples/auth/client](examples/auth/client) 目录。
+可运行的 JWT 与 API key client/server 接线见 [examples/auth](examples/auth)。上述 OAuth2 option 使用相同的 client API 连接外部 token endpoint。
 
 ### 推送通知鉴权
 

--- a/auth/provider.go
+++ b/auth/provider.go
@@ -59,6 +59,12 @@ type User struct {
 	OAuth2Info *OAuth2UserInfo
 }
 
+// UserFromContext returns the authenticated user installed by Middleware.
+func UserFromContext(ctx context.Context) (*User, bool) {
+	user, ok := ctx.Value(AuthUserKey).(*User)
+	return user, ok && user != nil
+}
+
 // OAuth2UserInfo contains additional user information from OAuth2 providers.
 type OAuth2UserInfo struct {
 	// AccessToken is the OAuth2 access token.

--- a/auth/provider_test.go
+++ b/auth/provider_test.go
@@ -7,6 +7,7 @@
 package auth_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -18,6 +19,18 @@ import (
 	"golang.org/x/oauth2"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/auth"
 )
+
+func TestUserFromContext(t *testing.T) {
+	if user, ok := auth.UserFromContext(context.Background()); ok || user != nil {
+		t.Fatalf("empty context returned user=%+v ok=%v", user, ok)
+	}
+	want := &auth.User{ID: "user-1"}
+	ctx := context.WithValue(context.Background(), auth.AuthUserKey, want)
+	got, ok := auth.UserFromContext(ctx)
+	if !ok || got != want {
+		t.Fatalf("UserFromContext() = %+v, %v; want %+v, true", got, ok, want)
+	}
+}
 
 func TestJWTAuthProvider(t *testing.T) {
 	// Setup test data

--- a/docs/mkdocs/en/client.md
+++ b/docs/mkdocs/en/client.md
@@ -141,7 +141,7 @@ c, _ := client.NewA2AClient("http://localhost:8080/",
 )
 ```
 
-Full client wiring for JWT, API key, and OAuth2:
+Runnable client/server wiring for JWT and API key:
 → [examples/auth](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples/auth).
 
 ## Calling agents from an agent (orchestration)

--- a/docs/mkdocs/en/overview.md
+++ b/docs/mkdocs/en/overview.md
@@ -22,9 +22,10 @@ the runtime contract see [Server](server.md) and [Client](client.md).
 | Blocking send, `returnImmediately`, live streaming, `SubscribeToTask` | ✅ | Four client consumption modes over the same agent. |
 | Stateless request-scoped execution | ✅ | Direct Messages and ephemeral Tasks with no retained state or conversation history. |
 | In-memory & Redis task stores | ✅ | Pluggable `TaskManager` interface; bring your own. |
+| Per-owner retained-task isolation | ✅ Opt-in | Memory and Redis use `WithOwnerResolver`; tenant routing alone is not end-user authorization. |
 | Authentication: JWT · API key · OAuth2 | ✅ | Chainable providers, server and client side. |
 | Push notifications (webhooks) signed with JWT + JWKS | ✅ | For disconnected, callback-driven operation. |
-| Multi-tenant hosting with per-tenant agent cards | ✅ | One process, many agents, routed by tenant. |
+| Multi-tenant hosting with per-tenant agent cards | ✅ | One process, many agents, routed by tenant; routing alone does not isolate users. |
 | Legacy v0.2.x wire compatibility | ✅ | `compat/v0` on the same endpoint and auth chain. |
 | Telemetry: OpenTelemetry metrics, TTFT tracking | ✅ | Pluggable meter provider and first-token policy. |
 | Cross-node `SubscribeToTask` on Redis | ✅ | Redis TaskManager journals Task events by default; Redis 5.0+ is required. |

--- a/docs/mkdocs/en/server.md
+++ b/docs/mkdocs/en/server.md
@@ -291,6 +291,34 @@ The Redis TaskManager requires Redis 5.0 or newer and atomically stores Task upd
 → [examples/redis](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples/redis).
 Implement the `taskmanager.TaskManager` interface for a custom backend.
 
+### Owner-scoped retained state
+
+The A2A `tenant` selects and routes a hosted agent; it is not an end-user authorization boundary. By default, memory and Redis preserve the compatibility behavior in which callers within one tenant share the same retained-task namespace. Configure an `OwnerResolver` when tasks must also be isolated by user, group, project, or another application-defined owner.
+
+Authentication middleware runs before TaskManager operations, so a resolver can derive the owner from `auth.User`:
+
+```go
+func resolveOwner(ctx context.Context) (string, error) {
+    user, ok := auth.UserFromContext(ctx)
+    if !ok || user.ID == "" {
+        return "", errors.New("authenticated user is missing")
+    }
+    return user.ID, nil
+}
+
+tm, _ := memory.NewTaskManager(proc, memory.WithOwnerResolver(resolveOwner))
+srv, _ := server.NewA2AServer(tm,
+    server.WithAgentCard(agentCard),
+    server.WithAuthProvider(provider),
+)
+```
+
+For Redis, pass the same resolver as `redistm.WithOwnerResolver(resolveOwner)`. The scope is `(tenant, owner)`, and covers retained task and conversation history, continuations, `ListTasks`, `GetTask`, `CancelTask`, live execution slots, `SubscribeToTask` / Redis Streams, and push-notification configuration and delivery. A caller using another owner cannot discover the task: task-addressed operations return task-not-found and list operations return only that owner's tasks.
+
+The owner is resolved once and frozen for each execution round; later task operations resolve the current caller independently. A resolver error or empty owner rejects the operation before retained state is accessed and is surfaced as a redacted internal error. A nil resolver remains supported and preserves tenant-wide sharing.
+
+Redis always namespaces the empty tenant as `tenant:~default:`. This prerelease does not read older unprefixed keys, so drain active tasks before upgrading or migrate the old keys while preserving TTLs and Redis Cluster hash-slot relationships.
+
 Retention for the stateful managers:
 
 | | memory backend | redis backend |

--- a/docs/mkdocs/zh/client.md
+++ b/docs/mkdocs/zh/client.md
@@ -234,6 +234,8 @@ c, err := client.NewA2AClient("https://agent.example.com/",
 )
 ```
 
+JWT 与 API key 的可运行 client/server 接线见 [`examples/auth`](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples/auth)。
+
 常用 option：
 
 | Option | 用途 |

--- a/docs/mkdocs/zh/index.md
+++ b/docs/mkdocs/zh/index.md
@@ -35,8 +35,8 @@ go run main.go
 | 示例 | 重点能力 |
 | --- | --- |
 | [`examples/simple`](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples/simple) | 裸 channel 最小示例；client 自动演示阻塞 send、`returnImmediately` 加轮询、streaming 和纯 Message。 |
-| [`examples/basic`](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples/basic) | `TaskHandle` 交互式 chat；长任务以及 GetTask、SubscribeToTask、CancelTask。 |
-| [`examples/auth`](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples/auth) | JWT、API key、OAuth2、鉴权后的 extended agent card。 |
+| [`examples/basic`](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples/basic) | `TaskHandle` 交互式 chat；长任务、Task 操作与跨用户 owner 隔离验证。 |
+| [`examples/auth`](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples/auth) | JWT、API key、鉴权用户与 `OwnerResolver` 接线。 |
 | [`examples/jwks`](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples/jwks) | push notification、JWT 签名、JWKS 校验。 |
 | [`examples/redis`](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples/redis) | Redis TaskManager、任务/会话持久化。 |
 | [`examples/tenant`](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples/tenant) | 一个进程托管多个 agent，按 `tenant` 路由。 |

--- a/docs/mkdocs/zh/overview.md
+++ b/docs/mkdocs/zh/overview.md
@@ -26,9 +26,10 @@ tRPC-A2A-Go 是 A2A（Agent-to-Agent）协议 v1.0 的 Go 实现。它同时提�
 | agent card 发现与扩展 card | 支持 | 公开 card、鉴权后的 extended card、v1/v0 双格式归一化。 |
 | 任务管理 | 支持 | `GetTask`、`ListTasks`、`CancelTask`，Go client 暴露为 `GetTasks`、`ListTasks`、`CancelTasks`。 |
 | 内存与 Redis 任务存储 | 支持 | 可插拔 `TaskManager` 接口；可自带实现。 |
+| 留存任务的 owner 隔离 | 可选支持 | memory / Redis 通过 `WithOwnerResolver` 开启；tenant 路由本身不等于用户授权隔离。 |
 | 鉴权 | 支持 | JWT、API key、OAuth2，可链式组合，服务端与客户端两侧都有封装。 |
 | 推送通知 | 支持 | webhook 配置 CRUD、JWT 签名、JWKS 公钥发布。 |
-| 多租户托管 | 支持 | 一个进程承载多个 agent，按请求里的 `tenant` 路由并提供租户 card。 |
+| 多租户托管 | 支持 | 一个进程承载多个 agent，按请求里的 `tenant` 路由并提供租户 card；路由本身不隔离用户。 |
 | 子路径部署 | 支持 | `WithBasePath` 适配网关或统一前缀。 |
 | legacy v0.2.x wire 兼容 | 支持 | `compat/v0` 挂到同一端点、同一鉴权链，保留 v0 默认行为。 |
 | OpenTelemetry 指标 | 支持 | 请求数、耗时、TTFT；可注入 meter provider 或让 server 创建 OTLP provider。 |

--- a/docs/mkdocs/zh/server.md
+++ b/docs/mkdocs/zh/server.md
@@ -245,6 +245,34 @@ Redis TaskManager 要求 Redis 5.0 或更高版本，并默认将 Task 更新与
 
 → [examples/redis](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples/redis)。实现 `taskmanager.TaskManager` 接口即可自带后端。
 
+### 按 owner 隔离留存状态
+
+A2A 的 `tenant` 用于选择和路由当前托管的 agent，它不是最终用户的授权边界。memory 和 Redis 默认保留兼容行为：同一 tenant 中的调用者共享留存任务命名空间。当 Task 还需要按用户、用户组、项目或其他业务 owner 隔离时，请配置 `OwnerResolver`。
+
+鉴权中间件会在 TaskManager 操作前执行，因此 resolver 可以直接从 `auth.User` 派生 owner：
+
+```go
+func resolveOwner(ctx context.Context) (string, error) {
+    user, ok := auth.UserFromContext(ctx)
+    if !ok || user.ID == "" {
+        return "", errors.New("缺少已鉴权用户")
+    }
+    return user.ID, nil
+}
+
+tm, _ := memory.NewTaskManager(proc, memory.WithOwnerResolver(resolveOwner))
+srv, _ := server.NewA2AServer(tm,
+    server.WithAgentCard(agentCard),
+    server.WithAuthProvider(provider),
+)
+```
+
+Redis 使用同一 resolver：`redistm.WithOwnerResolver(resolveOwner)`。隔离维度为 `(tenant, owner)`，覆盖 Task 与会话历史、continuation、`ListTasks`、`GetTask`、`CancelTask`、在途执行槽、`SubscribeToTask` / Redis Stream，以及 push notification 配置与投递。其他 owner 无法发现该 Task：按 Task 定址的操作返回 task-not-found，list 操作只返回当前 owner 的 Task。
+
+每个执行轮次只解析一次 owner，并在该轮内固定使用；后续跨请求的 Task 操作会独立解析当前调用者。resolver 返回错误或空 owner 时，操作会在访问留存状态前被拒绝，并对外表现为经脱敏的 internal error。resolver 为 nil 仍受支持，并保留 tenant 内共享行为。
+
+Redis 会始终将空 tenant 放入 `tenant:~default:` 命名空间。当前预发布版不读取旧的无前缀 key；升级前请先排空活跃 Task，或在保留 TTL 和 Redis Cluster hash slot 关系的前提下迁移旧 key。
+
 有状态 manager 的留存策略:
 
 | | memory 后端 | redis 后端 |
@@ -288,7 +316,7 @@ srv, _ := server.NewA2AServer(tm,
 )
 ```
 
-客户端用 `GetAuthenticatedExtendedCard` 获取；底层 wire 方法是 `GetExtendedAgentCard`。→ [examples/auth](https://github.com/trpc-group/trpc-a2a-go/tree/v2/examples/auth)。
+客户端用 `GetAuthenticatedExtendedCard` 获取；底层 wire 方法是 `GetExtendedAgentCard`。
 
 ## 推送通知
 

--- a/examples/auth/client/main.go
+++ b/examples/auth/client/main.go
@@ -4,7 +4,7 @@
 //
 // trpc-a2a-go is licensed under the Apache License Version 2.0.
 
-// Package main provides example code for using different authentication methods with the A2A client.
+// Package main demonstrates API-key and JWT authentication with the A2A client.
 package main
 
 import (
@@ -12,294 +12,105 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"os"
 	"strings"
 	"time"
 
-	"golang.org/x/oauth2/clientcredentials"
-	"trpc.group/trpc-go/trpc-a2a-go/v2/auth"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/client"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
 )
 
-// config holds the client configuration options.
-type config struct {
-	AuthMethod string
-	AgentURL   string
-	Timeout    time.Duration
+const (
+	defaultJWTSecret   = "auth-example-shared-secret"
+	defaultJWTAudience = "a2a-server"
+	defaultJWTIssuer   = "auth-example"
+)
 
-	// JWT Auth options
-	JWTSecret     string
-	JWTSecretFile string
-	JWTAudience   string
-	JWTIssuer     string
-	JWTExpiry     time.Duration
-
-	// API Key options
-	APIKey       string
-	APIKeyHeader string
-
-	// OAuth2 options
-	OAuth2ClientID     string
-	OAuth2ClientSecret string
-	OAuth2TokenURL     string
-	OAuth2Scopes       string
-
-	// Task options
-	TaskMessage string
-	SessionID   string
-}
-
-// parseFlags parses command-line flags and returns a Config.
-func parseFlags() config {
-	var config config
-
-	// Basic options
-	flag.StringVar(&config.AuthMethod, "auth", "jwt", "Authentication method (jwt, apikey, oauth2)")
-	flag.StringVar(&config.AgentURL, "url", "http://localhost:8080/", "Target A2A agent URL")
-	flag.DurationVar(&config.Timeout, "timeout", 60*time.Second, "Request timeout")
-
-	// JWT options
-	flag.StringVar(&config.JWTSecret, "jwt-secret", "my-secret-key", "JWT secret key")
-	flag.StringVar(&config.JWTSecretFile, "jwt-secret-file", "../server/jwt-secret.key", "File containing JWT secret key")
-	flag.StringVar(&config.JWTAudience, "jwt-audience", "a2a-server", "JWT audience")
-	flag.StringVar(&config.JWTIssuer, "jwt-issuer", "example", "JWT issuer")
-	flag.DurationVar(&config.JWTExpiry, "jwt-expiry", 1*time.Hour, "JWT expiration time")
-
-	// API Key options
-	flag.StringVar(&config.APIKey, "api-key", "test-api-key", "API key")
-	flag.StringVar(&config.APIKeyHeader, "api-key-header", "X-API-Key", "API key header name")
-
-	// OAuth2 options
-	flag.StringVar(&config.OAuth2ClientID, "oauth2-client-id", "my-client-id", "OAuth2 client ID")
-	flag.StringVar(&config.OAuth2ClientSecret, "oauth2-client-secret", "my-client-secret", "OAuth2 client secret")
-	flag.StringVar(&config.OAuth2TokenURL, "oauth2-token-url", "", "OAuth2 token URL (default: derived from agent URL)")
-	flag.StringVar(&config.OAuth2Scopes, "oauth2-scopes", "a2a.read,a2a.write", "OAuth2 scopes (comma-separated)")
-
-	// Task options
-	flag.StringVar(&config.TaskMessage, "message", "Hello, this is an authenticated request", "Message to send")
-	flag.StringVar(&config.SessionID, "session-id", "", "Optional session ID for the task")
-
-	flag.Parse()
-
-	return config
-}
+var (
+	url       = flag.String("url", "http://localhost:8080/", "A2A server URL")
+	method    = flag.String("auth", "apikey", "Authentication method: apikey or jwt")
+	apiKey    = flag.String("api-key", "alice-key", "API key (alice-key or bob-key)")
+	jwtSecret = flag.String("jwt-secret", defaultJWTSecret, "Shared JWT signing secret")
+	message   = flag.String("message", "Hello, authenticated world", "Message to send")
+)
 
 func main() {
-	config := parseFlags()
+	flag.Parse()
 
-	if config.AuthMethod == "" {
-		flag.Usage()
-		return
-	}
-
-	var a2aClient *client.A2AClient
-	var err error
-
-	// Create client with the specified authentication method
-	switch config.AuthMethod {
-	case "jwt":
-		a2aClient, err = createJWTClient(config)
-	case "apikey":
-		a2aClient, err = createAPIKeyClient(config)
-	case "oauth2":
-		a2aClient, err = createOAuth2Client(config)
-	default:
-		fmt.Printf("Unknown authentication method: %s\n", config.AuthMethod)
-		return
-	}
-
+	a2aClient, err := newClient(*url, *method, *apiKey, *jwtSecret)
 	if err != nil {
-		log.Fatalf("Failed to create client: %v", err)
+		log.Fatal(err)
 	}
 
-	// Create a simple task to test authentication
-	textPart := protocol.NewTextPart(config.TaskMessage)
-	message := protocol.NewMessage(protocol.MessageRoleUser, []*protocol.Part{textPart})
-
-	// Prepare message parameters
-	params := protocol.SendMessageParams{
-		Message: message,
-	}
-
-	// Add context ID if session ID is provided
-	if config.SessionID != "" {
-		// In the new protocol, we use contextID instead of sessionID
-		params.Message.ContextID = &config.SessionID
-	}
-
-	agentCard, err := a2aClient.GetAuthenticatedExtendedCard(context.Background())
-
-	if err != nil {
-		log.Fatalf("Failed to get extended card: %v", err)
-	}
-
-	fmt.Printf("Authenticated extended card: %v\n", agentCard.Name)
-	fmt.Printf("Authenticated extended card Desc: %v\n", agentCard.Description)
-
-	// Send the message
-	ctx, cancel := context.WithTimeout(context.Background(), config.Timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	result, err := a2aClient.SendMessage(ctx, params)
-
+	result, err := a2aClient.SendMessage(ctx, protocol.SendMessageParams{
+		Message: protocol.NewMessage(
+			protocol.MessageRoleUser,
+			[]*protocol.Part{protocol.NewTextPart(*message)},
+		),
+	})
 	if err != nil {
-		log.Fatalf("Failed to send message: %v", err)
+		log.Fatalf("SendMessage failed: %v", err)
 	}
 
-	// Handle the response based on its type
-	if msg := result.GetMessage(); msg != nil {
-		fmt.Printf("Message Response: %s\n", msg.MessageID)
-		if msg.ContextID != nil {
-			fmt.Printf("Context ID: %s\n", *msg.ContextID)
-		}
-		for _, part := range msg.Parts {
-			if text := part.TextContent(); text != "" {
-				fmt.Printf("Response: %s\n", text)
-			}
-		}
-	} else if task := result.GetTask(); task != nil {
-		fmt.Printf("Task ID: %s, Status: %s\n", task.ID, task.Status.State)
-		if task.ContextID != "" {
-			fmt.Printf("Context ID: %s\n", task.ContextID)
-		}
-
-		taskQuery := protocol.TaskQueryParams{
-			ID: task.ID,
-		}
-
-		updatedTask, err := a2aClient.GetTasks(ctx, taskQuery)
-		if err != nil {
-			log.Fatalf("Failed to get task: %v", err)
-		}
-
-		fmt.Printf("Updated task status: %s\n", updatedTask.Status.State)
-	} else {
-		fmt.Println("Unknown response type")
+	task := result.GetTask()
+	if task == nil {
+		log.Fatalf("Expected a task, got %T", result)
 	}
-}
-
-// getJWTSecret retrieves the JWT secret from either the direct key or a file.
-func getJWTSecret(config config) ([]byte, error) {
-	// If a secret file is provided, read from it
-	if config.JWTSecretFile != "" {
-		secret, err := os.ReadFile(config.JWTSecretFile)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read JWT secret file: %w", err)
-		}
-		return secret, nil
+	fmt.Printf("Task ID: %s\n", task.ID)
+	fmt.Printf("Status: %s\n", task.Status.State)
+	if task.Status.Message != nil {
+		fmt.Printf("Response: %s\n", extractText(*task.Status.Message))
 	}
 
-	// Otherwise use the direct secret value
-	return []byte(config.JWTSecret), nil
-}
-
-// createJWTClient creates an A2A client with JWT authentication.
-func createJWTClient(config config) (*client.A2AClient, error) {
-	secret, err := getJWTSecret(config)
+	// The owner that created the task can retrieve it.
+	stored, err := a2aClient.GetTasks(ctx, protocol.TaskQueryParams{ID: task.ID})
 	if err != nil {
-		return nil, err
+		log.Fatalf("GetTask failed: %v", err)
 	}
+	fmt.Printf("Same-owner GetTask succeeded; status=%s\n", stored.Status.State)
 
-	return client.NewA2AClient(
-		config.AgentURL,
-		client.WithJWTAuth(secret, config.JWTAudience, config.JWTIssuer, config.JWTExpiry),
-	)
-}
-
-// createAPIKeyClient creates an A2A client with API key authentication.
-func createAPIKeyClient(config config) (*client.A2AClient, error) {
-	return client.NewA2AClient(
-		config.AgentURL,
-		client.WithAPIKeyAuth(config.APIKey, config.APIKeyHeader),
-	)
-}
-
-// createOAuth2Client creates an A2A client with OAuth2 authentication.
-func createOAuth2Client(config config) (*client.A2AClient, error) {
-	// Method 1: Using client credentials flow
-	return createOAuth2ClientCredentialsClient(config)
-
-	// Alternative methods:
-	// return createOAuth2TokenSourceClient(config)
-	// return createCustomOAuth2Client(config)
-}
-
-// createOAuth2ClientCredentialsClient creates a client using OAuth2 client credentials flow.
-func createOAuth2ClientCredentialsClient(config config) (*client.A2AClient, error) {
-	// Determine token URL if not specified
-	tokenURL := config.OAuth2TokenURL
-	if tokenURL == "" {
-		tokenURL = getOAuthTokenURL(config.AgentURL)
+	// API-key mode also proves the negative path with the other demo owner.
+	if *method == "apikey" {
+		otherAPIKey := "bob-key"
+		if *apiKey == otherAPIKey {
+			otherAPIKey = "alice-key"
+		}
+		otherClient, err := newClient(*url, *method, otherAPIKey, *jwtSecret)
+		if err != nil {
+			log.Fatalf("Create cross-owner client failed: %v", err)
+		}
+		if _, err := otherClient.GetTasks(ctx, protocol.TaskQueryParams{ID: task.ID}); err == nil || !strings.Contains(
+			err.Error(), `"code":-32001`,
+		) {
+			log.Fatalf("Cross-owner GetTask error = %v, want task-not-found", err)
+		}
+		fmt.Println("Cross-owner GetTask denied with task-not-found")
 	}
+}
 
-	// Parse scopes
-	scopes := []string{}
-	if config.OAuth2Scopes != "" {
-		for _, scope := range strings.Split(config.OAuth2Scopes, ",") {
-			scopes = append(scopes, strings.TrimSpace(scope))
+func newClient(url, method, apiKey, jwtSecret string) (*client.A2AClient, error) {
+	switch method {
+	case "apikey":
+		return client.NewA2AClient(url, client.WithAPIKeyAuth(apiKey, "X-API-Key"))
+	case "jwt":
+		return client.NewA2AClient(url, client.WithJWTAuth(
+			[]byte(jwtSecret),
+			defaultJWTAudience,
+			defaultJWTIssuer,
+			time.Hour,
+		))
+	default:
+		return nil, fmt.Errorf("unsupported auth method %q: use apikey or jwt", method)
+	}
+}
+
+func extractText(message protocol.Message) string {
+	for _, part := range message.Parts {
+		if text := part.TextContent(); text != "" {
+			return text
 		}
 	}
-
-	return client.NewA2AClient(
-		config.AgentURL,
-		client.WithOAuth2ClientCredentials(config.OAuth2ClientID, config.OAuth2ClientSecret, tokenURL, scopes),
-	)
-}
-
-// createOAuth2TokenSourceClient creates a client using a custom OAuth2 token source.
-func createOAuth2TokenSourceClient(config config) (*client.A2AClient, error) {
-	// Extract the OAuth token URL from agentURL
-	tokenURL := getOAuthTokenURL(config.AgentURL)
-
-	// Example with password credentials grant
-	config.OAuth2TokenURL = tokenURL
-	config.OAuth2Scopes = "a2a.read,a2a.write"
-
-	return createOAuth2ClientCredentialsClient(config)
-}
-
-// createCustomOAuth2Client creates a client with a completely custom OAuth2 provider.
-func createCustomOAuth2Client(config config) (*client.A2AClient, error) {
-	// Extract the OAuth token URL from agentURL
-	tokenURL := getOAuthTokenURL(config.AgentURL)
-
-	// Create a client credentials config
-	ccConfig := &clientcredentials.Config{
-		ClientID:     config.OAuth2ClientID,
-		ClientSecret: config.OAuth2ClientSecret,
-		TokenURL:     tokenURL,
-		Scopes:       []string{config.OAuth2Scopes},
-	}
-
-	// Create a custom OAuth2 provider
-	provider := auth.NewOAuth2ClientCredentialsProvider(
-		ccConfig.ClientID,
-		ccConfig.ClientSecret,
-		ccConfig.TokenURL,
-		ccConfig.Scopes,
-	)
-
-	// Use the custom provider
-	return client.NewA2AClient(
-		config.AgentURL,
-		client.WithAuthProvider(provider),
-	)
-}
-
-// getOAuthTokenURL is a helper function to get the OAuth token URL based on agent URL.
-func getOAuthTokenURL(agentURL string) string {
-	tokenURL := ""
-	if agentURL == "http://localhost:8080/" {
-		tokenURL = "http://localhost:8080/oauth2/token"
-	} else {
-		// Try to adapt to a different port
-		// This is a simple adaptation, not fully robust
-		tokenURL = agentURL + "oauth2/token"
-		if tokenURL[len(tokenURL)-1] == '/' {
-			tokenURL = tokenURL[:len(tokenURL)-1]
-		}
-	}
-	fmt.Printf("Using OAuth2 token URL: %s\n", tokenURL)
-	return tokenURL
+	return ""
 }

--- a/examples/auth/server/main.go
+++ b/examples/auth/server/main.go
@@ -4,21 +4,18 @@
 //
 // trpc-a2a-go is licensed under the Apache License Version 2.0.
 
-// Package main implements an A2A server with authentication and push notification authentication.
+// Package main demonstrates built-in API-key and JWT authentication together
+// with owner-scoped task storage.
 package main
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 	"os/signal"
-	"path/filepath"
-	"strings"
 	"syscall"
 	"time"
 
@@ -29,135 +26,99 @@ import (
 	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager/memory"
 )
 
-// config holds server configuration
-type config struct {
-	Host          string
-	Port          int
-	JWTSecretFile string
-	JWTSecret     []byte
-	JWTAudience   string
-	JWTIssuer     string
-	APIKeys       map[string]string
-	APIKeyHeader  string
-	UseHTTPS      bool
-	CertFile      string
-	KeyFile       string
-	EnableOAuth   bool
-}
+const (
+	defaultJWTSecret   = "auth-example-shared-secret"
+	defaultJWTAudience = "a2a-server"
+	defaultJWTIssuer   = "auth-example"
+)
 
-// parseFlags parses command line flags and returns a configuration
-func parseFlags() *config {
-	config := &config{
-		APIKeys: map[string]string{
-			"test-api-key": "test-user",
-		},
-		APIKeyHeader: "X-API-Key",
+var (
+	apiKeys = map[string]string{
+		"alice-key": "alice",
+		"bob-key":   "bob",
 	}
-
-	flag.StringVar(&config.Host, "host", "localhost", "Host address to bind to")
-	flag.IntVar(&config.Port, "port", 8080, "Port to listen on")
-	flag.StringVar(&config.JWTSecretFile, "jwt-secret-file", "jwt-secret.key", "File to store JWT secret")
-	flag.StringVar(&config.JWTAudience, "jwt-audience", "a2a-server", "JWT audience claim")
-	flag.StringVar(&config.JWTIssuer, "jwt-issuer", "example", "JWT issuer claim")
-	flag.BoolVar(&config.UseHTTPS, "https", false, "Use HTTPS")
-	flag.StringVar(&config.CertFile, "cert", "server.crt", "TLS certificate file (for HTTPS)")
-	flag.StringVar(&config.KeyFile, "key", "server.key", "TLS key file (for HTTPS)")
-	flag.BoolVar(&config.EnableOAuth, "enable-oauth", true, "Enable OAuth2 mock server")
-
-	flag.Parse()
-	return config
-}
+	host      = flag.String("host", "localhost", "Host address to bind to")
+	port      = flag.Int("port", 8080, "Port to listen on")
+	jwtSecret = flag.String("jwt-secret", defaultJWTSecret, "Shared JWT signing secret")
+)
 
 func main() {
-	// Parse command line flags
-	config := parseFlags()
+	flag.Parse()
 
-	// Create a HTTP server mux for both the A2A server and OAuth endpoints
-	mux := http.NewServeMux()
+	baseURL := fmt.Sprintf("http://%s:%d/", *host, *port)
 
-	// Start the OAuth mock server if enabled
-	var tokenEndpoint string
-	if config.EnableOAuth {
-		oauthServer := newMockOAuthServer()
-		oauthServer.Start(mux)
-		tokenEndpoint = "http://localhost:" + fmt.Sprintf("%d", config.Port) + oauthServer.TokenEndpoint
-		log.Printf("OAuth token endpoint: %s", tokenEndpoint)
-	}
+	// The chain accepts either an API key or a JWT. Both providers return an
+	// auth.User whose ID becomes the task owner below.
+	provider := auth.NewChainAuthProvider(
+		auth.NewAPIKeyAuthProvider(apiKeys, "X-API-Key"),
+		auth.NewJWTAuthProvider(
+			[]byte(*jwtSecret),
+			defaultJWTAudience,
+			defaultJWTIssuer,
+			time.Hour,
+		),
+	)
 
-	// Create a simple echo processor for demonstration purposes
-	processor := &echoMessageProcessor{}
-
-	// Create a real task manager with our processor
-	taskManager, err := memory.NewTaskManager(processor)
+	taskManager, err := memory.NewTaskManager(
+		&echoMessageProcessor{},
+		memory.WithOwnerResolver(resolveOwner),
+	)
 	if err != nil {
 		log.Fatalf("Failed to create task manager: %v", err)
 	}
 
-	// Load or generate JWT secret
-	if err := loadOrGenerateSecret(config); err != nil {
-		log.Fatalf("Failed to setup JWT secret: %v", err)
-	}
-
-	// Create JWT auth provider
-	jwtProvider := auth.NewJWTAuthProvider(
-		config.JWTSecret,
-		config.JWTAudience,
-		config.JWTIssuer,
-		1*time.Hour,
+	srv, err := server.NewA2AServer(
+		taskManager,
+		server.WithAgentCard(buildAgentCard(baseURL)),
+		server.WithAuthProvider(provider),
 	)
-
-	// Create API key auth provider
-	apiKeyProvider := auth.NewAPIKeyAuthProvider(config.APIKeys, config.APIKeyHeader)
-
-	// Create an OAuth2 auth provider if enabled
-	var providers []auth.Provider
-	providers = append(providers, jwtProvider, apiKeyProvider)
-
-	// Add OAuth2 provider if enabled
-	if config.EnableOAuth {
-		// For server-side token validation, we use NewOAuth2AuthProviderWithConfig
-		// which is designed to validate tokens rather than generate them
-		oauth2Provider := auth.NewOAuth2AuthProviderWithConfig(
-			nil,   // No config needed for simple validation
-			"",    // No userinfo endpoint for this example
-			"sub", // Default subject field
-		)
-		providers = append(providers, oauth2Provider)
-		log.Printf("Added OAuth2 authentication provider for token validation")
+	if err != nil {
+		log.Fatalf("Failed to create A2A server: %v", err)
 	}
 
-	// Chain the auth providers
-	chainProvider := auth.NewChainAuthProvider(providers...)
+	go func() {
+		addr := fmt.Sprintf("%s:%d", *host, *port)
+		log.Printf("Starting server on %s", addr)
+		log.Printf("API keys: alice-key -> alice, bob-key -> bob")
+		log.Printf("JWT: issuer=%s audience=%s", defaultJWTIssuer, defaultJWTAudience)
+		if err := srv.Start(addr); err != nil {
+			log.Fatalf("Server failed: %v", err)
+		}
+	}()
 
-	// Create agent card with authentication info
-	authType := "apiKey,jwt"
-	if config.EnableOAuth {
-		authType += ",oauth2"
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	log.Printf("Received signal %v, shutting down", <-sigCh)
+}
+
+func resolveOwner(ctx context.Context) (string, error) {
+	user, ok := auth.UserFromContext(ctx)
+	if !ok || user.ID == "" {
+		return "", errors.New("authenticated user is missing")
 	}
+	return user.ID, nil
+}
 
-	agentCard := server.AgentCard{
-		Name:        "A2A Server with Authentication",
-		Description: "A demonstration server with JWT and API key authentication",
-		URL:         fmt.Sprintf("http://localhost:%d", config.Port),
-		Provider: &server.AgentProvider{
-			Organization: "Example Provider",
-		},
-		Version: "1.0.0",
+func buildAgentCard(baseURL string) server.AgentCard {
+	return server.AgentCard{
+		Name:        "A2A Authentication Example",
+		Description: "API-key and JWT authentication with per-user task isolation",
+		URL:         baseURL,
+		Version:     "1.0.0",
 		Capabilities: server.AgentCapabilities{
-			Streaming:              boolPtr(true),
-			PushNotifications:      boolPtr(true),
-			StateTransitionHistory: boolPtr(true),
+			Streaming:         boolPtr(false),
+			PushNotifications: boolPtr(false),
 		},
 		SecuritySchemes: map[string]server.SecurityScheme{
 			"apiKey": {
 				Type:        "apiKey",
 				Description: stringPtr("API key authentication"),
-				Name:        stringPtr(config.APIKeyHeader),
+				Name:        stringPtr("X-API-Key"),
 				In:          securitySchemeInPtr(server.SecuritySchemeInHeader),
 			},
 			"jwt": {
 				Type:         "http",
-				Description:  stringPtr("JWT Bearer token authentication"),
+				Description:  stringPtr("JWT Bearer authentication"),
 				Scheme:       stringPtr("bearer"),
 				BearerFormat: stringPtr("JWT"),
 			},
@@ -171,166 +132,16 @@ func main() {
 		Skills: []server.AgentSkill{
 			{
 				ID:          "echo",
-				Name:        "Echo Service",
-				Description: stringPtr("Echoes back the input text with authentication"),
+				Name:        "Authenticated Echo",
+				Description: stringPtr("Echoes text and returns the authenticated owner"),
 				Tags:        []string{"text", "echo", "auth"},
-				Examples:    []string{"Hello, world!"},
 				InputModes:  []string{"text"},
 				OutputModes: []string{"text"},
 			},
 		},
-		SupportsAuthenticatedExtendedCard: boolPtr(true),
 	}
-
-	// Create the server with authentication
-	a2aServer, err := server.NewA2AServer(
-		taskManager,
-		server.WithAgentCard(agentCard),
-		server.WithAuthProvider(chainProvider),
-		server.WithAuthenticatedExtendedCardHandler(
-			func(ctx context.Context, baseCard server.AgentCard) (server.AgentCard, error) {
-				baseCard.Description = "Authenticated extended card"
-				return baseCard, nil
-			},
-		),
-	)
-	if err != nil {
-		log.Fatalf("Failed to create A2A server: %v", err)
-	}
-
-	// Get A2A server http handler and add it to the mux
-	mux.Handle("/", a2aServer.Handler())
-
-	// Create an HTTP server
-	httpServer := &http.Server{
-		Addr:    fmt.Sprintf("%s:%d", config.Host, config.Port),
-		Handler: mux,
-	}
-
-	// Handle graceful shutdown
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// Setup signal handling for graceful shutdown
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-	go func() {
-		sig := <-sigCh
-		log.Printf("Received signal %v, initiating shutdown...", sig)
-		cancel()
-	}()
-
-	// Start the server in a goroutine
-	go func() {
-		log.Printf("Starting server on %s:%d...", config.Host, config.Port)
-		var err error
-		if config.UseHTTPS {
-			err = httpServer.ListenAndServeTLS(config.CertFile, config.KeyFile)
-		} else {
-			err = httpServer.ListenAndServe()
-		}
-		if err != nil && err != http.ErrServerClosed {
-			log.Fatalf("Server error: %v", err)
-		}
-	}()
-
-	// Create a token for testing
-	token, err := jwtProvider.CreateToken("test-user", nil)
-	if err != nil {
-		log.Printf("Warning: Failed to create test token: %v", err)
-	} else {
-		log.Printf("Test JWT token: %s", token)
-		printExampleCommands(config.Port, token, config.EnableOAuth, tokenEndpoint)
-	}
-
-	// Wait for context cancellation (from signal handler)
-	<-ctx.Done()
-
-	// Perform graceful shutdown with a 5-second timeout
-	shutdownCtx, shutdownCancel := context.WithTimeout(
-		context.Background(), 5*time.Second,
-	)
-	defer shutdownCancel()
-	if err := httpServer.Shutdown(shutdownCtx); err != nil {
-		log.Printf("Error during server shutdown: %v", err)
-	}
-	log.Println("Server shutdown complete")
 }
 
-// loadOrGenerateSecret loads a JWT secret from file or generates and saves a new one
-func loadOrGenerateSecret(config *config) error {
-	// Try to load existing secret
-	data, err := os.ReadFile(config.JWTSecretFile)
-	if err == nil && len(data) >= 32 {
-		log.Printf("Loaded JWT secret from %s", config.JWTSecretFile)
-		config.JWTSecret = data
-		return nil
-	}
-
-	// Generate new secret
-	config.JWTSecret = make([]byte, 32)
-	if _, err := rand.Read(config.JWTSecret); err != nil {
-		return fmt.Errorf("failed to generate JWT secret: %w", err)
-	}
-
-	// Create directory if it doesn't exist
-	dir := filepath.Dir(config.JWTSecretFile)
-	if dir != "." {
-		if err := os.MkdirAll(dir, 0700); err != nil {
-			return fmt.Errorf("failed to create directory for JWT secret: %w", err)
-		}
-	}
-
-	// Save for future use with tight permissions
-	if err := os.WriteFile(config.JWTSecretFile, config.JWTSecret, 0600); err != nil {
-		log.Printf("Warning: Could not save JWT secret to %s: %v", config.JWTSecretFile, err)
-	} else {
-		log.Printf("Generated and saved new JWT secret to %s", config.JWTSecretFile)
-	}
-
-	return nil
-}
-
-// printExampleCommands prints example curl commands for testing
-func printExampleCommands(port int, token string, enableOAuth bool, tokenEndpoint string) {
-	log.Printf("Example curl commands:")
-
-	// JWT example
-	log.Printf("Using JWT authentication:")
-	log.Printf("curl -X POST http://localhost:%d -H 'Content-Type: application/json' "+
-		"-H 'Authorization: Bearer %s' "+
-		"-d '{\"jsonrpc\":\"2.0\",\"method\":\"message/send\",\"id\":1,"+
-		"\"params\":{\"message\":{\"role\":\"user\","+
-		"\"parts\":[{\"type\":\"text\",\"text\":\"Hello, world!\"}]}}}'", port, token)
-
-	// API key example
-	log.Printf("\nUsing API key authentication:")
-	log.Printf("curl -X POST http://localhost:%d -H 'Content-Type: application/json' "+
-		"-H 'X-API-Key: test-api-key' "+
-		"-d '{\"jsonrpc\":\"2.0\",\"method\":\"message/send\",\"id\":1,"+
-		"\"params\":{\"message\":{\"role\":\"user\","+
-		"\"parts\":[{\"type\":\"text\",\"text\":\"Hello, world!\"}]}}}'", port)
-
-	// OAuth2 example if enabled
-	if enableOAuth {
-		log.Printf("\nUsing OAuth2 authentication:")
-		log.Printf("Step 1: Get OAuth2 token:")
-		log.Printf("curl -X POST %s -u my-client-id:my-client-secret "+
-			"-d 'grant_type=client_credentials&scope=a2a.read a2a.write'", tokenEndpoint)
-		log.Printf("\nStep 2: Use the token with the A2A API:")
-		log.Printf("curl -X POST http://localhost:%d -H 'Content-Type: application/json' "+
-			"-H 'Authorization: Bearer <access_token_from_step_1>' "+
-			"-d '{\"jsonrpc\":\"2.0\",\"method\":\"message/send\",\"id\":1,"+
-			"\"params\":{\"message\":{\"role\":\"user\","+
-			"\"parts\":[{\"type\":\"text\",\"text\":\"Hello, world!\"}]}}}'", port)
-	}
-
-	// Agent card example
-	log.Printf("\nFetch agent card:")
-	log.Printf("curl http://localhost:%d/.well-known/agent-card.json", port)
-}
-
-// echoMessageProcessor is a simple processor that echoes user messages
 type echoMessageProcessor struct{}
 
 func (p *echoMessageProcessor) ProcessMessage(
@@ -340,134 +151,32 @@ func (p *echoMessageProcessor) ProcessMessage(
 	handle := taskmanager.NewTaskHandle(ctx, ec)
 	defer handle.Close()
 
-	var responseText string
-	for _, part := range ec.Message.Parts {
-		if text := part.TextContent(); text != "" {
-			responseText += text + " "
-		}
+	user, _ := auth.UserFromContext(ctx)
+	text := extractText(ec.Message)
+	response := protocol.NewAgentText(fmt.Sprintf("owner=%s echo=%q", user.ID, text))
+	if err := handle.UpdateTaskState(protocol.TaskStateCompleted, response); err != nil {
+		return nil, err
 	}
-
-	// A pure message reply: no task comes into existence this round.
-	handle.Reply(protocol.NewAgentText(fmt.Sprintf("Echo: %s", responseText)))
 	return handle.Events(), nil
 }
 
-// mockOAuthServer implements a simple OAuth2 server for demonstration purposes.
-type mockOAuthServer struct {
-	// ValidCredentials maps client_id to client_secret
-	ValidCredentials map[string]string
-	// TokenEndpoint is the path for token requests (e.g., "/oauth2/token")
-	TokenEndpoint string
+func extractText(message protocol.Message) string {
+	for _, part := range message.Parts {
+		if text := part.TextContent(); text != "" {
+			return text
+		}
+	}
+	return ""
 }
 
-// newMockOAuthServer creates a new mock OAuth2 server.
-func newMockOAuthServer() *mockOAuthServer {
-	return &mockOAuthServer{
-		ValidCredentials: map[string]string{
-			"my-client-id": "my-client-secret",
-		},
-		TokenEndpoint: "/oauth2/token",
-	}
+func boolPtr(v bool) *bool {
+	return &v
 }
 
-// Start initializes the OAuth server handlers and starts the server.
-func (m *mockOAuthServer) Start(mux *http.ServeMux) {
-	mux.HandleFunc(m.TokenEndpoint, m.handleTokenRequest)
-	log.Printf("Mock OAuth2 server endpoint available at: %s", m.TokenEndpoint)
-	log.Printf("Use client_id: 'my-client-id' and client_secret: 'my-client-secret'")
+func stringPtr(v string) *string {
+	return &v
 }
 
-// handleTokenRequest processes OAuth2 token requests.
-func (m *mockOAuthServer) handleTokenRequest(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, "Failed to parse form data", http.StatusBadRequest)
-		return
-	}
-
-	// Get grant type
-	grantType := r.FormValue("grant_type")
-	if grantType != "client_credentials" {
-		http.Error(w, "Unsupported grant type", http.StatusBadRequest)
-		return
-	}
-
-	// Get client credentials
-	clientID, clientSecret := getClientCredentials(r)
-	if clientID == "" || clientSecret == "" {
-		w.Header().Set("WWW-Authenticate", `Basic realm="OAuth2 Server"`)
-		http.Error(w, "Missing client credentials", http.StatusUnauthorized)
-		return
-	}
-
-	// Validate credentials
-	validSecret, ok := m.ValidCredentials[clientID]
-	if !ok || validSecret != clientSecret {
-		http.Error(w, "Invalid client credentials", http.StatusUnauthorized)
-		return
-	}
-
-	// Get requested scopes
-	scopeStr := r.FormValue("scope")
-	scopes := []string{}
-	if scopeStr != "" {
-		scopes = strings.Split(scopeStr, " ")
-	}
-
-	// Generate token response
-	token := generateToken(clientID, scopes)
-
-	// Return the token
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(token)
-}
-
-// getClientCredentials extracts client credentials from the request.
-// Supports both Basic auth and form parameters.
-func getClientCredentials(r *http.Request) (string, string) {
-	// Try Basic auth first
-	clientID, clientSecret, ok := r.BasicAuth()
-	if ok && clientID != "" && clientSecret != "" {
-		return clientID, clientSecret
-	}
-
-	// Try form parameters
-	return r.FormValue("client_id"), r.FormValue("client_secret")
-}
-
-// TokenResponse represents an OAuth2 token response.
-type TokenResponse struct {
-	AccessToken string `json:"access_token"`
-	TokenType   string `json:"token_type"`
-	ExpiresIn   int    `json:"expires_in"`
-	Scope       string `json:"scope,omitempty"`
-	ClientID    string `json:"client_id"`
-}
-
-// generateToken creates a mock access token.
-func generateToken(clientID string, scopes []string) TokenResponse {
-	// In a real implementation, this would be a proper signed JWT
-	return TokenResponse{
-		AccessToken: "mock-access-token-" + clientID,
-		TokenType:   "Bearer",
-		ExpiresIn:   3600,
-		Scope:       strings.Join(scopes, " "),
-		ClientID:    clientID,
-	}
-}
-
-func boolPtr(b bool) *bool {
-	return &b
-}
-
-func stringPtr(s string) *string {
-	return &s
-}
-
-func securitySchemeInPtr(in server.SecuritySchemeIn) *server.SecuritySchemeIn {
-	return &in
+func securitySchemeInPtr(v server.SecuritySchemeIn) *server.SecuritySchemeIn {
+	return &v
 }

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -11,6 +11,7 @@ The example covers:
 - `GetTask`, `SubscribeToTask`, and `CancelTask`
 - Conversation grouping and server-side message history through `contextId`
 - Multiple artifact chunks aggregated into task snapshots
+- Custom `auth.Provider` + `server.WithAuthProvider` + `OwnerResolver` (per-user task isolation)
 
 For the minimal raw-channel `MessageProcessor` contract, see
 [`examples/simple`](../simple). For an `input-required` continuation flow, see
@@ -30,10 +31,13 @@ go run ./server -host 0.0.0.0 -port 9000
 go run ./server -http-json=false
 ```
 
-In another shell, run the interactive client:
+In another shell, run the interactive client (default `alice` / `alice-pass`):
 
 ```bash
 go run ./client -host localhost:8080
+
+# Run as bob to demonstrate owner isolation.
+go run ./client -host localhost:8080 -user bob -password bob-pass
 
 # Consume ordinary messages through message/stream.
 go run ./client -host localhost:8080 -stream
@@ -42,12 +46,27 @@ go run ./client -host localhost:8080 -stream
 go run ./client -host localhost:8080 -http-json=false
 ```
 
+Demo accounts: `alice` / `alice-pass`, `bob` / `bob-pass` (HTTP Basic Auth).
+A2A operation requests without valid credentials get `401 Unauthorized`; the public Agent Card remains discoverable.
+
 Useful REPL commands: `/help`, `/long-task`, `/async-long-task`, `/gettask`,
 `/subscribe`, `/cancel`, `/new`, and `/quit`.
 
 `/long-task` starts a task with `returnImmediately` and immediately subscribes
 to its events. `/async-long-task` only starts the task, leaving `/gettask`,
 `/subscribe`, and `/cancel` to be run separately.
+
+## Verify owner isolation
+
+Start an Alice client, enter `/async-long-task`, and copy the Task ID printed as `async task: id=...`. While that Task is running, start a Bob client and address Alice's ID explicitly:
+
+```text
+/gettask <alice-task-id>
+/subscribe <alice-task-id>
+/cancel <alice-task-id>
+```
+
+Each Bob operation reports task-not-found (`/subscribe` also attempts its documented `GetTask` fallback). The same `/gettask <alice-task-id>` command still succeeds in Alice's client. This proves owner isolation of retained Task lookup and live-task operations; the TaskManager tests additionally cover list, conversation, push, and Redis Stream boundaries.
 
 > `http.Client.Timeout` bounds the whole response body read. For
 > `message/stream` and `SubscribeToTask`, that includes the entire SSE

--- a/examples/basic/client/main.go
+++ b/examples/basic/client/main.go
@@ -15,10 +15,12 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"strings"
 	"time"
 
+	"trpc.group/trpc-go/trpc-a2a-go/v2/auth"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/client"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
 )
@@ -27,18 +29,15 @@ import (
 // Sent by /long-task to simulate a long-running server turn (async/subscribe/cancel).
 const longTaskMarker = "__long_task__"
 
-// session holds REPL state across turns.
-type session struct {
-	client     *client.A2AClient
-	stream     bool
-	contextID  *string
-	lastTaskID string
-}
+var (
+	host     = flag.String("host", "localhost:8080", "server address")
+	stream   = flag.Bool("stream", false, "use message/stream instead of message/send")
+	httpJSON = flag.Bool("http-json", true, "use HTTP+JSON/REST binding (false = JSON-RPC)")
+	user     = flag.String("user", "alice", "Basic Auth username (alice or bob)")
+	password = flag.String("password", "alice-pass", "Basic Auth password matching examples/basic/server")
+)
 
 func main() {
-	host := flag.String("host", "localhost:8080", "server address")
-	stream := flag.Bool("stream", false, "use message/stream instead of message/send")
-	httpJSON := flag.Bool("http-json", true, "use HTTP+JSON/REST binding (false = JSON-RPC)")
 	flag.Parse()
 
 	opts := []client.Option{
@@ -46,6 +45,7 @@ func main() {
 		// for message/stream / SubscribeToTask is the entire SSE lifetime.
 		// 60s covers the 30s /long-task demo with some headroom.
 		client.WithTimeout(60 * time.Second),
+		client.WithAuthProvider(&basicAuthClientProvider{user: *user, password: *password}),
 	}
 	binding := "JSON-RPC"
 	if *httpJSON {
@@ -62,13 +62,53 @@ func main() {
 	if *stream {
 		mode = "message/stream"
 	}
-	fmt.Printf("Connected to http://%s/ (%s, %s)\n", *host, binding, mode)
+	fmt.Printf("Connected to http://%s/ (%s, %s, user=%s)\n", *host, binding, mode, *user)
 	printHelp()
 
 	s := &session{client: a2aClient, stream: *stream}
 	if err := s.runREPL(bufio.NewScanner(os.Stdin)); err != nil {
 		log.Fatalf("Failed to read stdin: %v", err)
 	}
+}
+
+// session holds REPL state across turns.
+type session struct {
+	client     *client.A2AClient
+	stream     bool
+	contextID  *string
+	lastTaskID string
+}
+
+// basicAuthClientProvider attaches HTTP Basic Auth to every client request.
+type basicAuthClientProvider struct {
+	user     string
+	password string
+}
+
+func (p *basicAuthClientProvider) Authenticate(*http.Request) (*auth.User, error) {
+	return &auth.User{ID: p.user}, nil
+}
+
+func (p *basicAuthClientProvider) ConfigureClient(c *http.Client) *http.Client {
+	base := c.Transport
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	cloned := *c
+	cloned.Transport = &basicAuthTransport{base: base, user: p.user, password: p.password}
+	return &cloned
+}
+
+type basicAuthTransport struct {
+	base     http.RoundTripper
+	user     string
+	password string
+}
+
+func (t *basicAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	cloned := req.Clone(req.Context())
+	cloned.SetBasicAuth(t.user, t.password)
+	return t.base.RoundTrip(cloned)
 }
 
 func (s *session) runREPL(scanner *bufio.Scanner) error {

--- a/examples/basic/server/main.go
+++ b/examples/basic/server/main.go
@@ -7,18 +7,26 @@
 // Package main implements a basic A2A chat server built on the MessageProcessor
 // contract: one code path serves both message/send and message/stream, and the
 // framework owns the task lifecycle (creation, persistence, fan-out).
+//
+// Authentication and owner isolation:
+//  1. passwordAuthProvider validates HTTP Basic Auth (user/password)
+//  2. server.WithAuthProvider installs that user on the request context
+//  3. OwnerResolver maps auth.User.ID to the task-manager owner scope
 package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
 	"os/signal"
 	"strings"
 	"syscall"
 	"time"
 
+	"trpc.group/trpc-go/trpc-a2a-go/v2/auth"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/log"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/server"
@@ -35,17 +43,69 @@ const longTaskMarker = "__long_task__"
 // show the words aggregated into this full sentence.
 const longTaskSentence = "Hello from the long task demo: we stream one word per second so SubscribeToTask can show live updates and GetTask can return the aggregated sentence until CancelTasks stops us early."
 
+var (
+	host     = flag.String("host", "localhost", "Host to listen on")
+	port     = flag.Int("port", 8080, "Port to listen on")
+	httpJSON = flag.Bool("http-json", true, "also mount the HTTP+JSON/REST binding on /")
+)
+
 func main() {
-	// Parse command-line flags.
-	host := flag.String("host", "localhost", "Host to listen on")
-	port := flag.Int("port", 8080, "Port to listen on")
-	httpJSON := flag.Bool("http-json", true, "also mount the HTTP+JSON/REST binding on /")
 	flag.Parse()
 
 	baseURL := fmt.Sprintf("http://%s:%d/", *host, *port)
+	agentCard := buildAgentCard(baseURL, *httpJSON)
 
-	// Create the agent card.
-	agentCard := server.AgentCard{
+	// Auth provider → middleware → OwnerResolver: each request's User.ID becomes
+	// the task-manager owner so alice/bob cannot see each other's tasks.
+	authProvider := &passwordAuthProvider{users: demoUsers}
+
+	taskManager, err := memory.NewTaskManager(&basicMessageProcessor{}, memory.WithOwnerResolver(resolveOwner))
+	if err != nil {
+		log.Fatalf("Failed to create task manager: %v", err)
+	}
+
+	opts := []server.Option{
+		server.WithAgentCard(agentCard),
+		server.WithAuthProvider(authProvider),
+	}
+
+	// add the HTTP+JSON endpoint if the flag is set
+	if *httpJSON {
+		// set the HTTP+JSON endpoint to enable the HTTP+JSON endpoint
+		opts = append(opts, server.WithHTTPJSONEndpoint("/"))
+	}
+
+	srv, err := server.NewA2AServer(taskManager, opts...)
+	if err != nil {
+		log.Fatalf("Failed to create server: %v", err)
+	}
+
+	// Set up a channel to listen for termination signals.
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	// Start the server in a goroutine.
+	go func() {
+		serverAddr := fmt.Sprintf("%s:%d", *host, *port)
+		log.Infof("Starting server on %s...", serverAddr)
+		log.Infof("  Agent Card: %s.well-known/agent-card.json", baseURL)
+		log.Infof("  JSON-RPC:   %s", baseURL)
+		if *httpJSON {
+			log.Infof("  HTTP+JSON:  %s (e.g. /message:send, /tasks/{id})", baseURL)
+		}
+		log.Infof("  Auth:       HTTP Basic (alice/alice-pass, bob/bob-pass)")
+		if err := srv.Start(serverAddr); err != nil {
+			log.Fatalf("Server failed: %v", err)
+		}
+	}()
+
+	// Wait for termination signal.
+	sig := <-sigChan
+	log.Infof("Received signal %v, shutting down...", sig)
+}
+
+func buildAgentCard(baseURL string, httpJSON bool) server.AgentCard {
+	card := server.AgentCard{
 		Name:        "Basic A2A Chat Example Server",
 		Description: "An interactive chat example with task lifecycle operations",
 		URL:         baseURL,
@@ -76,51 +136,44 @@ func main() {
 			},
 		},
 	}
-	if *httpJSON {
-		agentCard.SupportedInterfaces = append(agentCard.SupportedInterfaces, server.AgentInterface{
+	if httpJSON {
+		card.SupportedInterfaces = append(card.SupportedInterfaces, server.AgentInterface{
 			URL: baseURL, ProtocolBinding: protocol.ProtocolBindingHTTPJSON, ProtocolVersion: protocol.ProtocolVersionV1,
 		})
 	}
+	return card
+}
 
-	// Create the processor and inject it into a task manager.
-	// (redis.NewTaskManager accepts the same MessageProcessor for persistent storage.)
-	taskManager, err := memory.NewTaskManager(&basicMessageProcessor{})
-	if err != nil {
-		log.Fatalf("Failed to create task manager: %v", err)
+// Demo users → passwords. Keep in sync with examples/basic/client defaults.
+var demoUsers = map[string]string{
+	"alice": "alice-pass",
+	"bob":   "bob-pass",
+}
+
+// passwordAuthProvider is a minimal custom auth.Provider for the example.
+type passwordAuthProvider struct {
+	users map[string]string // username -> password
+}
+
+func (p *passwordAuthProvider) Authenticate(r *http.Request) (*auth.User, error) {
+	user, password, ok := r.BasicAuth()
+	if !ok {
+		return nil, auth.ErrMissingToken
 	}
-
-	opts := []server.Option{server.WithAgentCard(agentCard)}
-	if *httpJSON {
-		opts = append(opts, server.WithHTTPJSONEndpoint("/"))
+	expected, ok := p.users[user]
+	if !ok || expected != password {
+		return nil, auth.ErrInvalidToken
 	}
+	return &auth.User{ID: user}, nil
+}
 
-	// Create the server.
-	srv, err := server.NewA2AServer(taskManager, opts...)
-	if err != nil {
-		log.Fatalf("Failed to create server: %v", err)
+// resolveOwner scopes retained tasks to the authenticated user.
+func resolveOwner(ctx context.Context) (string, error) {
+	user, ok := auth.UserFromContext(ctx)
+	if !ok || user.ID == "" {
+		return "", errors.New("unauthenticated request")
 	}
-
-	// Set up a channel to listen for termination signals.
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-
-	// Start the server in a goroutine.
-	go func() {
-		serverAddr := fmt.Sprintf("%s:%d", *host, *port)
-		log.Infof("Starting server on %s...", serverAddr)
-		log.Infof("  Agent Card: %s.well-known/agent-card.json", baseURL)
-		log.Infof("  JSON-RPC:   %s", baseURL)
-		if *httpJSON {
-			log.Infof("  HTTP+JSON:  %s (e.g. /message:send, /tasks/{id})", baseURL)
-		}
-		if err := srv.Start(serverAddr); err != nil {
-			log.Fatalf("Server failed: %v", err)
-		}
-	}()
-
-	// Wait for termination signal.
-	sig := <-sigChan
-	log.Infof("Received signal %v, shutting down...", sig)
+	return user.ID, nil
 }
 
 // basicMessageProcessor contains ordinary synchronous business logic.
@@ -135,9 +188,14 @@ func (e *basicMessageProcessor) ProcessMessage(
 ) (<-chan protocol.StreamEvent, error) {
 	handle := taskmanager.NewTaskHandle(ctx, ec)
 
+	owner := "unknown"
+	if user, ok := auth.UserFromContext(ctx); ok {
+		owner = user.ID
+	}
 	history := handle.GetMessageHistory()
 	log.Infof(
-		"Task context: taskID=%s contextID=%s historyCount=%d",
+		"Task context: owner=%s taskID=%s contextID=%s historyCount=%d",
+		owner,
 		handle.TaskID(),
 		handle.GetContextID(),
 		len(history),

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -8,7 +8,6 @@ replace trpc.group/trpc-go/trpc-a2a-go/taskmanager/redis/v2 => ../taskmanager/re
 
 require (
 	github.com/redis/go-redis/v9 v9.10.0
-	golang.org/x/oauth2 v0.26.0
 	trpc.group/trpc-go/trpc-a2a-go/taskmanager/redis/v2 v2.0.0
 	trpc.group/trpc-go/trpc-a2a-go/v2 v2.0.0
 )
@@ -44,6 +43,7 @@ require (
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.32.0 // indirect
 	golang.org/x/net v0.24.0 // indirect
+	golang.org/x/oauth2 v0.26.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240102182953-50ed04b92917 // indirect

--- a/push/dispatcher.go
+++ b/push/dispatcher.go
@@ -32,6 +32,7 @@ var ErrDispatcherClosed = errors.New("push dispatcher is closed")
 
 type job struct {
 	taskID     string
+	owner      string
 	generation string
 	cfg        []byte
 	event      []byte
@@ -43,10 +44,13 @@ type job struct {
 type Registration struct {
 	Config     protocol.TaskPushNotificationConfig `json:"config"`
 	Generation string                              `json:"generation"`
+	// Owner is the private authorization scope used to revalidate queued work.
+	// It is not part of the protocol push config and is never sent to callbacks.
+	Owner string `json:"-"`
 }
 
 // Dispatcher bounds automatic delivery while preserving FIFO order for each
-// (taskId, configId). Keys are assigned to stable worker shards; this avoids a
+// (owner, taskId, configId). Keys are assigned to stable worker shards; this avoids a
 // goroutine per webhook while allowing unrelated webhooks to make progress.
 type Dispatcher struct {
 	sender Sender
@@ -129,6 +133,7 @@ func (d *Dispatcher) Enqueue(
 		}
 		jobs[i] = job{
 			taskID:     cfg.TaskID,
+			owner:      registrations[i].Owner,
 			generation: registrations[i].Generation,
 			cfg:        cfgJSON,
 			event:      eventJSON,
@@ -136,7 +141,7 @@ func (d *Dispatcher) Enqueue(
 	}
 	for i := range jobs {
 		j := jobs[i]
-		queue := d.queues[shard(registrations[i].Config, len(d.queues))]
+		queue := d.queues[shard(registrations[i], len(d.queues))]
 		select {
 		case <-d.ctx.Done():
 			return ErrDispatcherClosed
@@ -171,7 +176,7 @@ func (d *Dispatcher) run(queue <-chan job) {
 				log.Warnf("push dispatch: restore event for task %s: %v", j.taskID, err)
 				continue
 			}
-			registration := Registration{Config: cfg, Generation: j.generation}
+			registration := Registration{Config: cfg, Generation: j.generation, Owner: j.owner}
 			if d.isCurrent != nil {
 				current, err := d.isCurrent(d.ctx, registration)
 				if err != nil {
@@ -215,8 +220,11 @@ func (d *Dispatcher) send(
 	returned = true
 }
 
-func shard(cfg protocol.TaskPushNotificationConfig, count int) int {
+func shard(registration Registration, count int) int {
 	h := fnv.New32a()
+	_, _ = h.Write([]byte(registration.Owner))
+	_, _ = h.Write([]byte{0})
+	cfg := registration.Config
 	_, _ = h.Write([]byte(cfg.TaskID))
 	_, _ = h.Write([]byte{0})
 	_, _ = h.Write([]byte(cfg.ID))

--- a/push/dispatcher_test.go
+++ b/push/dispatcher_test.go
@@ -122,6 +122,45 @@ func TestDispatcherSnapshotsInputs(t *testing.T) {
 	}
 }
 
+func TestDispatcherPreservesPrivateOwnerForValidation(t *testing.T) {
+	validated := make(chan Registration, 1)
+	delivered := make(chan struct{}, 1)
+	d := NewDispatcher(context.Background(), SenderFunc(func(
+		context.Context, protocol.TaskPushNotificationConfig, protocol.StreamResponse,
+	) error {
+		delivered <- struct{}{}
+		return nil
+	}), 1, 1, func(_ context.Context, registration Registration) (bool, error) {
+		validated <- registration
+		return true, nil
+	})
+	defer d.Close()
+
+	registration := Registration{
+		Config: protocol.TaskPushNotificationConfig{
+			TaskID: "shared-task", ID: "shared-config", URL: "https://example.com",
+		},
+		Generation: "generation-1",
+		Owner:      "alice",
+	}
+	if err := d.Enqueue([]Registration{registration}, statusResponse(protocol.TaskStateWorking)); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case got := <-validated:
+		if got.Owner != "alice" {
+			t.Fatalf("validation owner = %q, want alice", got.Owner)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("registration was not validated")
+	}
+	select {
+	case <-delivered:
+	case <-time.After(time.Second):
+		t.Fatal("push was not delivered")
+	}
+}
+
 func TestDispatcherBackpressureUnblocksOnClose(t *testing.T) {
 	started := make(chan struct{})
 	var once sync.Once

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -411,6 +411,33 @@ func TestA2AServer_HandleJSONRPC_Methods(t *testing.T) {
 	})
 }
 
+func TestA2AServerOwnerResolverErrorIsNotLeaked(t *testing.T) {
+	const sensitive = "identity lookup failed: token=secret at 10.0.0.7"
+	tm, err := memory.NewTaskManager(
+		&mockExecutor{},
+		memory.WithOwnerResolver(func(context.Context) (string, error) {
+			return "", fmt.Errorf("%s", sensitive)
+		}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, tm.Close()) })
+
+	a2aServer, err := NewA2AServer(tm, WithAgentCard(defaultAgentCard()))
+	require.NoError(t, err)
+	testServer := httptest.NewServer(http.HandlerFunc(a2aServer.handleJSONRPC))
+	t.Cleanup(testServer.Close)
+
+	resp := performJSONRPCRequest(t, testServer, protocol.MethodMessageSend, protocol.SendMessageParams{
+		Message: protocol.NewMessage(protocol.MessageRoleUser, []*protocol.Part{protocol.NewTextPart("hello")}),
+	}, "owner-resolver-error")
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, jsonrpc.CodeInternalError, resp.Error.Code)
+	assert.Nil(t, resp.Error.Data)
+	encoded, err := json.Marshal(resp)
+	require.NoError(t, err)
+	assert.NotContains(t, string(encoded), sensitive)
+}
+
 func TestA2ASrv_HandleMessageStream_SSE(t *testing.T) {
 	mockTM := newMockTaskManager()
 	agentCard := defaultAgentCard()

--- a/taskmanager/interface.go
+++ b/taskmanager/interface.go
@@ -13,6 +13,13 @@ import (
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
 )
 
+// OwnerResolver derives the application-defined owner scope for retained task
+// data from the authenticated request context. The owner may identify a user,
+// group, project, or another authorization boundary. Retaining task managers
+// use it together with the request tenant; it is never written into protocol
+// objects.
+type OwnerResolver func(context.Context) (string, error)
+
 // ExecContext is the read-only snapshot of one incoming message for a
 // MessageProcessor to process.
 type ExecContext struct {

--- a/taskmanager/memory/execution_registry.go
+++ b/taskmanager/memory/execution_registry.go
@@ -31,8 +31,8 @@ func newExecutionRegistry() *executionRegistry {
 // register publishes the cancellation handle of a starting run. A task admits
 // at most one live run; a continuation waits through the previous round's
 // short suspend handoff, while any other concurrent round is rejected.
-func (r *executionRegistry) register(ctx context.Context, tenant, taskID string, exec *execution) error {
-	key := newScopedID(tenant, taskID)
+func (r *executionRegistry) register(ctx context.Context, tenant, owner, taskID string, exec *execution) error {
+	key := newScopedID(tenant, owner, taskID)
 	for {
 		r.mu.Lock()
 		if r.closed {
@@ -65,8 +65,8 @@ func (r *executionRegistry) register(ctx context.Context, tenant, taskID string,
 
 // release aborts a registered run whose engine never started: it undoes
 // register's registration and engine count.
-func (r *executionRegistry) release(tenant, taskID string, exec *execution) {
-	r.deregister(tenant, taskID, exec)
+func (r *executionRegistry) release(tenant, owner, taskID string, exec *execution) {
+	r.deregister(tenant, owner, taskID, exec)
 	r.engines.Done()
 }
 
@@ -86,9 +86,10 @@ func (r *executionRegistry) wait() {
 // continuation can register (and then write) concurrently with it.
 func (r *executionRegistry) claimCancelSlot(
 	tenant string,
+	owner string,
 	taskID string,
 ) (live *execution, sentinel *execution, yieldDone <-chan struct{}) {
-	key := newScopedID(tenant, taskID)
+	key := newScopedID(tenant, owner, taskID)
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if exec, ok := r.executions[key]; ok {
@@ -107,10 +108,11 @@ func (r *executionRegistry) claimCancelSlot(
 // cancelRequested under the registry lock.
 func (r *executionRegistry) requestCancel(
 	tenant string,
+	owner string,
 	taskID string,
 	exec *execution,
 ) (yieldDone <-chan struct{}, accepted bool) {
-	key := newScopedID(tenant, taskID)
+	key := newScopedID(tenant, owner, taskID)
 	r.mu.Lock()
 	if r.executions[key] != exec {
 		r.mu.Unlock()
@@ -128,8 +130,8 @@ func (r *executionRegistry) requestCancel(
 }
 
 // deregister removes the handle if it still belongs to this run.
-func (r *executionRegistry) deregister(tenant, taskID string, exec *execution) {
-	key := newScopedID(tenant, taskID)
+func (r *executionRegistry) deregister(tenant, owner, taskID string, exec *execution) {
+	key := newScopedID(tenant, owner, taskID)
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.executions[key] == exec {
@@ -144,8 +146,8 @@ func (r *executionRegistry) deregister(tenant, taskID string, exec *execution) {
 // beginYield turns an active slot into a short handoff barrier. The slot
 // remains owned by exec until its suspend frame has reached every local
 // observer, but continuations wait for the handoff instead of failing.
-func (r *executionRegistry) beginYield(tenant, taskID string, exec *execution) bool {
-	key := newScopedID(tenant, taskID)
+func (r *executionRegistry) beginYield(tenant, owner, taskID string, exec *execution) bool {
+	key := newScopedID(tenant, owner, taskID)
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.executions[key] == exec && exec.yieldDone == nil && !exec.cancelRequested.Load() {
@@ -157,8 +159,8 @@ func (r *executionRegistry) beginYield(tenant, taskID string, exec *execution) b
 
 // abortYield restores an active slot when committing the suspended state fails.
 // Waiters wake and re-evaluate it as an ordinary active run.
-func (r *executionRegistry) abortYield(tenant, taskID string, exec *execution) {
-	key := newScopedID(tenant, taskID)
+func (r *executionRegistry) abortYield(tenant, owner, taskID string, exec *execution) {
+	key := newScopedID(tenant, owner, taskID)
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.executions[key] == exec && exec.yieldDone != nil {
@@ -168,10 +170,10 @@ func (r *executionRegistry) abortYield(tenant, taskID string, exec *execution) {
 }
 
 // live returns the cancellation handle of the task's live run, if any.
-func (r *executionRegistry) live(tenant, taskID string) *execution {
+func (r *executionRegistry) live(tenant, owner, taskID string) *execution {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return r.executions[newScopedID(tenant, taskID)]
+	return r.executions[newScopedID(tenant, owner, taskID)]
 }
 
 // isClosed reports whether shutdown has begun.

--- a/taskmanager/memory/memory.go
+++ b/taskmanager/memory/memory.go
@@ -42,15 +42,16 @@ type ConversationHistory struct {
 	LastAccessTime time.Time
 }
 
-// scopedID is the internal identity of tenant-owned data. Tenant remains
-// request scope and is deliberately not written into protocol.Task.
+// scopedID is the internal identity of tenant-and-owner-scoped data. Neither
+// scope component is written into protocol.Task.
 type scopedID struct {
 	tenant string
+	owner  string
 	id     string
 }
 
-func newScopedID(tenant, id string) scopedID {
-	return scopedID{tenant: tenant, id: id}
+func newScopedID(tenant, owner, id string) scopedID {
+	return scopedID{tenant: tenant, owner: owner, id: id}
 }
 
 // taskSubscriber is one fan-out endpoint of a task's event stream: the
@@ -142,7 +143,7 @@ type TaskManager struct {
 	// processor is the user-provided agent logic invoked for every incoming message.
 	processor taskmanager.MessageProcessor
 
-	// messages stores all Messages, indexed by tenant and message ID.
+	// messages stores all Messages, indexed by tenant, owner, and message ID.
 	messages map[scopedID]protocol.Message
 
 	// conversations stores the message history of each conversation, indexed by contextID
@@ -192,6 +193,20 @@ type TaskManager struct {
 }
 
 var _ taskmanager.TaskManager = (*TaskManager)(nil)
+
+func (m *TaskManager) resolveOwner(ctx context.Context) (string, error) {
+	if m.options.OwnerResolver == nil {
+		return "", nil
+	}
+	owner, err := m.options.OwnerResolver(ctx)
+	if err != nil {
+		return "", taskmanager.ErrInternalError(fmt.Sprintf("resolve task owner: %v", err))
+	}
+	if owner == "" {
+		return "", taskmanager.ErrInternalError("task owner resolver returned an empty owner")
+	}
+	return owner, nil
+}
 
 // NewTaskManager creates a new TaskManager instance driven by the given MessageProcessor.
 func NewTaskManager(processor taskmanager.MessageProcessor, opts ...TaskManagerOption) (*TaskManager, error) {
@@ -280,10 +295,10 @@ func (m *TaskManager) OnSendMessage(
 		// engine keep running; later state is retrievable via GetTask/subscribe.
 		select {
 		case out := <-eng.immediateResult:
-			return m.buildSendResponse(request.Tenant, out.task, out.message, historyLength)
+			return m.buildSendResponse(request.Tenant, eng.owner, out.task, out.message, historyLength)
 		case <-eng.done:
 			// The stream closed before any immediate result: same derivation as blocking.
-			return m.buildSendResponse(request.Tenant, eng.finalOutcome.task, eng.finalOutcome.message, historyLength)
+			return m.buildSendResponse(request.Tenant, eng.owner, eng.finalOutcome.task, eng.finalOutcome.message, historyLength)
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		}
@@ -291,7 +306,7 @@ func (m *TaskManager) OnSendMessage(
 
 	select {
 	case <-eng.done:
-		return m.buildSendResponse(request.Tenant, eng.finalOutcome.task, eng.finalOutcome.message, historyLength)
+		return m.buildSendResponse(request.Tenant, eng.owner, eng.finalOutcome.task, eng.finalOutcome.message, historyLength)
 	case <-ctx.Done():
 		// The request died first. The execution is detached (§3.3): it keeps
 		// running and its results stay retrievable via GetTask/resubscribe.
@@ -330,7 +345,11 @@ func (m *TaskManager) OnSendMessageStream(
 
 // OnGetTask handles the tasks/get request
 func (m *TaskManager) OnGetTask(ctx context.Context, params protocol.TaskQueryParams) (*protocol.Task, error) {
-	key := newScopedID(params.Tenant, params.ID)
+	owner, err := m.resolveOwner(ctx)
+	if err != nil {
+		return nil, err
+	}
+	key := newScopedID(params.Tenant, owner, params.ID)
 	m.taskMu.RLock()
 	task, exists := m.tasks[key]
 	if !exists {
@@ -342,7 +361,7 @@ func (m *TaskManager) OnGetTask(ctx context.Context, params protocol.TaskQueryPa
 	taskCopy := copyTask(task)
 	m.taskMu.RUnlock()
 
-	m.fillTaskHistory(params.Tenant, taskCopy, params.HistoryLength)
+	m.fillTaskHistory(params.Tenant, owner, taskCopy, params.HistoryLength)
 	return taskCopy, nil
 }
 
@@ -354,8 +373,12 @@ func (m *TaskManager) OnGetTask(ctx context.Context, params protocol.TaskQueryPa
 // manager persists CANCELED directly, holding the execution slot with a
 // sentinel so no continuation can start (and write) concurrently.
 func (m *TaskManager) OnCancelTask(ctx context.Context, params protocol.TaskIDParams) (*protocol.Task, error) {
+	owner, err := m.resolveOwner(ctx)
+	if err != nil {
+		return nil, err
+	}
 	for {
-		live, sentinel, yieldDone := m.runs.claimCancelSlot(params.Tenant, params.ID)
+		live, sentinel, yieldDone := m.runs.claimCancelSlot(params.Tenant, owner, params.ID)
 		if yieldDone != nil {
 			select {
 			case <-yieldDone:
@@ -365,14 +388,14 @@ func (m *TaskManager) OnCancelTask(ctx context.Context, params protocol.TaskIDPa
 			}
 		}
 		if live == nil {
-			defer m.runs.deregister(params.Tenant, params.ID, sentinel)
-			return m.cancelWithoutLiveRun(params)
+			defer m.runs.deregister(params.Tenant, owner, params.ID, sentinel)
+			return m.cancelWithoutLiveRun(owner, params)
 		}
 
 		// A stored terminal state is immutable even while the round is still
 		// draining: canceling it must fail like the no-live path does.
 		m.taskMu.RLock()
-		task, exists := m.tasks[newScopedID(params.Tenant, params.ID)]
+		task, exists := m.tasks[newScopedID(params.Tenant, owner, params.ID)]
 		var snapshot *protocol.Task
 		var terminal protocol.TaskState
 		if exists {
@@ -389,7 +412,7 @@ func (m *TaskManager) OnCancelTask(ctx context.Context, params protocol.TaskIDPa
 		// Linearize cancellation against a concurrent suspend handoff. If the
 		// handoff won, wait for it and retry as a no-live cancel; otherwise the
 		// close rule is guaranteed to observe cancelRequested.
-		yieldDone, accepted := m.runs.requestCancel(params.Tenant, params.ID, live)
+		yieldDone, accepted := m.runs.requestCancel(params.Tenant, owner, params.ID, live)
 		if yieldDone != nil {
 			select {
 			case <-yieldDone:
@@ -402,7 +425,7 @@ func (m *TaskManager) OnCancelTask(ctx context.Context, params protocol.TaskIDPa
 			continue
 		}
 
-		if m.runs.live(params.Tenant, params.ID) != live {
+		if m.runs.live(params.Tenant, owner, params.ID) != live {
 			// The run yielded (suspend) or finished while we were canceling, so
 			// its close rule will not persist CANCELED on our behalf. Reassess:
 			// the next pass either claims the free slot and persists CANCELED
@@ -421,8 +444,8 @@ func (m *TaskManager) OnCancelTask(ctx context.Context, params protocol.TaskIDPa
 // cancelWithoutLiveRun persists CANCELED for a task with no live execution:
 // persist first, then broadcast (§3.6). The caller holds the task's execution
 // slot (sentinel), making this the task's single writer.
-func (m *TaskManager) cancelWithoutLiveRun(params protocol.TaskIDParams) (*protocol.Task, error) {
-	key := newScopedID(params.Tenant, params.ID)
+func (m *TaskManager) cancelWithoutLiveRun(owner string, params protocol.TaskIDParams) (*protocol.Task, error) {
+	key := newScopedID(params.Tenant, owner, params.ID)
 	m.taskMu.Lock()
 	task, exists := m.tasks[key]
 	if !exists {
@@ -447,8 +470,8 @@ func (m *TaskManager) cancelWithoutLiveRun(params protocol.TaskIDParams) (*proto
 	result := copyTask(task)
 	m.taskMu.Unlock()
 
-	m.notifySubscribers(params.Tenant, params.ID, protocol.NewStreamResponseStatusUpdate(event))
-	m.cleanSubscribers(params.Tenant, params.ID)
+	m.notifySubscribers(params.Tenant, owner, params.ID, protocol.NewStreamResponseStatusUpdate(event))
+	m.cleanSubscribers(params.Tenant, owner, params.ID)
 	return result, nil
 }
 
@@ -457,16 +480,20 @@ func (m *TaskManager) OnPushNotificationSet(
 	ctx context.Context,
 	params protocol.TaskPushNotificationConfig,
 ) (*protocol.TaskPushNotificationConfig, error) {
+	owner, err := m.resolveOwner(ctx)
+	if err != nil {
+		return nil, err
+	}
 	if !m.pushEnabled {
 		return nil, taskmanager.ErrPushNotificationNotSupported()
 	}
 	if err := push.ValidateConfig(params); err != nil {
 		return nil, taskmanager.ErrInvalidParams(err.Error())
 	}
-	if err := m.ensurePushTaskExists(params.Tenant, params.TaskID); err != nil {
+	if err := m.ensurePushTaskExists(params.Tenant, owner, params.TaskID); err != nil {
 		return nil, err
 	}
-	stored, err := m.pushStore.save(params)
+	stored, err := m.pushStore.save(owner, params)
 	if err != nil {
 		return nil, err
 	}
@@ -479,16 +506,20 @@ func (m *TaskManager) OnPushNotificationGet(
 	ctx context.Context,
 	params protocol.GetTaskPushNotificationConfigParams,
 ) (*protocol.TaskPushNotificationConfig, error) {
+	owner, err := m.resolveOwner(ctx)
+	if err != nil {
+		return nil, err
+	}
 	if !m.pushEnabled {
 		return nil, taskmanager.ErrPushNotificationNotSupported()
 	}
 	if params.ID == "" {
 		return nil, taskmanager.ErrInvalidParams("push notification config ID is required")
 	}
-	if err := m.ensurePushTaskExists(params.Tenant, params.TaskID); err != nil {
+	if err := m.ensurePushTaskExists(params.Tenant, owner, params.TaskID); err != nil {
 		return nil, err
 	}
-	config, found := m.pushStore.get(params.Tenant, params.TaskID, params.ID)
+	config, found := m.pushStore.get(params.Tenant, owner, params.TaskID, params.ID)
 	if !found {
 		return nil, taskmanager.ErrPushConfigNotFound(params.TaskID)
 	}
@@ -500,6 +531,10 @@ func (m *TaskManager) OnListTasks(
 	ctx context.Context,
 	params protocol.ListTasksParams,
 ) (*protocol.ListTasksResult, error) {
+	owner, err := m.resolveOwner(ctx)
+	if err != nil {
+		return nil, err
+	}
 	afterTime, err := taskmanager.ParseListTasksStatusTimestampAfter(params.StatusTimestampAfter)
 	if err != nil {
 		return nil, err
@@ -511,7 +546,7 @@ func (m *TaskManager) OnListTasks(
 	defer m.taskMu.RUnlock()
 	var filtered []*protocol.Task
 	for key, task := range m.tasks {
-		if key.tenant != params.Tenant {
+		if key.tenant != params.Tenant || key.owner != owner {
 			continue
 		}
 		if taskmanager.TaskMatchesListFilter(task, params, afterTime) {
@@ -527,13 +562,17 @@ func (m *TaskManager) OnPushNotificationList(
 	ctx context.Context,
 	params protocol.ListTaskPushNotificationConfigsParams,
 ) (*protocol.ListTaskPushNotificationConfigsResult, error) {
+	owner, err := m.resolveOwner(ctx)
+	if err != nil {
+		return nil, err
+	}
 	if !m.pushEnabled {
 		return nil, taskmanager.ErrPushNotificationNotSupported()
 	}
-	if err := m.ensurePushTaskExists(params.Tenant, params.TaskID); err != nil {
+	if err := m.ensurePushTaskExists(params.Tenant, owner, params.TaskID); err != nil {
 		return nil, err
 	}
-	configs := m.pushStore.list(params.Tenant, params.TaskID)
+	configs := m.pushStore.list(params.Tenant, owner, params.TaskID)
 	return &protocol.ListTaskPushNotificationConfigsResult{Configs: configs}, nil
 }
 
@@ -543,23 +582,27 @@ func (m *TaskManager) OnPushNotificationDelete(
 	ctx context.Context,
 	params protocol.DeleteTaskPushNotificationConfigParams,
 ) error {
+	owner, err := m.resolveOwner(ctx)
+	if err != nil {
+		return err
+	}
 	if !m.pushEnabled {
 		return taskmanager.ErrPushNotificationNotSupported()
 	}
 	if params.ID == "" {
 		return taskmanager.ErrInvalidParams("push notification config ID is required")
 	}
-	if err := m.ensurePushTaskExists(params.Tenant, params.TaskID); err != nil {
+	if err := m.ensurePushTaskExists(params.Tenant, owner, params.TaskID); err != nil {
 		return err
 	}
-	m.pushStore.remove(params.Tenant, params.TaskID, params.ID)
+	m.pushStore.remove(params.Tenant, owner, params.TaskID, params.ID)
 	log.Debugf("TaskManager: Push notification config %s deleted for task %s", params.ID, params.TaskID)
 	return nil
 }
 
-func (m *TaskManager) ensurePushTaskExists(tenant, taskID string) error {
+func (m *TaskManager) ensurePushTaskExists(tenant, owner, taskID string) error {
 	m.taskMu.RLock()
-	_, exists := m.tasks[newScopedID(tenant, taskID)]
+	_, exists := m.tasks[newScopedID(tenant, owner, taskID)]
 	m.taskMu.RUnlock()
 	if !exists {
 		return taskmanager.ErrTaskNotFound(taskID)
@@ -572,6 +615,10 @@ func (m *TaskManager) OnResubscribe(
 	ctx context.Context,
 	params protocol.TaskIDParams,
 ) (<-chan protocol.StreamResponse, error) {
+	owner, err := m.resolveOwner(ctx)
+	if err != nil {
+		return nil, err
+	}
 	m.taskMu.Lock()
 	defer m.taskMu.Unlock()
 	// Close marks the execution registry closed before sweeping subscribers.
@@ -581,7 +628,7 @@ func (m *TaskManager) OnResubscribe(
 	if m.runs.isClosed() {
 		return nil, taskmanager.ErrInternalError("task manager is closed")
 	}
-	key := newScopedID(params.Tenant, params.ID)
+	key := newScopedID(params.Tenant, owner, params.ID)
 
 	// Check if task exists
 	task, exists := m.tasks[key]
@@ -620,7 +667,7 @@ func (m *TaskManager) OnResubscribe(
 	go func() {
 		select {
 		case <-ctx.Done():
-			m.cleanupFailedSubscribers(params.Tenant, params.ID, []*taskSubscriber{subscriber})
+			m.cleanupFailedSubscribers(params.Tenant, owner, params.ID, []*taskSubscriber{subscriber})
 		case <-subscriber.done:
 		}
 	}()
@@ -633,17 +680,17 @@ func (m *TaskManager) OnResubscribe(
 // =============================================================================
 
 // storeMessage stores messages
-func (m *TaskManager) storeMessage(tenant string, message protocol.Message) {
+func (m *TaskManager) storeMessage(tenant, owner string, message protocol.Message) {
 	m.conversationMu.Lock()
 	defer m.conversationMu.Unlock()
 
 	// Store the message
-	m.messages[newScopedID(tenant, message.MessageID)] = message
+	m.messages[newScopedID(tenant, owner, message.MessageID)] = message
 
 	// If the message has a contextID, add it to conversation history
 	if message.ContextID != nil {
 		contextID := *message.ContextID
-		conversationKey := newScopedID(tenant, contextID)
+		conversationKey := newScopedID(tenant, owner, contextID)
 		conv, exists := m.conversations[conversationKey]
 		if !exists {
 			conv = &ConversationHistory{
@@ -674,13 +721,13 @@ func (m *TaskManager) storeMessage(tenant string, message protocol.Message) {
 			removedMsgID := conv.MessageIDs[0]
 			conv.MessageIDs = conv.MessageIDs[1:]
 			// Delete old message from message storage
-			delete(m.messages, newScopedID(tenant, removedMsgID))
+			delete(m.messages, newScopedID(tenant, owner, removedMsgID))
 		}
 	}
 }
 
 // getConversationHistory gets conversation history of specified length
-func (m *TaskManager) getConversationHistory(tenant, contextID string, length int) []protocol.Message {
+func (m *TaskManager) getConversationHistory(tenant, owner, contextID string, length int) []protocol.Message {
 	// LastAccessTime is mutated below: this must be the write lock (a read
 	// lock here races concurrent history reads and tears the time value).
 	m.conversationMu.Lock()
@@ -688,7 +735,7 @@ func (m *TaskManager) getConversationHistory(tenant, contextID string, length in
 
 	var history []protocol.Message
 
-	if conversation, exists := m.conversations[newScopedID(tenant, contextID)]; exists {
+	if conversation, exists := m.conversations[newScopedID(tenant, owner, contextID)]; exists {
 		// Update last access time
 		conversation.LastAccessTime = time.Now()
 
@@ -698,7 +745,7 @@ func (m *TaskManager) getConversationHistory(tenant, contextID string, length in
 		}
 
 		for i := start; i < len(conversation.MessageIDs); i++ {
-			if msg, exists := m.messages[newScopedID(tenant, conversation.MessageIDs[i])]; exists {
+			if msg, exists := m.messages[newScopedID(tenant, owner, conversation.MessageIDs[i])]; exists {
 				history = append(history, msg)
 			}
 		}
@@ -712,22 +759,22 @@ func (m *TaskManager) getConversationHistory(tenant, contextID string, length in
 //   - historyLength unset -> no limit (full history)
 //   - historyLength == 0  -> no messages
 //   - historyLength > 0   -> the most recent N messages
-func (m *TaskManager) fillTaskHistory(tenant string, task *protocol.Task, historyLength *int) {
+func (m *TaskManager) fillTaskHistory(tenant, owner string, task *protocol.Task, historyLength *int) {
 	if task.ContextID == "" {
 		return
 	}
 	switch {
 	case historyLength == nil:
-		task.History = m.getConversationHistory(tenant, task.ContextID, unlimitedHistoryLength)
+		task.History = m.getConversationHistory(tenant, owner, task.ContextID, unlimitedHistoryLength)
 	case *historyLength > 0:
-		task.History = m.getConversationHistory(tenant, task.ContextID, *historyLength)
+		task.History = m.getConversationHistory(tenant, owner, task.ContextID, *historyLength)
 	default: // == 0 (or negative): no messages
 		task.History = nil
 	}
 }
 
 // processReplyMessage processes the reply message, add messageID and contextID if not set
-func (m *TaskManager) processReplyMessage(tenant string, ctxID *string, message *protocol.Message) {
+func (m *TaskManager) processReplyMessage(tenant, owner string, ctxID *string, message *protocol.Message) {
 	message.ContextID = ctxID
 	message.Role = protocol.MessageRoleAgent
 
@@ -740,7 +787,7 @@ func (m *TaskManager) processReplyMessage(tenant string, ctxID *string, message 
 		message.ContextID = &contextID
 	}
 
-	m.storeMessage(tenant, *message)
+	m.storeMessage(tenant, owner, *message)
 }
 
 // isFinalState checks if it's a final state
@@ -787,11 +834,11 @@ func (m *TaskManager) SupportsPushNotifications() bool {
 // It is a no-op unless automatic delivery is configured. The bounded dispatcher
 // preserves order per config; when its queue is full this call applies
 // backpressure rather than dropping an event.
-func (m *TaskManager) dispatchPush(tenant, taskID string, event protocol.StreamResponse) {
+func (m *TaskManager) dispatchPush(tenant, owner, taskID string, event protocol.StreamResponse) {
 	if m.pushDispatcher == nil {
 		return
 	}
-	registrations := m.pushStore.registrations(tenant, taskID)
+	registrations := m.pushStore.registrations(tenant, owner, taskID)
 	if len(registrations) == 0 {
 		return
 	}
@@ -804,17 +851,17 @@ func (m *TaskManager) dispatchPush(tenant, taskID string, event protocol.StreamR
 }
 
 // notifySubscribers notifies all subscribers of the task
-func (m *TaskManager) notifySubscribers(tenant, taskID string, event protocol.StreamResponse) {
+func (m *TaskManager) notifySubscribers(tenant, owner, taskID string, event protocol.StreamResponse) {
 	// Deliver push notifications independently of live SSE subscribers: reaching
 	// clients that are not currently streaming is the whole point of push.
-	m.dispatchPush(tenant, taskID, event)
-	m.notifyLiveSubscribers(tenant, taskID, event)
+	m.dispatchPush(tenant, owner, taskID, event)
+	m.notifyLiveSubscribers(tenant, owner, taskID, event)
 }
 
 // notifyLiveSubscribers fans out to process-local task subscribers without
 // dispatching push a second time.
-func (m *TaskManager) notifyLiveSubscribers(tenant, taskID string, event protocol.StreamResponse) {
-	key := newScopedID(tenant, taskID)
+func (m *TaskManager) notifyLiveSubscribers(tenant, owner, taskID string, event protocol.StreamResponse) {
+	key := newScopedID(tenant, owner, taskID)
 	m.taskMu.RLock()
 	subs, exists := m.subscribers[key]
 	if !exists || len(subs) == 0 {
@@ -846,16 +893,16 @@ func (m *TaskManager) notifyLiveSubscribers(tenant, taskID string, event protoco
 
 	// Clean up failed or closed subscribers
 	if len(failedSubscribers) > 0 {
-		m.cleanupFailedSubscribers(tenant, taskID, failedSubscribers)
+		m.cleanupFailedSubscribers(tenant, owner, taskID, failedSubscribers)
 	}
 }
 
 // cleanupFailedSubscribers cleans up failed or closed subscribers
 func (m *TaskManager) cleanupFailedSubscribers(
-	tenant, taskID string,
+	tenant, owner, taskID string,
 	failedSubscribers []*taskSubscriber,
 ) {
-	key := newScopedID(tenant, taskID)
+	key := newScopedID(tenant, owner, taskID)
 	m.taskMu.Lock()
 
 	subs, exists := m.subscribers[key]
@@ -899,8 +946,8 @@ func (m *TaskManager) cleanupFailedSubscribers(
 }
 
 // cleanSubscribers closes and removes all subscribers for a task.
-func (m *TaskManager) cleanSubscribers(tenant, taskID string) {
-	key := newScopedID(tenant, taskID)
+func (m *TaskManager) cleanSubscribers(tenant, owner, taskID string) {
+	key := newScopedID(tenant, owner, taskID)
 	m.taskMu.Lock()
 
 	subs, exists := m.subscribers[key]
@@ -932,7 +979,7 @@ func (m *TaskManager) CleanExpiredConversations(maxAge time.Duration) int {
 		if now.Sub(conversation.LastAccessTime) > maxAge {
 			expiredContexts = append(expiredContexts, contextKey)
 			for _, messageID := range conversation.MessageIDs {
-				expiredMessages = append(expiredMessages, newScopedID(contextKey.tenant, messageID))
+				expiredMessages = append(expiredMessages, newScopedID(contextKey.tenant, contextKey.owner, messageID))
 			}
 		}
 	}
@@ -1007,13 +1054,13 @@ func (m *TaskManager) cleanExpiredTasks(maxAge time.Duration) int {
 		// A terminal task normally has no live execution, but its engine may
 		// still be draining; cancel the MessageProcessor ctx so a stuck run can exit.
 		for _, taskKey := range expiredTaskIDs {
-			if exec := m.runs.live(taskKey.tenant, taskKey.id); exec != nil {
+			if exec := m.runs.live(taskKey.tenant, taskKey.owner, taskKey.id); exec != nil {
 				exec.cancel()
 			}
 		}
 
 		for _, taskKey := range expiredTaskIDs {
-			m.pushStore.removeAll(taskKey.tenant, taskKey.id)
+			m.pushStore.removeAll(taskKey.tenant, taskKey.owner, taskKey.id)
 		}
 	}
 

--- a/taskmanager/memory/memory_engine.go
+++ b/taskmanager/memory/memory_engine.go
@@ -100,6 +100,9 @@ type engine struct {
 	manager *TaskManager
 	ec      *taskmanager.ExecContext
 	exec    *execution
+	// owner is resolved once from the request context and frozen for every
+	// foreground and detached operation performed by this execution.
+	owner string
 	// pipe is the message/stream response channel; nil for unary requests.
 	pipe *taskSubscriber
 	// historyLength shapes only the operation-local Task framing sent on pipe.
@@ -151,6 +154,7 @@ func (m *TaskManager) prepareExecContext(
 	ctx context.Context,
 	request *protocol.SendMessageParams,
 	exec *execution,
+	owner string,
 	taskID string,
 ) (*taskmanager.ExecContext, error) {
 	message := &request.Message
@@ -165,18 +169,18 @@ func (m *TaskManager) prepareExecContext(
 	// write — the slot frees only after that write — so the snapshot below can
 	// never be a stale pre-terminal copy that would smuggle writes past a
 	// terminal state.
-	if err := m.runs.register(ctx, request.Tenant, taskID, exec); err != nil {
+	if err := m.runs.register(ctx, request.Tenant, owner, taskID, exec); err != nil {
 		return nil, err
 	}
 	releaseOnError := true
 	defer func() {
 		if releaseOnError {
-			m.runs.release(request.Tenant, taskID, exec)
+			m.runs.release(request.Tenant, owner, taskID, exec)
 		}
 	}()
 
 	// Continuation: a message carrying a taskId targets an existing task (§3.4).
-	taskCopy, err := m.resolveContinuation(request.Tenant, message)
+	taskCopy, err := m.resolveContinuation(request.Tenant, owner, message)
 	if err != nil {
 		return nil, err
 	}
@@ -199,6 +203,7 @@ func (m *TaskManager) prepareExecContext(
 	acceptedOutputModes, pushConfig, err := m.prepareExecConfiguration(
 		request.Configuration,
 		request.Tenant,
+		owner,
 		taskID,
 		taskCopy != nil,
 	)
@@ -206,10 +211,10 @@ func (m *TaskManager) prepareExecContext(
 		return nil, err
 	}
 
-	m.commitIncomingMessage(request.Tenant, taskID, message, taskCopy)
+	m.commitIncomingMessage(request.Tenant, owner, taskID, message, taskCopy)
 	// The manager's history limit shapes the processor snapshot; the request's
 	// historyLength only shapes the task returned to the client.
-	history := m.getConversationHistory(request.Tenant, *message.ContextID, m.options.MaxHistoryLength)
+	history := m.getConversationHistory(request.Tenant, owner, *message.ContextID, m.options.MaxHistoryLength)
 
 	releaseOnError = false
 	return &taskmanager.ExecContext{
@@ -231,6 +236,7 @@ func (m *TaskManager) prepareExecContext(
 func (m *TaskManager) prepareExecConfiguration(
 	configuration *protocol.SendMessageConfiguration,
 	tenant string,
+	owner string,
 	taskID string,
 	continuation bool,
 ) ([]string, *protocol.TaskPushNotificationConfig, error) {
@@ -258,7 +264,7 @@ func (m *TaskManager) prepareExecConfiguration(
 		return nil, nil, taskmanager.ErrInvalidParams(err.Error())
 	}
 	if continuation {
-		stored, err := m.pushStore.save(pushConfig)
+		stored, err := m.pushStore.save(owner, pushConfig)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -272,6 +278,7 @@ func (m *TaskManager) prepareExecConfiguration(
 // becomes history immediately before the new user turn.
 func (m *TaskManager) commitIncomingMessage(
 	tenant string,
+	owner string,
 	taskID string,
 	message *protocol.Message,
 	taskCopy *protocol.Task,
@@ -284,20 +291,20 @@ func (m *TaskManager) commitIncomingMessage(
 		statusMessage := taskCopy.Status.Message
 		taskCopy.Status.Message = nil
 		m.taskMu.Lock()
-		if stored, exists := m.tasks[newScopedID(tenant, taskID)]; exists {
+		if stored, exists := m.tasks[newScopedID(tenant, owner, taskID)]; exists {
 			stored.Status.Message = nil
 		}
 		m.taskMu.Unlock()
-		m.storeStatusMessage(tenant, taskID, *message.ContextID, statusMessage)
+		m.storeStatusMessage(tenant, owner, taskID, *message.ContextID, statusMessage)
 	}
-	m.storeMessage(tenant, *message)
+	m.storeMessage(tenant, owner, *message)
 }
 
 // resolveContinuation loads and validates the task a continuation message
 // targets (§3.4), returning a copy for ec.Task. A message without a taskId is
 // a fresh round and resolves to nil. When taskId is set it is the same value
 // the caller registered the execution under (see startExecution).
-func (m *TaskManager) resolveContinuation(tenant string, message *protocol.Message) (*protocol.Task, error) {
+func (m *TaskManager) resolveContinuation(tenant, owner string, message *protocol.Message) (*protocol.Task, error) {
 	if message.TaskID == nil || *message.TaskID == "" {
 		return nil, nil
 	}
@@ -305,7 +312,7 @@ func (m *TaskManager) resolveContinuation(tenant string, message *protocol.Messa
 
 	m.taskMu.RLock()
 	defer m.taskMu.RUnlock()
-	stored, exists := m.tasks[newScopedID(tenant, taskID)]
+	stored, exists := m.tasks[newScopedID(tenant, owner, taskID)]
 	if !exists {
 		return nil, taskmanager.ErrTaskNotFound(taskID)
 	}
@@ -331,6 +338,10 @@ func (m *TaskManager) startExecution(
 	request *protocol.SendMessageParams,
 	withPipe bool,
 ) (*engine, error) {
+	owner, err := m.resolveOwner(reqCtx)
+	if err != nil {
+		return nil, err
+	}
 	// The execution ctx is detached from the request ctx's cancellation but
 	// keeps its values: a client disconnect must not cancel the work (§3.3).
 	// Only OnCancelTask (and manager teardown) cancels it, via the registry.
@@ -361,7 +372,7 @@ func (m *TaskManager) startExecution(
 	// prepareExecContext registers exec as the task's single live run before
 	// the MessageProcessor is invoked, so OnCancelTask can reach the run from
 	// the very first instant events may be produced.
-	ec, err := m.prepareExecContext(reqCtx, request, exec, taskID)
+	ec, err := m.prepareExecContext(reqCtx, request, exec, owner, taskID)
 	if err != nil {
 		cancel()
 		return nil, err
@@ -375,12 +386,12 @@ func (m *TaskManager) startExecution(
 	events, err := m.processor.ProcessMessage(execCtx, &processorEC)
 	if err != nil {
 		// Failed start (§3.5): no events are consumed, nothing was persisted.
-		m.runs.release(ec.Tenant, ec.TaskID, exec)
+		m.runs.release(ec.Tenant, owner, ec.TaskID, exec)
 		cancel()
 		return nil, err
 	}
 	if events == nil {
-		m.runs.release(ec.Tenant, ec.TaskID, exec)
+		m.runs.release(ec.Tenant, owner, ec.TaskID, exec)
 		cancel()
 		return nil, taskmanager.ErrInternalError("processor returned nil channel")
 	}
@@ -389,6 +400,7 @@ func (m *TaskManager) startExecution(
 		manager:           m,
 		ec:                ec,
 		exec:              exec,
+		owner:             owner,
 		pipe:              exec.pipe,
 		pendingInlinePush: ec.PushConfig != nil && ec.Task == nil,
 		immediateResult:   make(chan sendOutcome, 1),
@@ -491,7 +503,7 @@ func (eng *engine) handleMessage(message *protocol.Message) {
 	}
 	m := eng.manager
 	contextID := eng.ec.ContextID
-	m.processReplyMessage(eng.ec.Tenant, &contextID, message)
+	m.processReplyMessage(eng.ec.Tenant, eng.owner, &contextID, message)
 	eng.finalOutcome = sendOutcome{message: message}
 	eng.offerImmediateResult(sendOutcome{message: message})
 
@@ -499,10 +511,10 @@ func (eng *engine) handleMessage(message *protocol.Message) {
 	eng.sendToPipe(response)
 
 	m.taskMu.RLock()
-	_, exists := m.tasks[newScopedID(eng.ec.Tenant, eng.ec.TaskID)]
+	_, exists := m.tasks[newScopedID(eng.ec.Tenant, eng.owner, eng.ec.TaskID)]
 	m.taskMu.RUnlock()
 	if exists {
-		m.notifySubscribers(eng.ec.Tenant, eng.ec.TaskID, response)
+		m.notifySubscribers(eng.ec.Tenant, eng.owner, eng.ec.TaskID, response)
 	}
 	// The first valid event selects the response shape. Once a round returns a
 	// direct Message, the wire response is complete; keep draining the processor
@@ -516,7 +528,7 @@ func (eng *engine) handleMessage(message *protocol.Message) {
 // storeStatusMessage stores a stamped copy without mutating the processor's
 // message, which may still be visible in an earlier task snapshot or wire event.
 func (m *TaskManager) storeStatusMessage(
-	tenant, taskID, contextID string,
+	tenant, owner, taskID, contextID string,
 	message *protocol.Message,
 ) {
 	if message == nil {
@@ -529,7 +541,7 @@ func (m *TaskManager) storeStatusMessage(
 	if stored.MessageID == "" {
 		stored.MessageID = protocol.GenerateMessageID()
 	}
-	m.storeMessage(tenant, stored)
+	m.storeMessage(tenant, owner, stored)
 }
 
 // rollStatusMessage moves a superseded status message into conversation
@@ -544,7 +556,7 @@ func (eng *engine) rollStatusMessage(message *protocol.Message) {
 		return
 	}
 	eng.lastRolledStatusMessage = message
-	eng.manager.storeStatusMessage(eng.ec.Tenant, eng.ec.TaskID, eng.ec.ContextID, message)
+	eng.manager.storeStatusMessage(eng.ec.Tenant, eng.owner, eng.ec.TaskID, eng.ec.ContextID, message)
 }
 
 // statusPersistResult is the outcome of applying a status update under taskMu.
@@ -579,7 +591,7 @@ func (eng *engine) handleStatus(event *protocol.TaskStatusUpdateEvent) {
 	// still be rejected as a concurrent execution. If cancellation claimed
 	// the slot first, keep this round active so its close rule can persist
 	// CANCELED rather than swallowing the accepted cancellation.
-	yielding := suspended && m.runs.beginYield(eng.ec.Tenant, eng.ec.TaskID, eng.exec)
+	yielding := suspended && m.runs.beginYield(eng.ec.Tenant, eng.owner, eng.ec.TaskID, eng.exec)
 
 	// Persist first (§3.6), then publish.
 	persisted, ok := eng.persistStatusUpdate(event, yielding)
@@ -625,7 +637,7 @@ func (eng *engine) persistStatusUpdate(
 	m.taskMu.Lock()
 	defer m.taskMu.Unlock()
 
-	taskKey := newScopedID(eng.ec.Tenant, eng.ec.TaskID)
+	taskKey := newScopedID(eng.ec.Tenant, eng.owner, eng.ec.TaskID)
 	task, exists := m.tasks[taskKey]
 	if exists && isFinalState(task.Status.State) {
 		return statusPersistResult{alreadyTerminal: task.Status.State}, false
@@ -671,7 +683,7 @@ func (eng *engine) completeStatusYield(
 	eng.finalOutcome = outcome
 	eng.stopReason = engineStopYield
 	m := eng.manager
-	m.dispatchPush(eng.ec.Tenant, eng.ec.TaskID, response)
+	m.dispatchPush(eng.ec.Tenant, eng.owner, eng.ec.TaskID, response)
 	eng.broadcastWithoutPush(response, snapshot)
 	eng.closePipe()
 	// This round no longer owns the task after publishing its suspend frame.
@@ -679,13 +691,13 @@ func (eng *engine) completeStatusYield(
 	// cannot discover a yielded execution once the slot is released, but still
 	// waits for its drain engine to finish.
 	eng.exec.cancel()
-	m.runs.deregister(eng.ec.Tenant, eng.ec.TaskID, eng.exec)
+	m.runs.deregister(eng.ec.Tenant, eng.owner, eng.ec.TaskID, eng.exec)
 }
 
 // completeStatusTerminal ends the round after a terminal status frame.
 func (eng *engine) completeStatusTerminal() {
 	eng.stopReason = engineStopTerminal
-	eng.manager.cleanSubscribers(eng.ec.Tenant, eng.ec.TaskID)
+	eng.manager.cleanSubscribers(eng.ec.Tenant, eng.owner, eng.ec.TaskID)
 	// Nothing can follow a terminal frame: end the response stream here
 	// instead of trusting the MessageProcessor to close its channel promptly.
 	eng.closePipe()
@@ -694,7 +706,7 @@ func (eng *engine) completeStatusTerminal() {
 // abortYieldIf rolls back a suspend handoff when the status commit path fails.
 func (eng *engine) abortYieldIf(yielding bool) {
 	if yielding {
-		eng.manager.runs.abortYield(eng.ec.Tenant, eng.ec.TaskID, eng.exec)
+		eng.manager.runs.abortYield(eng.ec.Tenant, eng.owner, eng.ec.TaskID, eng.exec)
 	}
 }
 
@@ -705,7 +717,7 @@ func (eng *engine) handleArtifact(event *protocol.TaskArtifactUpdateEvent) {
 	m := eng.manager
 
 	m.taskMu.Lock()
-	taskKey := newScopedID(eng.ec.Tenant, eng.ec.TaskID)
+	taskKey := newScopedID(eng.ec.Tenant, eng.owner, eng.ec.TaskID)
 	task, exists := m.tasks[taskKey]
 	if exists && isFinalState(task.Status.State) {
 		// Terminal states are immutable: no artifact may land after one.
@@ -753,7 +765,7 @@ func (eng *engine) persistInlinePushConfig() error {
 		return nil
 	}
 	eng.pendingInlinePush = false
-	if _, err := eng.manager.pushStore.save(*eng.ec.PushConfig); err != nil {
+	if _, err := eng.manager.pushStore.save(eng.owner, *eng.ec.PushConfig); err != nil {
 		return fmt.Errorf("persist inline push config: %w", err)
 	}
 	return nil
@@ -789,7 +801,7 @@ func (eng *engine) broadcast(response protocol.StreamResponse, snapshot *protoco
 		eng.offerImmediateResult(sendOutcome{task: snapshot})
 	}
 	eng.sendToPipe(response)
-	eng.manager.notifySubscribers(eng.ec.Tenant, eng.ec.TaskID, response)
+	eng.manager.notifySubscribers(eng.ec.Tenant, eng.owner, eng.ec.TaskID, response)
 }
 
 // broadcastWithoutPush publishes an event whose automatic push delivery was
@@ -799,7 +811,7 @@ func (eng *engine) broadcastWithoutPush(response protocol.StreamResponse, snapsh
 		eng.offerImmediateResult(sendOutcome{task: snapshot})
 	}
 	eng.sendToPipe(response)
-	eng.manager.notifyLiveSubscribers(eng.ec.Tenant, eng.ec.TaskID, response)
+	eng.manager.notifyLiveSubscribers(eng.ec.Tenant, eng.owner, eng.ec.TaskID, response)
 }
 
 // offerImmediateResult publishes the immediate result exactly once.
@@ -828,7 +840,7 @@ func (eng *engine) sendInitialTask(task *protocol.Task) {
 	if task == nil || eng.pipe == nil {
 		return
 	}
-	eng.manager.fillTaskHistory(eng.ec.Tenant, task, eng.historyLength)
+	eng.manager.fillTaskHistory(eng.ec.Tenant, eng.owner, task, eng.historyLength)
 	eng.sendToPipe(protocol.NewStreamResponseTask(task))
 }
 
@@ -850,7 +862,7 @@ func (eng *engine) violate(reason string) {
 	m := eng.manager
 	event := eng.statusEvent(protocol.TaskStateFailed, eng.failureStatusMessage(reason))
 	m.taskMu.Lock()
-	task, exists := m.tasks[newScopedID(eng.ec.Tenant, eng.ec.TaskID)]
+	task, exists := m.tasks[newScopedID(eng.ec.Tenant, eng.owner, eng.ec.TaskID)]
 	if !exists || isFinalState(task.Status.State) {
 		m.taskMu.Unlock()
 		return
@@ -869,7 +881,7 @@ func (eng *engine) violate(reason string) {
 
 	eng.sendInitialTask(initial)
 	eng.broadcast(protocol.NewStreamResponseStatusUpdate(event), snapshot)
-	m.cleanSubscribers(eng.ec.Tenant, eng.ec.TaskID)
+	m.cleanSubscribers(eng.ec.Tenant, eng.owner, eng.ec.TaskID)
 	eng.closePipe()
 }
 
@@ -893,7 +905,7 @@ func (eng *engine) finish() {
 	var initial *protocol.Task
 
 	m.taskMu.Lock()
-	task, exists := m.tasks[newScopedID(eng.ec.Tenant, eng.ec.TaskID)]
+	task, exists := m.tasks[newScopedID(eng.ec.Tenant, eng.owner, eng.ec.TaskID)]
 	if exists && !isFinalState(task.Status.State) {
 		switch {
 		case eng.exec.cancelRequested.Load():
@@ -936,15 +948,15 @@ func (eng *engine) finish() {
 	if closing != nil {
 		response := protocol.NewStreamResponseStatusUpdate(closing)
 		eng.sendToPipe(response)
-		m.notifySubscribers(eng.ec.Tenant, eng.ec.TaskID, response)
-		m.cleanSubscribers(eng.ec.Tenant, eng.ec.TaskID)
+		m.notifySubscribers(eng.ec.Tenant, eng.owner, eng.ec.TaskID, response)
+		m.cleanSubscribers(eng.ec.Tenant, eng.owner, eng.ec.TaskID)
 	}
 
 	if eng.pipe != nil {
 		eng.pipe.Close()
 	}
 	eng.exec.cancel() // release the detached ctx resources
-	m.runs.deregister(eng.ec.Tenant, eng.ec.TaskID, eng.exec)
+	m.runs.deregister(eng.ec.Tenant, eng.owner, eng.ec.TaskID, eng.exec)
 	close(eng.done)
 }
 
@@ -978,12 +990,13 @@ func (eng *engine) failureStatusMessage(text string) *protocol.Message {
 // last message; an execution that produced neither is a MessageProcessor bug.
 func (m *TaskManager) buildSendResponse(
 	tenant string,
+	owner string,
 	task *protocol.Task,
 	message *protocol.Message,
 	historyLength *int,
 ) (*protocol.SendMessageResponse, error) {
 	if task != nil {
-		m.fillTaskHistory(tenant, task, historyLength)
+		m.fillTaskHistory(tenant, owner, task, historyLength)
 		return protocol.NewSendMessageResponseTask(task), nil
 	}
 	if message != nil {

--- a/taskmanager/memory/memory_engine_test.go
+++ b/taskmanager/memory/memory_engine_test.go
@@ -128,7 +128,7 @@ func statusMessageText(task *protocol.Task) string {
 func storedTaskState(m *TaskManager, taskID string) (protocol.TaskState, bool) {
 	m.taskMu.RLock()
 	defer m.taskMu.RUnlock()
-	task, ok := m.tasks[newScopedID("", taskID)]
+	task, ok := m.tasks[newScopedID("", "", taskID)]
 	if !ok {
 		return "", false
 	}
@@ -188,7 +188,7 @@ func seedTask(m *TaskManager, task protocol.Task) {
 		task.Status.Timestamp = nowTimestamp()
 	}
 	m.taskMu.Lock()
-	m.tasks[newScopedID("", task.ID)] = &task
+	m.tasks[newScopedID("", "", task.ID)] = &task
 	m.taskMu.Unlock()
 }
 
@@ -223,7 +223,7 @@ func TestOnSendMessage_PureMessageLeavesNoTask(t *testing.T) {
 
 	// The reply must be stored in the conversation.
 	manager.conversationMu.RLock()
-	_, stored := manager.messages[newScopedID("", message.MessageID)]
+	_, stored := manager.messages[newScopedID("", "", message.MessageID)]
 	manager.conversationMu.RUnlock()
 	if !stored {
 		t.Error("Reply message not found in storage")
@@ -696,7 +696,7 @@ func TestOnSendMessageStream_OrderAndPersistBeforeBroadcast(t *testing.T) {
 		t.Errorf("Expected stamped IDs, got taskID=%q contextID=%q", initial.ID, initial.ContextID)
 	}
 	manager.taskMu.RLock()
-	storedHistory := len(manager.tasks[newScopedID("", initial.ID)].History)
+	storedHistory := len(manager.tasks[newScopedID("", "", initial.ID)].History)
 	manager.taskMu.RUnlock()
 	if storedHistory != 0 {
 		t.Fatalf("Initial Task history must not be written into storage, got %d entries", storedHistory)
@@ -723,7 +723,7 @@ func TestOnSendMessageStream_OrderAndPersistBeforeBroadcast(t *testing.T) {
 		t.Fatalf("Expected the artifact event third, got %+v", third)
 	}
 	manager.taskMu.RLock()
-	artifactCount := len(manager.tasks[newScopedID("", initial.ID)].Artifacts)
+	artifactCount := len(manager.tasks[newScopedID("", "", initial.ID)].Artifacts)
 	manager.taskMu.RUnlock()
 	if artifactCount != 1 {
 		t.Errorf("Expected 1 persisted artifact when the event is received, got %d", artifactCount)
@@ -769,7 +769,7 @@ func TestOnSendMessageStream_ArtifactFirstStartsWithTask(t *testing.T) {
 		t.Fatal("Expected the artifact-created task persisted before delivery")
 	}
 	manager.taskMu.RLock()
-	artifactCount := len(manager.tasks[newScopedID("", initial.ID)].Artifacts)
+	artifactCount := len(manager.tasks[newScopedID("", "", initial.ID)].Artifacts)
 	manager.taskMu.RUnlock()
 	if artifactCount != 1 {
 		t.Fatalf("Expected the artifact persisted before the initial Task frame, got %d", artifactCount)
@@ -1768,7 +1768,7 @@ func TestOnSendMessage_ContinuationContextMismatchRejected(t *testing.T) {
 		t.Fatalf("processor must not run for the rejected round, invocations=%d", got)
 	}
 	manager.conversationMu.RLock()
-	_, stored := manager.messages[newScopedID("", "mismatch-msg")]
+	_, stored := manager.messages[newScopedID("", "", "mismatch-msg")]
 	manager.conversationMu.RUnlock()
 	if stored {
 		t.Fatal("rejected continuation must not store the request message")
@@ -1915,7 +1915,7 @@ func TestConversationHistoryConcurrentAccess(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for j := 0; j < 200; j++ {
-				manager.getConversationHistory("", contextID, 100)
+				manager.getConversationHistory("", "", contextID, 100)
 			}
 		}()
 	}

--- a/taskmanager/memory/memory_options.go
+++ b/taskmanager/memory/memory_options.go
@@ -12,10 +12,15 @@ import (
 	"time"
 
 	"trpc.group/trpc-go/trpc-a2a-go/v2/push"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
 )
 
 // TaskManagerOptions contains configuration options for TaskManager.
 type TaskManagerOptions struct {
+	// OwnerResolver derives the authorization owner scope from each request.
+	// A nil resolver preserves tenant-wide task sharing for compatibility.
+	OwnerResolver taskmanager.OwnerResolver
+
 	// MaxHistoryLength is the maximum number of messages to keep in conversation history.
 	MaxHistoryLength int
 
@@ -112,6 +117,15 @@ func WithTaskSubscriberBufferSize(size int) TaskManagerOption {
 func WithTaskSubscriberBlockingSend(blockingSend bool) TaskManagerOption {
 	return func(opts *TaskManagerOptions) {
 		opts.TaskSubscriberBlockingSend = blockingSend
+	}
+}
+
+// WithOwnerResolver scopes retained tasks and related state to the owner
+// returned for each request. The resolver must return a non-empty owner; an
+// error or empty result rejects the operation before any state is accessed.
+func WithOwnerResolver(resolver taskmanager.OwnerResolver) TaskManagerOption {
+	return func(opts *TaskManagerOptions) {
+		opts.OwnerResolver = resolver
 	}
 }
 

--- a/taskmanager/memory/memory_regression_test.go
+++ b/taskmanager/memory/memory_regression_test.go
@@ -181,23 +181,23 @@ func TestClaimCancelSlot_BlocksConcurrentRegistration(t *testing.T) {
 	manager := newTestManager(t, echoExecutor())
 	const taskID = "task-claim-slot"
 
-	live, sentinel, yieldDone := manager.runs.claimCancelSlot("", taskID)
+	live, sentinel, yieldDone := manager.runs.claimCancelSlot("", "", taskID)
 	if live != nil || sentinel == nil {
 		t.Fatalf("expected to claim the free slot, got live=%v sentinel=%v", live, sentinel)
 	}
 	if yieldDone != nil {
 		t.Fatal("free slot unexpectedly reported a yield handoff")
 	}
-	if err := manager.runs.register(context.Background(), "", taskID, &execution{cancel: func() {}}); err == nil {
+	if err := manager.runs.register(context.Background(), "", "", taskID, &execution{cancel: func() {}}); err == nil {
 		t.Fatal("registration must be rejected while a cancel sentinel holds the slot")
 	}
-	manager.runs.deregister("", taskID, sentinel)
+	manager.runs.deregister("", "", taskID, sentinel)
 
 	exec := &execution{cancel: func() {}}
-	if err := manager.runs.register(context.Background(), "", taskID, exec); err != nil {
+	if err := manager.runs.register(context.Background(), "", "", taskID, exec); err != nil {
 		t.Fatalf("registration after sentinel release failed: %v", err)
 	}
-	manager.runs.release("", taskID, exec)
+	manager.runs.release("", "", taskID, exec)
 }
 
 // Cancellation and suspend handoff use the execution registry as their linearization point.
@@ -209,21 +209,21 @@ func TestCancelYieldLinearization(t *testing.T) {
 		const taskID = "task-cancel-wins-yield"
 		var cancelCalls atomic.Int32
 		exec := &execution{cancel: func() { cancelCalls.Add(1) }}
-		if err := manager.runs.register(context.Background(), "", taskID, exec); err != nil {
+		if err := manager.runs.register(context.Background(), "", "", taskID, exec); err != nil {
 			t.Fatalf("register execution: %v", err)
 		}
 		var releaseOnce sync.Once
-		release := func() { releaseOnce.Do(func() { manager.runs.release("", taskID, exec) }) }
+		release := func() { releaseOnce.Do(func() { manager.runs.release("", "", taskID, exec) }) }
 		defer release()
 
-		yieldDone, accepted := manager.runs.requestCancel("", taskID, exec)
+		yieldDone, accepted := manager.runs.requestCancel("", "", taskID, exec)
 		if !accepted || yieldDone != nil {
 			t.Fatalf("cancel result: accepted=%v yieldDone=%v, want accepted with no handoff", accepted, yieldDone)
 		}
 		if got := cancelCalls.Load(); got != 1 {
 			t.Fatalf("execution cancel calls = %d, want 1", got)
 		}
-		if manager.runs.beginYield("", taskID, exec) {
+		if manager.runs.beginYield("", "", taskID, exec) {
 			t.Fatal("suspend handoff started after cancellation had already won")
 		}
 
@@ -235,18 +235,18 @@ func TestCancelYieldLinearization(t *testing.T) {
 		const taskID = "task-yield-wins-cancel"
 		var cancelCalls atomic.Int32
 		exec := &execution{cancel: func() { cancelCalls.Add(1) }}
-		if err := manager.runs.register(context.Background(), "", taskID, exec); err != nil {
+		if err := manager.runs.register(context.Background(), "", "", taskID, exec); err != nil {
 			t.Fatalf("register execution: %v", err)
 		}
 		var releaseOnce sync.Once
-		release := func() { releaseOnce.Do(func() { manager.runs.release("", taskID, exec) }) }
+		release := func() { releaseOnce.Do(func() { manager.runs.release("", "", taskID, exec) }) }
 		defer release()
-		if !manager.runs.beginYield("", taskID, exec) {
+		if !manager.runs.beginYield("", "", taskID, exec) {
 			t.Fatal("suspend handoff did not start")
 		}
 		handoff := exec.yieldDone
 
-		yieldDone, accepted := manager.runs.requestCancel("", taskID, exec)
+		yieldDone, accepted := manager.runs.requestCancel("", "", taskID, exec)
 		if accepted || yieldDone != handoff {
 			t.Fatalf("cancel result: accepted=%v yieldDone=%v, want existing handoff %v",
 				accepted, yieldDone, handoff)
@@ -599,7 +599,7 @@ func TestResubscribe_ClientDisconnectDropsSubscriber(t *testing.T) {
 	eventually(t, func() bool {
 		manager.taskMu.RLock()
 		defer manager.taskMu.RUnlock()
-		return len(manager.subscribers[newScopedID("", taskID)]) == 0
+		return len(manager.subscribers[newScopedID("", "", taskID)]) == 0
 	}, "disconnected subscriber was not removed")
 }
 

--- a/taskmanager/memory/memory_test.go
+++ b/taskmanager/memory/memory_test.go
@@ -124,7 +124,7 @@ func TestTaskManager_OnSendMessage(t *testing.T) {
 
 			// Check that the reply message is in storage
 			manager.conversationMu.RLock()
-			_, exists := manager.messages[newScopedID("", message.MessageID)]
+			_, exists := manager.messages[newScopedID("", "", message.MessageID)]
 			manager.conversationMu.RUnlock()
 			if !exists {
 				t.Error("Message not found in storage")
@@ -414,10 +414,10 @@ func TestTaskManager_cleanupFailedSubscribersClosesRemovedSubscribers(t *testing
 	activeSub := newTaskSubscriber(taskID, 10, false)
 
 	manager.taskMu.Lock()
-	manager.subscribers[newScopedID("", taskID)] = []*taskSubscriber{failedSub, activeSub}
+	manager.subscribers[newScopedID("", "", taskID)] = []*taskSubscriber{failedSub, activeSub}
 	manager.taskMu.Unlock()
 
-	manager.cleanupFailedSubscribers("", taskID, []*taskSubscriber{failedSub})
+	manager.cleanupFailedSubscribers("", "", taskID, []*taskSubscriber{failedSub})
 
 	if !failedSub.Closed() {
 		t.Error("Expected failed subscriber to be closed")
@@ -427,7 +427,7 @@ func TestTaskManager_cleanupFailedSubscribersClosesRemovedSubscribers(t *testing
 	}
 
 	manager.taskMu.RLock()
-	subs := manager.subscribers[newScopedID("", taskID)]
+	subs := manager.subscribers[newScopedID("", "", taskID)]
 	manager.taskMu.RUnlock()
 
 	if len(subs) != 1 || subs[0] != activeSub {
@@ -447,7 +447,7 @@ func TestTaskManager_cleanExpiredTasks(t *testing.T) {
 		},
 	})
 	manager.taskMu.Lock()
-	manager.subscribers[newScopedID("", "expired-task")] = []*taskSubscriber{
+	manager.subscribers[newScopedID("", "", "expired-task")] = []*taskSubscriber{
 		newTaskSubscriber("expired-task", 10, false),
 	}
 	manager.taskMu.Unlock()
@@ -476,7 +476,7 @@ func TestTaskManager_cleanExpiredTasks(t *testing.T) {
 		t.Errorf("Expected 0 cleaned tasks with TTL=0, got %d", skipped)
 	}
 	manager.taskMu.RLock()
-	if _, exists := manager.tasks[newScopedID("", "expired-task")]; !exists {
+	if _, exists := manager.tasks[newScopedID("", "", "expired-task")]; !exists {
 		t.Error("Expired task should still exist when TTL=0")
 	}
 	manager.taskMu.RUnlock()
@@ -491,16 +491,16 @@ func TestTaskManager_cleanExpiredTasks(t *testing.T) {
 	manager.taskMu.RLock()
 	defer manager.taskMu.RUnlock()
 
-	if _, exists := manager.tasks[newScopedID("", "expired-task")]; exists {
+	if _, exists := manager.tasks[newScopedID("", "", "expired-task")]; exists {
 		t.Error("Expected expired task to be removed")
 	}
-	if _, exists := manager.subscribers[newScopedID("", "expired-task")]; exists {
+	if _, exists := manager.subscribers[newScopedID("", "", "expired-task")]; exists {
 		t.Error("Expected expired task subscribers to be removed")
 	}
-	if _, exists := manager.tasks[newScopedID("", "active-task")]; !exists {
+	if _, exists := manager.tasks[newScopedID("", "", "active-task")]; !exists {
 		t.Error("Active task should not be removed")
 	}
-	if _, exists := manager.tasks[newScopedID("", "recent-task")]; !exists {
+	if _, exists := manager.tasks[newScopedID("", "", "recent-task")]; !exists {
 		t.Error("Recently completed task should not be removed")
 	}
 }
@@ -524,10 +524,10 @@ func TestTaskManager_TaskTTLCleanupGoroutine(t *testing.T) {
 	})
 
 	manager.taskMu.Lock()
-	manager.subscribers[newScopedID("", taskID)] = []*taskSubscriber{sub}
+	manager.subscribers[newScopedID("", "", taskID)] = []*taskSubscriber{sub}
 	manager.taskMu.Unlock()
 
-	if _, err := manager.pushStore.save(protocol.TaskPushNotificationConfig{TaskID: taskID}); err != nil {
+	if _, err := manager.pushStore.save("", protocol.TaskPushNotificationConfig{TaskID: taskID}); err != nil {
 		t.Fatalf("Failed to seed push config: %v", err)
 	}
 
@@ -537,11 +537,11 @@ func TestTaskManager_TaskTTLCleanupGoroutine(t *testing.T) {
 
 	for {
 		manager.taskMu.RLock()
-		_, taskExists := manager.tasks[newScopedID("", taskID)]
-		_, subsExists := manager.subscribers[newScopedID("", taskID)]
+		_, taskExists := manager.tasks[newScopedID("", "", taskID)]
+		_, subsExists := manager.subscribers[newScopedID("", "", taskID)]
 		manager.taskMu.RUnlock()
 
-		pushConfigs := manager.pushStore.list("", taskID)
+		pushConfigs := manager.pushStore.list("", "", taskID)
 		pushExists := len(pushConfigs) > 0
 
 		if !taskExists && !subsExists && !pushExists && sub.Closed() {
@@ -579,7 +579,7 @@ func TestTaskManager_Close(t *testing.T) {
 	sub := newTaskSubscriber("close-test-task", 10, false)
 
 	manager.taskMu.Lock()
-	manager.subscribers[newScopedID("", "close-test-task")] = []*taskSubscriber{sub}
+	manager.subscribers[newScopedID("", "", "close-test-task")] = []*taskSubscriber{sub}
 	manager.taskMu.Unlock()
 
 	manager.Close()

--- a/taskmanager/memory/push_dispatch_test.go
+++ b/taskmanager/memory/push_dispatch_test.go
@@ -301,12 +301,12 @@ func TestInlinePushConfigRegistration(t *testing.T) {
 				len(suspended.History), len(after.History))
 		}
 		manager.conversationMu.RLock()
-		_, stored := manager.messages[newScopedID("", followUp.Message.MessageID)]
+		_, stored := manager.messages[newScopedID("", "", followUp.Message.MessageID)]
 		manager.conversationMu.RUnlock()
 		if stored {
 			t.Fatalf("rejected continuation stored incoming message %s", followUp.Message.MessageID)
 		}
-		if live := manager.runs.live("", suspended.ID); live != nil {
+		if live := manager.runs.live("", "", suspended.ID); live != nil {
 			t.Fatal("rejected continuation did not release its execution slot")
 		}
 	})
@@ -460,7 +460,7 @@ func TestQueuedPushUsesRegistrationGeneration(t *testing.T) { //nolint:gocyclo /
 	}); err != nil {
 		t.Fatalf("set old config: %v", err)
 	}
-	oldRegistrations := manager.pushStore.registrations("", taskID)
+	oldRegistrations := manager.pushStore.registrations("", "", taskID)
 	if len(oldRegistrations) != 1 {
 		t.Fatalf("old registrations = %d, want 1", len(oldRegistrations))
 	}
@@ -497,7 +497,7 @@ func TestQueuedPushUsesRegistrationGeneration(t *testing.T) { //nolint:gocyclo /
 	}); err != nil {
 		t.Fatalf("re-create config: %v", err)
 	}
-	newRegistrations := manager.pushStore.registrations("", taskID)
+	newRegistrations := manager.pushStore.registrations("", "", taskID)
 	if len(newRegistrations) != 1 {
 		t.Fatalf("new registrations = %d, want 1", len(newRegistrations))
 	}
@@ -601,7 +601,7 @@ func TestSuspendWaitsForPushCapacityBeforeHandoff(t *testing.T) { //nolint:gocyc
 	}); err != nil {
 		t.Fatalf("set prefill config: %v", err)
 	}
-	prefillRegistrations := manager.pushStore.registrations("", prefillTaskID)
+	prefillRegistrations := manager.pushStore.registrations("", "", prefillTaskID)
 	prefillEvent := protocol.NewStreamResponseStatusUpdate(&protocol.TaskStatusUpdateEvent{
 		TaskID: prefillTaskID,
 		Status: protocol.TaskStatus{State: protocol.TaskStateWorking},
@@ -641,7 +641,7 @@ func TestSuspendWaitsForPushCapacityBeforeHandoff(t *testing.T) { //nolint:gocyc
 		state, ok := storedTaskState(manager, taskID)
 		return ok && state == protocol.TaskStateInputRequired
 	}, "task must persist input-required before publication")
-	exec := manager.runs.live("", taskID)
+	exec := manager.runs.live("", "", taskID)
 	yielding := exec != nil && exec.yieldDone != nil
 	if !yielding {
 		t.Fatal("input-required became visible before the suspend handoff barrier")

--- a/taskmanager/memory/push_store.go
+++ b/taskmanager/memory/push_store.go
@@ -28,7 +28,7 @@ type pushConfigStore struct {
 	mu sync.RWMutex
 	// closed prevents configs from being re-created after manager shutdown.
 	closed bool
-	// configs maps tenant+taskID -> configID -> internal registration. Generation is
+	// configs maps tenant+owner+taskID -> configID -> internal registration. Generation is
 	// intentionally kept out of the public protocol type.
 	configs map[scopedID]map[string]push.Registration
 }
@@ -41,6 +41,7 @@ func newPushConfigStore() *pushConfigStore {
 
 // save stores cfg, generating a resource ID when absent.
 func (s *pushConfigStore) save(
+	owner string,
 	cfg protocol.TaskPushNotificationConfig,
 ) (protocol.TaskPushNotificationConfig, error) {
 	if cfg.TaskID == "" {
@@ -55,22 +56,23 @@ func (s *pushConfigStore) save(
 		cfg.ID = "push-" + uuid.New().String()
 	}
 	cfg = clonePushConfig(cfg)
-	taskKey := newScopedID(cfg.Tenant, cfg.TaskID)
+	taskKey := newScopedID(cfg.Tenant, owner, cfg.TaskID)
 	if s.configs[taskKey] == nil {
 		s.configs[taskKey] = make(map[string]push.Registration)
 	}
 	s.configs[taskKey][cfg.ID] = push.Registration{
 		Config:     cfg,
 		Generation: uuid.New().String(),
+		Owner:      owner,
 	}
 	return clonePushConfig(cfg), nil
 }
 
 // list returns all configs for taskID, ordered by ID for stable pagination.
-func (s *pushConfigStore) list(tenant, taskID string) []protocol.TaskPushNotificationConfig {
+func (s *pushConfigStore) list(tenant, owner, taskID string) []protocol.TaskPushNotificationConfig {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	byID := s.configs[newScopedID(tenant, taskID)]
+	byID := s.configs[newScopedID(tenant, owner, taskID)]
 	out := make([]protocol.TaskPushNotificationConfig, 0, len(byID))
 	for _, registration := range byID {
 		out = append(out, clonePushConfig(registration.Config))
@@ -83,11 +85,11 @@ func (s *pushConfigStore) list(tenant, taskID string) []protocol.TaskPushNotific
 
 // get returns the config identified by taskID and configID.
 func (s *pushConfigStore) get(
-	tenant, taskID, configID string,
+	tenant, owner, taskID, configID string,
 ) (protocol.TaskPushNotificationConfig, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	byID := s.configs[newScopedID(tenant, taskID)]
+	byID := s.configs[newScopedID(tenant, owner, taskID)]
 	registration, ok := byID[configID]
 	return clonePushConfig(registration.Config), ok
 }
@@ -95,10 +97,10 @@ func (s *pushConfigStore) get(
 // registrations returns internal delivery snapshots, ordered by config ID.
 // Generation remains internal and lets the dispatcher discard queued work for
 // a config that was deleted or replaced after enqueue.
-func (s *pushConfigStore) registrations(tenant, taskID string) []push.Registration {
+func (s *pushConfigStore) registrations(tenant, owner, taskID string) []push.Registration {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	byID := s.configs[newScopedID(tenant, taskID)]
+	byID := s.configs[newScopedID(tenant, owner, taskID)]
 	out := make([]push.Registration, 0, len(byID))
 	for _, registration := range byID {
 		registration.Config = clonePushConfig(registration.Config)
@@ -119,7 +121,7 @@ func (s *pushConfigStore) isCurrent(
 ) (bool, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	byID := s.configs[newScopedID(registration.Config.Tenant, registration.Config.TaskID)]
+	byID := s.configs[newScopedID(registration.Config.Tenant, registration.Owner, registration.Config.TaskID)]
 	current, ok := byID[registration.Config.ID]
 	return ok && current.Generation == registration.Generation, nil
 }
@@ -135,10 +137,10 @@ func clonePushConfig(cfg protocol.TaskPushNotificationConfig) protocol.TaskPushN
 }
 
 // remove deletes a single config by ID; a missing config is a no-op.
-func (s *pushConfigStore) remove(tenant, taskID, configID string) {
+func (s *pushConfigStore) remove(tenant, owner, taskID, configID string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	taskKey := newScopedID(tenant, taskID)
+	taskKey := newScopedID(tenant, owner, taskID)
 	if byID := s.configs[taskKey]; byID != nil {
 		delete(byID, configID)
 		if len(byID) == 0 {
@@ -148,10 +150,10 @@ func (s *pushConfigStore) remove(tenant, taskID, configID string) {
 }
 
 // removeAll deletes every config for taskID.
-func (s *pushConfigStore) removeAll(tenant, taskID string) {
+func (s *pushConfigStore) removeAll(tenant, owner, taskID string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	delete(s.configs, newScopedID(tenant, taskID))
+	delete(s.configs, newScopedID(tenant, owner, taskID))
 }
 
 func (s *pushConfigStore) close() {

--- a/taskmanager/memory/push_store_test.go
+++ b/taskmanager/memory/push_store_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestPushConfigStore_SaveGeneratesID(t *testing.T) {
 	s := newPushConfigStore()
-	got, err := s.save(protocol.TaskPushNotificationConfig{TaskID: "t1", URL: "https://x"})
+	got, err := s.save("", protocol.TaskPushNotificationConfig{TaskID: "t1", URL: "https://x"})
 	if err != nil {
 		t.Fatalf("save: %v", err)
 	}
@@ -25,14 +25,14 @@ func TestPushConfigStore_SaveGeneratesID(t *testing.T) {
 
 func TestPushConfigStore_SaveRequiresTaskID(t *testing.T) {
 	s := newPushConfigStore()
-	if _, err := s.save(protocol.TaskPushNotificationConfig{URL: "https://x"}); err == nil {
+	if _, err := s.save("", protocol.TaskPushNotificationConfig{URL: "https://x"}); err == nil {
 		t.Error("expected an error for empty taskId")
 	}
 }
 
 func TestPushConfigStore_SavePreservesExplicitID(t *testing.T) {
 	s := newPushConfigStore()
-	got, err := s.save(protocol.TaskPushNotificationConfig{TaskID: "t1", ID: "my-id", URL: "https://a"})
+	got, err := s.save("", protocol.TaskPushNotificationConfig{TaskID: "t1", ID: "my-id", URL: "https://a"})
 	if err != nil {
 		t.Fatalf("save: %v", err)
 	}
@@ -44,17 +44,18 @@ func TestPushConfigStore_SavePreservesExplicitID(t *testing.T) {
 func TestPushConfigStore_ClonesAuthentication(t *testing.T) {
 	s := newPushConfigStore()
 	auth := &protocol.AuthenticationInfo{Scheme: "Bearer", Credentials: "secret"}
-	_, _ = s.save(protocol.TaskPushNotificationConfig{
+	_, _ = s.save("", protocol.TaskPushNotificationConfig{
 		TaskID: "t1", ID: "c1", URL: "https://a", Authentication: auth,
 	})
+
 	auth.Credentials = "mutated"
 
-	first, ok := s.get("", "t1", "c1")
+	first, ok := s.get("", "", "t1", "c1")
 	if !ok || first.Authentication.Credentials != "secret" {
 		t.Fatalf("caller mutation changed stored config: %+v", first)
 	}
 	first.Authentication.Credentials = "returned-mutation"
-	second, _ := s.get("", "t1", "c1")
+	second, _ := s.get("", "", "t1", "c1")
 	if second.Authentication.Credentials != "secret" {
 		t.Fatalf("returned value mutation changed stored config: %+v", second)
 	}
@@ -62,18 +63,18 @@ func TestPushConfigStore_ClonesAuthentication(t *testing.T) {
 
 func TestPushConfigStore_MultipleConfigsPerTask(t *testing.T) {
 	s := newPushConfigStore()
-	c1, _ := s.save(protocol.TaskPushNotificationConfig{TaskID: "t1", URL: "https://a"})
-	c2, _ := s.save(protocol.TaskPushNotificationConfig{TaskID: "t1", URL: "https://b"})
+	c1, _ := s.save("", protocol.TaskPushNotificationConfig{TaskID: "t1", URL: "https://a"})
+	c2, _ := s.save("", protocol.TaskPushNotificationConfig{TaskID: "t1", URL: "https://b"})
 	if c1.ID == c2.ID {
 		t.Fatal("expected distinct config IDs")
 	}
 
-	if list := s.list("", "t1"); len(list) != 2 {
+	if list := s.list("", "", "t1"); len(list) != 2 {
 		t.Fatalf("expected 2 configs, got %d", len(list))
 	}
 
-	s.remove("", "t1", c1.ID)
-	list := s.list("", "t1")
+	s.remove("", "", "t1", c1.ID)
+	list := s.list("", "", "t1")
 	if len(list) != 1 || list[0].ID != c2.ID {
 		t.Fatalf("expected only c2 to remain, got %+v", list)
 	}
@@ -81,7 +82,7 @@ func TestPushConfigStore_MultipleConfigsPerTask(t *testing.T) {
 
 func TestPushConfigStore_ListEmptyIsNotNil(t *testing.T) {
 	s := newPushConfigStore()
-	list := s.list("", "nope")
+	list := s.list("", "", "nope")
 	if list == nil {
 		t.Error("expected a non-nil empty slice")
 	}
@@ -92,26 +93,26 @@ func TestPushConfigStore_ListEmptyIsNotNil(t *testing.T) {
 
 func TestPushConfigStore_RemoveAll(t *testing.T) {
 	s := newPushConfigStore()
-	_, _ = s.save(protocol.TaskPushNotificationConfig{TaskID: "t1", URL: "https://a"})
-	_, _ = s.save(protocol.TaskPushNotificationConfig{TaskID: "t1", URL: "https://b"})
-	s.removeAll("", "t1")
-	if list := s.list("", "t1"); len(list) != 0 {
+	_, _ = s.save("", protocol.TaskPushNotificationConfig{TaskID: "t1", URL: "https://a"})
+	_, _ = s.save("", protocol.TaskPushNotificationConfig{TaskID: "t1", URL: "https://b"})
+	s.removeAll("", "", "t1")
+	if list := s.list("", "", "t1"); len(list) != 0 {
 		t.Errorf("expected no configs after removeAll, got %d", len(list))
 	}
 }
 
 func TestPushConfigStore_CloseClearsAndRejectsWrites(t *testing.T) {
 	store := newPushConfigStore()
-	if _, err := store.save(protocol.TaskPushNotificationConfig{
+	if _, err := store.save("", protocol.TaskPushNotificationConfig{
 		TaskID: "task-1", URL: "https://example.com",
 	}); err != nil {
 		t.Fatal(err)
 	}
 	store.close()
-	if got := store.list("", "task-1"); len(got) != 0 {
+	if got := store.list("", "", "task-1"); len(got) != 0 {
 		t.Fatalf("closed store retained configs: %+v", got)
 	}
-	if _, err := store.save(protocol.TaskPushNotificationConfig{
+	if _, err := store.save("", protocol.TaskPushNotificationConfig{
 		TaskID: "task-1", URL: "https://example.com",
 	}); err == nil {
 		t.Fatal("closed store accepted a write")

--- a/taskmanager/memory/tenant_isolation_test.go
+++ b/taskmanager/memory/tenant_isolation_test.go
@@ -9,12 +9,157 @@ package memory
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/push"
 	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
 )
+
+type ownerContextKey struct{}
+
+func ownerContext(owner string) context.Context {
+	return context.WithValue(context.Background(), ownerContextKey{}, owner)
+}
+
+func testOwnerResolver(ctx context.Context) (string, error) {
+	owner, _ := ctx.Value(ownerContextKey{}).(string)
+	if owner == "" {
+		return "", fmt.Errorf("owner is missing")
+	}
+	return owner, nil
+}
+
+func TestTaskManagerOwnerIsolation(t *testing.T) {
+	manager := newTestManager(t, eventsExecutor(
+		statusUpdate(protocol.TaskStateWorking, nil),
+		statusUpdate(protocol.TaskStateInputRequired, nil),
+	), WithOwnerResolver(testOwnerResolver), WithPushNotifications(push.Config{ManualDelivery: true}))
+
+	const tenant = "shared-tenant"
+	aliceCtx := ownerContext("alice")
+	bobCtx := ownerContext("bob")
+	request := userParams("hello")
+	request.Tenant = tenant
+	request.Message.MessageID = "shared-message"
+	sharedContext := "shared-context"
+	request.Message.ContextID = &sharedContext
+
+	aliceResult, err := manager.OnSendMessage(aliceCtx, request)
+	if err != nil {
+		t.Fatalf("alice send: %v", err)
+	}
+	aliceTask := aliceResult.GetTask()
+	if aliceTask == nil {
+		t.Fatal("alice send did not materialize a task")
+	}
+
+	if _, err := manager.OnGetTask(bobCtx, protocol.TaskQueryParams{Tenant: tenant, ID: aliceTask.ID}); !errors.Is(err, taskmanager.ErrTaskNotFoundSentinel) {
+		t.Fatalf("bob must not get alice task: %v", err)
+	}
+	if _, err := manager.OnCancelTask(bobCtx, protocol.TaskIDParams{Tenant: tenant, ID: aliceTask.ID}); !errors.Is(err, taskmanager.ErrTaskNotFoundSentinel) {
+		t.Fatalf("bob must not cancel alice task: %v", err)
+	}
+	if _, err := manager.OnResubscribe(bobCtx, protocol.TaskIDParams{Tenant: tenant, ID: aliceTask.ID}); !errors.Is(err, taskmanager.ErrTaskNotFoundSentinel) {
+		t.Fatalf("bob must not subscribe to alice task: %v", err)
+	}
+	if _, err := manager.OnPushNotificationSet(bobCtx, protocol.TaskPushNotificationConfig{
+		Tenant: tenant, TaskID: aliceTask.ID, URL: "https://bob.example/push",
+	}); !errors.Is(err, taskmanager.ErrTaskNotFoundSentinel) {
+		t.Fatalf("bob must not register push for alice task: %v", err)
+	}
+
+	aliceList, err := manager.OnListTasks(aliceCtx, protocol.ListTasksParams{Tenant: tenant})
+	if err != nil || len(aliceList.Tasks) != 1 || aliceList.Tasks[0].ID != aliceTask.ID {
+		t.Fatalf("alice list = %+v, err=%v", aliceList, err)
+	}
+	bobList, err := manager.OnListTasks(bobCtx, protocol.ListTasksParams{Tenant: tenant})
+	if err != nil || len(bobList.Tasks) != 0 {
+		t.Fatalf("bob list leaked alice task: %+v, err=%v", bobList, err)
+	}
+
+	manager.taskMu.Lock()
+	manager.tasks[newScopedID(tenant, "bob", aliceTask.ID)] = &protocol.Task{
+		ID: aliceTask.ID, ContextID: sharedContext,
+		Status: protocol.TaskStatus{State: protocol.TaskStateWorking},
+	}
+	manager.taskMu.Unlock()
+	bobContextID := sharedContext
+	manager.storeMessage(tenant, "bob", protocol.Message{
+		MessageID: "shared-message", ContextID: &bobContextID, Role: protocol.MessageRoleAgent,
+	})
+	bobTask, err := manager.OnGetTask(bobCtx, protocol.TaskQueryParams{Tenant: tenant, ID: aliceTask.ID})
+	if err != nil || bobTask.ID != aliceTask.ID || len(bobTask.History) != 1 ||
+		bobTask.History[0].Role != protocol.MessageRoleAgent {
+		t.Fatalf("same task ID must be usable by another owner: task=%+v err=%v", bobTask, err)
+	}
+	aliceTask, err = manager.OnGetTask(aliceCtx, protocol.TaskQueryParams{Tenant: tenant, ID: aliceTask.ID})
+	if err != nil || len(aliceTask.History) != 1 || aliceTask.History[0].Role != protocol.MessageRoleUser {
+		t.Fatalf("bob's shared message/context IDs changed alice history: task=%+v err=%v", aliceTask, err)
+	}
+
+	for _, tc := range []struct {
+		ctx   context.Context
+		owner string
+		url   string
+	}{
+		{aliceCtx, "alice", "https://alice.example/push"},
+		{bobCtx, "bob", "https://bob.example/push"},
+	} {
+		if _, err := manager.OnPushNotificationSet(tc.ctx, protocol.TaskPushNotificationConfig{
+			Tenant: tenant, TaskID: aliceTask.ID, ID: "shared-config", URL: tc.url,
+		}); err != nil {
+			t.Fatalf("set %s push config: %v", tc.owner, err)
+		}
+	}
+	aliceRegistration := manager.pushStore.registrations(tenant, "alice", aliceTask.ID)[0]
+	if aliceRegistration.Owner != "alice" {
+		t.Fatalf("queued push owner = %q, want alice", aliceRegistration.Owner)
+	}
+	if current, err := manager.pushStore.isCurrent(context.Background(), aliceRegistration); err != nil || !current {
+		t.Fatalf("alice push registration current=%v err=%v", current, err)
+	}
+	if err := manager.OnPushNotificationDelete(bobCtx, protocol.DeleteTaskPushNotificationConfigParams{
+		Tenant: tenant, TaskID: aliceTask.ID, ID: "shared-config",
+	}); err != nil {
+		t.Fatalf("delete bob push config: %v", err)
+	}
+	if current, err := manager.pushStore.isCurrent(context.Background(), aliceRegistration); err != nil || !current {
+		t.Fatalf("bob push deletion invalidated alice registration: current=%v err=%v", current, err)
+	}
+
+	subCtx, cancel := context.WithCancel(bobCtx)
+	defer cancel()
+	bobStream, err := manager.OnResubscribe(subCtx, protocol.TaskIDParams{Tenant: tenant, ID: aliceTask.ID})
+	if err != nil {
+		t.Fatalf("bob subscribe to bob-owned task: %v", err)
+	}
+	if initial := <-bobStream; initial.GetTask() == nil {
+		t.Fatalf("bob initial stream frame = %+v", initial)
+	}
+	manager.notifySubscribers(tenant, "alice", aliceTask.ID,
+		protocol.NewStreamResponseMessage(agentReply("alice-only")))
+	select {
+	case event := <-bobStream:
+		t.Fatalf("alice event reached bob stream: %+v", event)
+	default:
+	}
+}
+
+func TestTaskManagerOwnerResolverFailsBeforeWrite(t *testing.T) {
+	manager := newTestManager(t, eventsExecutor(statusUpdate(protocol.TaskStateCompleted, nil)),
+		WithOwnerResolver(testOwnerResolver))
+	request := userParams("hello")
+	request.Message.MessageID = "must-not-store"
+	if _, err := manager.OnSendMessage(context.Background(), request); !errors.Is(err, taskmanager.ErrInternalErrorSentinel) {
+		t.Fatalf("send without owner error = %v, want internal error", err)
+	}
+	if len(manager.messages) != 0 || len(manager.tasks) != 0 || manager.runs.len() != 0 {
+		t.Fatalf("owner failure left state: messages=%d tasks=%d runs=%d",
+			len(manager.messages), len(manager.tasks), manager.runs.len())
+	}
+}
 
 func TestTaskManagerTenantDataIsolation(t *testing.T) {
 	manager := newTestManager(t, echoExecutor())
@@ -24,20 +169,21 @@ func TestTaskManagerTenantDataIsolation(t *testing.T) {
 	const messageID = "shared-message"
 
 	manager.taskMu.Lock()
-	manager.tasks[newScopedID("tenant-a", taskID)] = &protocol.Task{
+	manager.tasks[newScopedID("tenant-a", "", taskID)] = &protocol.Task{
 		ID: taskID, ContextID: contextID, Status: protocol.TaskStatus{State: protocol.TaskStateWorking},
 	}
-	manager.tasks[newScopedID("tenant-b", taskID)] = &protocol.Task{
+	manager.tasks[newScopedID("tenant-b", "", taskID)] = &protocol.Task{
 		ID: taskID, ContextID: contextID, Status: protocol.TaskStatus{State: protocol.TaskStateInputRequired},
 	}
 	manager.taskMu.Unlock()
 
 	contextA := contextID
-	manager.storeMessage("tenant-a", protocol.Message{
+	manager.storeMessage("tenant-a", "", protocol.Message{
 		MessageID: messageID, ContextID: &contextA, Role: protocol.MessageRoleUser,
 	})
+
 	contextB := contextID
-	manager.storeMessage("tenant-b", protocol.Message{
+	manager.storeMessage("tenant-b", "", protocol.Message{
 		MessageID: messageID, ContextID: &contextB, Role: protocol.MessageRoleAgent,
 	})
 
@@ -75,25 +221,25 @@ func TestTaskManagerTenantDataIsolation(t *testing.T) {
 		t.Fatalf("canceling tenant-a changed tenant-b: task=%+v err=%v", taskB, err)
 	}
 
-	if _, err := manager.pushStore.save(protocol.TaskPushNotificationConfig{
+	if _, err := manager.pushStore.save("", protocol.TaskPushNotificationConfig{
 		Tenant: "tenant-a", TaskID: taskID, ID: "shared-config", URL: "https://a.example/push",
 	}); err != nil {
 		t.Fatalf("save tenant-a push config: %v", err)
 	}
-	if _, err := manager.pushStore.save(protocol.TaskPushNotificationConfig{
+	if _, err := manager.pushStore.save("", protocol.TaskPushNotificationConfig{
 		Tenant: "tenant-b", TaskID: taskID, ID: "shared-config", URL: "https://b.example/push",
 	}); err != nil {
 		t.Fatalf("save tenant-b push config: %v", err)
 	}
-	if got := manager.pushStore.list("tenant-a", taskID); len(got) != 1 || got[0].URL != "https://a.example/push" {
+	if got := manager.pushStore.list("tenant-a", "", taskID); len(got) != 1 || got[0].URL != "https://a.example/push" {
 		t.Fatalf("tenant-a push config leaked: %+v", got)
 	}
 
 	subscriberA := newTaskSubscriber(taskID, 1, false)
 	manager.taskMu.Lock()
-	manager.subscribers[newScopedID("tenant-a", taskID)] = []*taskSubscriber{subscriberA}
+	manager.subscribers[newScopedID("tenant-a", "", taskID)] = []*taskSubscriber{subscriberA}
 	manager.taskMu.Unlock()
-	manager.notifySubscribers("tenant-b", taskID, protocol.NewStreamResponseTask(taskB))
+	manager.notifySubscribers("tenant-b", "", taskID, protocol.NewStreamResponseTask(taskB))
 	select {
 	case <-subscriberA.Channel():
 		t.Fatal("tenant-b event reached tenant-a subscriber")
@@ -102,14 +248,14 @@ func TestTaskManagerTenantDataIsolation(t *testing.T) {
 
 	liveA := &execution{cancel: func() {}}
 	liveB := &execution{cancel: func() {}}
-	if err := manager.runs.register(ctx, "tenant-a", taskID, liveA); err != nil {
+	if err := manager.runs.register(ctx, "tenant-a", "", taskID, liveA); err != nil {
 		t.Fatalf("register tenant-a execution: %v", err)
 	}
-	if err := manager.runs.register(ctx, "tenant-b", taskID, liveB); err != nil {
+	if err := manager.runs.register(ctx, "tenant-b", "", taskID, liveB); err != nil {
 		t.Fatalf("register tenant-b execution with the same task ID: %v", err)
 	}
-	manager.runs.release("tenant-a", taskID, liveA)
-	manager.runs.release("tenant-b", taskID, liveB)
+	manager.runs.release("tenant-a", "", taskID, liveA)
+	manager.runs.release("tenant-b", "", taskID, liveB)
 }
 
 func TestTaskManagerProcessorCannotMutateTenantScope(t *testing.T) {
@@ -159,12 +305,12 @@ func TestTaskManagerProcessorCannotMutateTenantScope(t *testing.T) {
 	}); !errors.Is(err, taskmanager.ErrTaskNotFoundSentinel) {
 		t.Fatalf("processor moved task into another tenant: %v", err)
 	}
-	configs := manager.pushStore.list("tenant-a", task.ID)
+	configs := manager.pushStore.list("tenant-a", "", task.ID)
 	if len(configs) != 1 || configs[0].TaskID != task.ID || configs[0].Authentication == nil ||
 		configs[0].Authentication.Credentials != "original-credentials" {
 		t.Fatalf("processor mutation changed stored push scope: %+v", configs)
 	}
-	if configs := manager.pushStore.list("mutated-tenant", "mutated-task"); len(configs) != 0 {
+	if configs := manager.pushStore.list("mutated-tenant", "", "mutated-task"); len(configs) != 0 {
 		t.Fatalf("processor moved push config into another tenant: %+v", configs)
 	}
 }

--- a/taskmanager/redis/redis_cross_node_test.go
+++ b/taskmanager/redis/redis_cross_node_test.go
@@ -79,6 +79,7 @@ type readSequenceTransport struct {
 func (*nonBlockingEmptyTransport) CommitTaskEvent(
 	context.Context,
 	string,
+	string,
 	*protocol.Task,
 	protocol.StreamResponse,
 	bool,
@@ -90,6 +91,7 @@ func (*nonBlockingEmptyTransport) AppendEvent(
 	context.Context,
 	string,
 	string,
+	string,
 	protocol.StreamResponse,
 ) error {
 	return nil
@@ -97,6 +99,7 @@ func (*nonBlockingEmptyTransport) AppendEvent(
 
 func (*nonBlockingEmptyTransport) LoadTaskAndCursor(
 	context.Context,
+	string,
 	string,
 	string,
 ) (*protocol.Task, string, error) {
@@ -112,12 +115,14 @@ func (*nonBlockingEmptyTransport) RefreshTaskLease(
 	context.Context,
 	string,
 	string,
+	string,
 ) error {
 	return nil
 }
 
 func (t *nonBlockingEmptyTransport) ReadAfter(
 	context.Context,
+	string,
 	string,
 	string,
 	string,
@@ -128,6 +133,7 @@ func (t *nonBlockingEmptyTransport) ReadAfter(
 
 func (*readSequenceTransport) CommitTaskEvent(
 	context.Context,
+	string,
 	string,
 	*protocol.Task,
 	protocol.StreamResponse,
@@ -140,6 +146,7 @@ func (*readSequenceTransport) AppendEvent(
 	context.Context,
 	string,
 	string,
+	string,
 	protocol.StreamResponse,
 ) error {
 	return nil
@@ -147,6 +154,7 @@ func (*readSequenceTransport) AppendEvent(
 
 func (*readSequenceTransport) LoadTaskAndCursor(
 	context.Context,
+	string,
 	string,
 	string,
 ) (*protocol.Task, string, error) {
@@ -162,12 +170,14 @@ func (*readSequenceTransport) RefreshTaskLease(
 	context.Context,
 	string,
 	string,
+	string,
 ) error {
 	return nil
 }
 
 func (t *readSequenceTransport) ReadAfter(
 	context.Context,
+	string,
 	string,
 	string,
 	string,
@@ -295,7 +305,7 @@ func TestCrossNode_ResubscribeReceivesSubsequentEvents(t *testing.T) {
 	if !drainForState(t, chB, protocol.TaskStateCompleted) {
 		t.Fatal("cross-node resubscriber never received the completed event before the stream closed")
 	}
-	if got, err := nodeA.client.XLen(context.Background(), streamKey("", taskA.ID)).Result(); err != nil || got != 2 {
+	if got, err := nodeA.client.XLen(context.Background(), streamKey("", "", taskA.ID)).Result(); err != nil || got != 2 {
 		t.Fatalf("each status must be appended exactly once: xlen=%d err=%v", got, err)
 	}
 }
@@ -305,7 +315,7 @@ func TestCrossNode_ResubscribeReceivesSubsequentEvents(t *testing.T) {
 func TestCrossNode_DeliversEventPublishedRightAfterResubscribe(t *testing.T) {
 	nodeA, nodeB := twoNodeManagers(t, scriptedExecutor())
 	task := storedTask(t, nodeA, "task-gap", "ctx-gap", protocol.TaskStateWorking)
-	if err := nodeA.appendTaskEvent(context.Background(), "", task.ID, protocol.NewStreamResponseStatusUpdate(
+	if err := nodeA.appendTaskEvent(context.Background(), "", "", task.ID, protocol.NewStreamResponseStatusUpdate(
 		statusEvent(protocol.TaskStateWorking, agentReply("w1")))); err != nil {
 		t.Fatalf("append working event: %v", err)
 	}
@@ -315,7 +325,7 @@ func TestCrossNode_DeliversEventPublishedRightAfterResubscribe(t *testing.T) {
 		t.Fatalf("OnResubscribe: %v", err)
 	}
 	// Publish the terminal event immediately after resubscribe.
-	if err := nodeA.appendTaskEvent(context.Background(), "", task.ID, protocol.NewStreamResponseStatusUpdate(
+	if err := nodeA.appendTaskEvent(context.Background(), "", "", task.ID, protocol.NewStreamResponseStatusUpdate(
 		statusEvent(protocol.TaskStateCompleted, agentReply("done")))); err != nil {
 		t.Fatalf("append completed event: %v", err)
 	}
@@ -367,7 +377,7 @@ func TestTaskEventsUseStreamByDefault(t *testing.T) {
 	if task == nil {
 		t.Fatalf("expected Task response, got %+v", response)
 	}
-	if got, err := mgr.client.XLen(context.Background(), streamKey("", task.ID)).Result(); err != nil || got != 2 {
+	if got, err := mgr.client.XLen(context.Background(), streamKey("", "", task.ID)).Result(); err != nil || got != 2 {
 		t.Fatalf("default event stream length = %d, want 2: %v", got, err)
 	}
 }
@@ -387,10 +397,10 @@ func TestSendStreamingInitialTaskDoesNotEnterJournal(t *testing.T) {
 		t.Fatalf("stream frames = %+v, want Task then two status updates", frames)
 	}
 	taskID := frames[0].GetTask().ID
-	if got, err := mgr.client.XLen(context.Background(), streamKey("", taskID)).Result(); err != nil || got != 2 {
+	if got, err := mgr.client.XLen(context.Background(), streamKey("", "", taskID)).Result(); err != nil || got != 2 {
 		t.Fatalf("journal length = %d, want only two processor updates: %v", got, err)
 	}
-	entries, err := mgr.client.XRange(context.Background(), streamKey("", taskID), "-", "+").Result()
+	entries, err := mgr.client.XRange(context.Background(), streamKey("", "", taskID), "-", "+").Result()
 	if err != nil {
 		t.Fatalf("read journal: %v", err)
 	}
@@ -447,8 +457,8 @@ func TestTaskEventCommitIsIdempotentAcrossInterleavedWrite(t *testing.T) {
 		TaskID: working.ID, ContextID: working.ContextID, Status: working.Status,
 	})
 	if err := transport.commitTaskEventWithOperationID(
-		context.Background(), "tenant-a", working, workingEvent, true, "op-a",
-	); err != nil {
+		context.Background(), "tenant-a", "",
+		working, workingEvent, true, "op-a"); err != nil {
 		t.Fatalf("first commit: %v", err)
 	}
 
@@ -458,22 +468,22 @@ func TestTaskEventCommitIsIdempotentAcrossInterleavedWrite(t *testing.T) {
 		TaskID: completed.ID, ContextID: completed.ContextID, Status: completed.Status,
 	})
 	if err := transport.commitTaskEventWithOperationID(
-		context.Background(), "tenant-a", completed, completedEvent, false, "op-b",
-	); err != nil {
+		context.Background(), "tenant-a", "",
+		completed, completedEvent, false, "op-b"); err != nil {
 		t.Fatalf("second commit: %v", err)
 	}
 	if err := transport.commitTaskEventWithOperationID(
-		context.Background(), "tenant-a", working, workingEvent, false, "op-a",
-	); err != nil {
+		context.Background(), "tenant-a", "",
+		working, workingEvent, false, "op-a"); err != nil {
 		t.Fatalf("replayed first commit: %v", err)
 	}
 
 	if got, err := manager.client.XLen(
-		context.Background(), streamKey("tenant-a", working.ID),
+		context.Background(), streamKey("tenant-a", "", working.ID),
 	).Result(); err != nil || got != 2 {
 		t.Fatalf("stream length after replay = %d, want 2: %v", got, err)
 	}
-	stored, err := manager.getTaskInternal(context.Background(), "tenant-a", working.ID)
+	stored, err := manager.getTaskInternal(context.Background(), "tenant-a", "", working.ID)
 	if err != nil {
 		t.Fatalf("load task: %v", err)
 	}
@@ -481,7 +491,7 @@ func TestTaskEventCommitIsIdempotentAcrossInterleavedWrite(t *testing.T) {
 		t.Fatalf("replayed operation rolled task back to %s", stored.Status.State)
 	}
 	if got, err := manager.client.ZCard(
-		context.Background(), streamDedupeKey("tenant-a", working.ID),
+		context.Background(), streamDedupeKey("tenant-a", "", working.ID),
 	).Result(); err != nil || got != 3 {
 		t.Fatalf("dedupe journal size = %d, want two operations plus sequence: %v", got, err)
 	}
@@ -494,16 +504,16 @@ func TestAppendTaskEventIsIdempotent(t *testing.T) {
 	first := protocol.NewStreamResponseArtifactUpdate(artifactEvent("artifact", "chunk-a"))
 	second := protocol.NewStreamResponseArtifactUpdate(artifactEvent("artifact", "chunk-b"))
 
-	if err := transport.appendEventWithOperationID(context.Background(), "", task.ID, first, "op-a"); err != nil {
+	if err := transport.appendEventWithOperationID(context.Background(), "", "", task.ID, first, "op-a"); err != nil {
 		t.Fatalf("first append: %v", err)
 	}
-	if err := transport.appendEventWithOperationID(context.Background(), "", task.ID, second, "op-b"); err != nil {
+	if err := transport.appendEventWithOperationID(context.Background(), "", "", task.ID, second, "op-b"); err != nil {
 		t.Fatalf("second append: %v", err)
 	}
-	if err := transport.appendEventWithOperationID(context.Background(), "", task.ID, first, "op-a"); err != nil {
+	if err := transport.appendEventWithOperationID(context.Background(), "", "", task.ID, first, "op-a"); err != nil {
 		t.Fatalf("replayed append: %v", err)
 	}
-	if got, err := manager.client.XLen(context.Background(), streamKey("", task.ID)).Result(); err != nil || got != 2 {
+	if got, err := manager.client.XLen(context.Background(), streamKey("", "", task.ID)).Result(); err != nil || got != 2 {
 		t.Fatalf("stream length after append replay = %d, want 2: %v", got, err)
 	}
 }
@@ -518,42 +528,43 @@ func TestTaskEventDedupeIsTenantScopedAndTypeChecked(t *testing.T) {
 		}
 		event := protocol.NewStreamResponseTask(task)
 		if err := transport.commitTaskEventWithOperationID(
-			context.Background(), tenant, task, event, true, "op-shared",
-		); err != nil {
+			context.Background(), tenant, "",
+			task, event, true, "op-shared"); err != nil {
 			t.Fatalf("commit for %s: %v", tenant, err)
 		}
 	}
 	for _, tenant := range []string{"tenant-a", "tenant-b"} {
 		if got, err := manager.client.XLen(
-			context.Background(), streamKey(tenant, "shared-task"),
+			context.Background(), streamKey(tenant, "", "shared-task"),
 		).Result(); err != nil || got != 1 {
 			t.Fatalf("%s stream length = %d, want 1: %v", tenant, got, err)
 		}
 	}
 
 	task := storedTask(t, manager, "task-wrong-dedupe", "ctx-wrong-dedupe", protocol.TaskStateWorking)
-	before, err := manager.client.Get(context.Background(), taskKey("", task.ID)).Bytes()
+	before, err := manager.client.Get(context.Background(), taskKey("", "", task.ID)).Bytes()
 	if err != nil {
 		t.Fatalf("load original task: %v", err)
 	}
 	if err := manager.client.Set(
-		context.Background(), streamDedupeKey("", task.ID), "wrong-type", 0,
+		context.Background(), streamDedupeKey("", "", task.ID), "wrong-type", 0,
 	).Err(); err != nil {
 		t.Fatalf("seed wrong-type dedupe journal: %v", err)
 	}
 	changed := copyTask(task)
 	changed.Status.State = protocol.TaskStateCompleted
 	err = transport.commitTaskEventWithOperationID(
-		context.Background(), "", changed, protocol.NewStreamResponseTask(changed), false, "op-wrong-type",
-	)
+		context.Background(), "", "",
+		changed, protocol.NewStreamResponseTask(changed), false, "op-wrong-type")
+
 	if err == nil {
 		t.Fatal("commit unexpectedly succeeded with wrong-type dedupe journal")
 	}
-	after, getErr := manager.client.Get(context.Background(), taskKey("", task.ID)).Bytes()
+	after, getErr := manager.client.Get(context.Background(), taskKey("", "", task.ID)).Bytes()
 	if getErr != nil || !bytes.Equal(after, before) {
 		t.Fatalf("failed commit changed task: before=%s after=%s err=%v", before, after, getErr)
 	}
-	if got, xlenErr := manager.client.XLen(context.Background(), streamKey("", task.ID)).Result(); xlenErr != nil || got != 0 {
+	if got, xlenErr := manager.client.XLen(context.Background(), streamKey("", "", task.ID)).Result(); xlenErr != nil || got != 0 {
 		t.Fatalf("failed commit partially appended event: len=%d err=%v", got, xlenErr)
 	}
 }
@@ -562,19 +573,19 @@ func TestReadAfterAdvancesPastMalformedEntry(t *testing.T) {
 	manager, _ := setupTest(t, scriptedExecutor())
 	task := storedTask(t, manager, "task-malformed-entry", "ctx-malformed-entry", protocol.TaskStateWorking)
 	if err := manager.client.XAdd(context.Background(), &redis.XAddArgs{
-		Stream: streamKey("", task.ID), Values: map[string]interface{}{"unexpected": "value"},
+		Stream: streamKey("", "", task.ID), Values: map[string]interface{}{"unexpected": "value"},
 	}).Err(); err != nil {
 		t.Fatalf("seed malformed entry: %v", err)
 	}
 	transport := manager.eventTransport.(*redisTaskEventTransport)
-	events, cursor, err := transport.ReadAfter(context.Background(), "", task.ID, "0-0")
+	events, cursor, err := transport.ReadAfter(context.Background(), "", "", task.ID, "0-0")
 	if err != nil {
 		t.Fatalf("ReadAfter malformed entry: %v", err)
 	}
 	if len(events) != 0 || cursor == "0-0" {
 		t.Fatalf("malformed entry result: events=%+v cursor=%q", events, cursor)
 	}
-	events, next, err := transport.ReadAfter(context.Background(), "", task.ID, cursor)
+	events, next, err := transport.ReadAfter(context.Background(), "", "", task.ID, cursor)
 	if err != nil || len(events) != 0 || next != cursor {
 		t.Fatalf("malformed entry was replayed: events=%+v cursor=%q next=%q err=%v", events, cursor, next, err)
 	}
@@ -666,7 +677,7 @@ func TestStreamResubscribe_LiveTaskRenewsLeaseUntilTerminal(t *testing.T) {
 	if task == nil || task.Status.State != protocol.TaskStateWorking {
 		t.Fatalf("expected working Task, got %+v", response)
 	}
-	if _, err := manager.storePushConfig(context.Background(), protocol.TaskPushNotificationConfig{
+	if _, err := manager.storePushConfig(context.Background(), "", protocol.TaskPushNotificationConfig{
 		TaskID: task.ID, URL: "https://example.com/live-task",
 	}); err != nil {
 		t.Fatalf("store push config: %v", err)
@@ -686,10 +697,10 @@ func TestStreamResubscribe_LiveTaskRenewsLeaseUntilTerminal(t *testing.T) {
 		mr.FastForward(700 * time.Millisecond)
 		time.Sleep(400 * time.Millisecond)
 		for _, key := range []string{
-			taskKey("", task.ID),
-			streamKey("", task.ID),
-			streamDedupeKey("", task.ID),
-			pushNotificationKey("", task.ID),
+			taskKey("", "", task.ID),
+			streamKey("", "", task.ID),
+			streamDedupeKey("", "", task.ID),
+			pushNotificationKey("", "", task.ID),
 		} {
 			if !mr.Exists(key) {
 				t.Fatalf("live lease did not retain %s after step %d", key, i+1)
@@ -699,7 +710,7 @@ func TestStreamResubscribe_LiveTaskRenewsLeaseUntilTerminal(t *testing.T) {
 
 	// Force the tenant index member stale; the next heartbeat must restore its
 	// score, otherwise ListTasks would prune a Task whose storage is still live.
-	if err := manager.client.ZAdd(context.Background(), taskIndexKey(""), redis.Z{
+	if err := manager.client.ZAdd(context.Background(), taskIndexKey("", ""), redis.Z{
 		Score: float64(time.Now().Add(-time.Second).UnixMilli()), Member: task.ID,
 	}).Err(); err != nil {
 		t.Fatalf("stale task index: %v", err)
@@ -734,10 +745,10 @@ func TestStreamResubscribe_LiveTaskRenewsLeaseUntilTerminal(t *testing.T) {
 	mr.FastForward(2 * expiration)
 	if got, err := manager.client.Exists(
 		context.Background(),
-		taskKey("", task.ID),
-		streamKey("", task.ID),
-		streamDedupeKey("", task.ID),
-		pushNotificationKey("", task.ID),
+		taskKey("", "", task.ID),
+		streamKey("", "", task.ID),
+		streamDedupeKey("", "", task.ID),
+		pushNotificationKey("", "", task.ID),
 	).Result(); err != nil || got != 0 {
 		t.Fatalf("terminal task lease kept renewing: exists=%d err=%v", got, err)
 	}
@@ -774,7 +785,7 @@ func TestContinuationRenewsLeaseBeforeProcessor(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("processor was not called")
 	}
-	if ttl := mr.TTL(taskKey("", task.ID)); ttl != expiration {
+	if ttl := mr.TTL(taskKey("", "", task.ID)); ttl != expiration {
 		t.Fatalf("task TTL at processor entry = %v, want %v", ttl, expiration)
 	}
 	close(release)
@@ -787,17 +798,17 @@ func TestContinuationRenewsLeaseBeforeProcessor(t *testing.T) {
 
 func TestRefreshTaskLeaseDoesNotCreateMissingTask(t *testing.T) {
 	manager, _ := setupTest(t, scriptedExecutor(), WithExpireTime(time.Second))
-	err := manager.refreshTaskLease(context.Background(), "tenant-a", "missing-task")
+	err := manager.refreshTaskLease(context.Background(), "tenant-a", "", "missing-task")
 	if !errors.Is(err, taskmanager.ErrTaskNotFoundSentinel) {
 		t.Fatalf("refresh missing task error = %v, want TaskNotFound", err)
 	}
 	if got, existsErr := manager.client.Exists(
 		context.Background(),
-		taskKey("tenant-a", "missing-task"),
-		streamKey("tenant-a", "missing-task"),
-		streamDedupeKey("tenant-a", "missing-task"),
-		taskIndexKey("tenant-a"),
-		pushNotificationKey("tenant-a", "missing-task"),
+		taskKey("tenant-a", "", "missing-task"),
+		streamKey("tenant-a", "", "missing-task"),
+		streamDedupeKey("tenant-a", "", "missing-task"),
+		taskIndexKey("tenant-a", ""),
+		pushNotificationKey("tenant-a", "", "missing-task"),
 	).Result(); existsErr != nil || got != 0 {
 		t.Fatalf("refresh created missing task storage: exists=%d err=%v", got, existsErr)
 	}
@@ -1000,12 +1011,12 @@ func TestCrossNode_AtomicSnapshotCursorHasNoOverlapOrGap(t *testing.T) {
 	first.ContextID = task.ContextID
 	task.Artifacts, _ = protocol.AppendArtifact(task.Artifacts, first.Artifact, false)
 	if err := nodeA.commitTaskEvent(
-		context.Background(), "", task, protocol.NewStreamResponseArtifactUpdate(first), false,
-	); err != nil {
+		context.Background(), "", "",
+		task, protocol.NewStreamResponseArtifactUpdate(first), false); err != nil {
 		t.Fatalf("store first task event: %v", err)
 	}
 
-	snapshot, cursor, err := nodeB.eventTransport.LoadTaskAndCursor(context.Background(), "", task.ID)
+	snapshot, cursor, err := nodeB.eventTransport.LoadTaskAndCursor(context.Background(), "", "", task.ID)
 	if err != nil {
 		t.Fatalf("loadTaskAndCursor: %v", err)
 	}
@@ -1013,7 +1024,7 @@ func TestCrossNode_AtomicSnapshotCursorHasNoOverlapOrGap(t *testing.T) {
 		t.Fatalf("snapshot must contain the committed artifact exactly once, got %+v", snapshot)
 	}
 	if duplicate, err := nodeB.client.XRead(context.Background(), &redis.XReadArgs{
-		Streams: []string{streamKey("", task.ID), cursor},
+		Streams: []string{streamKey("", "", task.ID), cursor},
 		Count:   1,
 		Block:   -1,
 	}).Result(); !errors.Is(err, redis.Nil) {
@@ -1027,12 +1038,12 @@ func TestCrossNode_AtomicSnapshotCursorHasNoOverlapOrGap(t *testing.T) {
 	second.Append = &appendChunk
 	task.Artifacts, _ = protocol.AppendArtifact(task.Artifacts, second.Artifact, true)
 	if err := nodeA.commitTaskEvent(
-		context.Background(), "", task, protocol.NewStreamResponseArtifactUpdate(second), false,
-	); err != nil {
+		context.Background(), "", "",
+		task, protocol.NewStreamResponseArtifactUpdate(second), false); err != nil {
 		t.Fatalf("store second task event: %v", err)
 	}
 	streams, err := nodeB.client.XRead(context.Background(), &redis.XReadArgs{
-		Streams: []string{streamKey("", task.ID), cursor},
+		Streams: []string{streamKey("", "", task.ID), cursor},
 		Count:   2,
 		Block:   -1,
 	}).Result()
@@ -1062,8 +1073,8 @@ func TestCrossNode_InputRequiredDoesNotCloseResubscribe(t *testing.T) {
 	input.ContextID = task.ContextID
 	task.Status = input.Status
 	if err := nodeA.commitTaskEvent(
-		context.Background(), "", task, protocol.NewStreamResponseStatusUpdate(input), false,
-	); err != nil {
+		context.Background(), "", "",
+		task, protocol.NewStreamResponseStatusUpdate(input), false); err != nil {
 		t.Fatalf("store input-required: %v", err)
 	}
 	if frame, ok := recvTimeout(t, stream); !ok || frame.GetStatusUpdate() == nil ||
@@ -1075,8 +1086,8 @@ func TestCrossNode_InputRequiredDoesNotCloseResubscribe(t *testing.T) {
 	completed.ContextID = task.ContextID
 	task.Status = completed.Status
 	if err := nodeA.commitTaskEvent(
-		context.Background(), "", task, protocol.NewStreamResponseStatusUpdate(completed), false,
-	); err != nil {
+		context.Background(), "", "",
+		task, protocol.NewStreamResponseStatusUpdate(completed), false); err != nil {
 		t.Fatalf("store completed: %v", err)
 	}
 	if !drainForState(t, stream, protocol.TaskStateCompleted) {
@@ -1092,7 +1103,7 @@ func TestCrossNode_ContinuationStatusMessageClearIsJournaled(t *testing.T) {
 	nodeA, nodeB := twoNodeManagers(t, scriptedExecutor(agentReply("clarification")))
 	task := storedTask(t, nodeA, "task-clear-status", "ctx-clear-status", protocol.TaskStateInputRequired)
 	task.Status.Message = agentReply("need input")
-	if err := nodeA.storeTask(context.Background(), "", task); err != nil {
+	if err := nodeA.storeTask(context.Background(), "", "", task); err != nil {
 		t.Fatalf("store task status message: %v", err)
 	}
 
@@ -1149,7 +1160,7 @@ func TestCrossNode_SlowConsumerDoesNotLoseStream(t *testing.T) {
 		update := protocol.NewStreamResponseStatusUpdate(
 			statusEvent(protocol.TaskStateWorking, agentReply("still working")),
 		)
-		if err := nodeA.appendTaskEvent(context.Background(), "", task.ID, update); err != nil {
+		if err := nodeA.appendTaskEvent(context.Background(), "", "", task.ID, update); err != nil {
 			t.Fatalf("append stream event %d: %v", i, err)
 		}
 	}
@@ -1228,7 +1239,7 @@ func TestCrossNode_IdleTailerDoesNotStarveTaskStoragePool(t *testing.T) {
 func TestCrossNode_WrongTypeStreamFailsAtomically(t *testing.T) {
 	nodeA, nodeB := twoNodeManagers(t, scriptedExecutor())
 	task := storedTask(t, nodeA, "task-wrongtype", "ctx-wrongtype", protocol.TaskStateWorking)
-	if err := nodeA.client.Set(context.Background(), streamKey("", task.ID), "not-a-stream", 0).Err(); err != nil {
+	if err := nodeA.client.Set(context.Background(), streamKey("", "", task.ID), "not-a-stream", 0).Err(); err != nil {
 		t.Fatalf("seed wrong-type stream key: %v", err)
 	}
 
@@ -1253,7 +1264,7 @@ func TestCrossNode_WrongTypeStreamFailsAtomically(t *testing.T) {
 func TestCrossNode_MessageAppendFailureIsNotExposedAsSuccess(t *testing.T) {
 	manager, _ := setupTest(t, scriptedExecutor(agentReply("reply")))
 	task := storedTask(t, manager, "task-message-fail", "ctx-message-fail", protocol.TaskStateWorking)
-	if err := manager.client.Set(context.Background(), streamKey("", task.ID), "not-a-stream", 0).Err(); err != nil {
+	if err := manager.client.Set(context.Background(), streamKey("", "", task.ID), "not-a-stream", 0).Err(); err != nil {
 		t.Fatalf("seed wrong-type stream key: %v", err)
 	}
 	params := sendParams("continue", task.ContextID)
@@ -1265,7 +1276,7 @@ func TestCrossNode_MessageAppendFailureIsNotExposedAsSuccess(t *testing.T) {
 	if !strings.Contains(err.Error(), "task event stream has wrong type") {
 		t.Fatalf("message append returned the wrong error: %v", err)
 	}
-	history, err := manager.getConversationHistory(context.Background(), "", task.ContextID, 100)
+	history, err := manager.getConversationHistory(context.Background(), "", "", task.ContextID, 100)
 	if err != nil {
 		t.Fatalf("getConversationHistory: %v", err)
 	}
@@ -1301,7 +1312,7 @@ func TestCrossNode_TaskCommitFailureIsNotExposedAsSuccess(t *testing.T) {
 			taskID := "task-" + test.name + "-fail"
 			contextID := "ctx-" + test.name + "-fail"
 			task := storedTask(t, manager, taskID, contextID, protocol.TaskStateWorking)
-			if err := manager.client.Set(context.Background(), streamKey("", task.ID), "not-a-stream", 0).Err(); err != nil {
+			if err := manager.client.Set(context.Background(), streamKey("", "", task.ID), "not-a-stream", 0).Err(); err != nil {
 				t.Fatalf("seed wrong-type stream key: %v", err)
 			}
 
@@ -1350,7 +1361,7 @@ func TestCrossNode_PersistenceFailureReturnsBeforeProcessorCloses(t *testing.T) 
 	})
 	manager, _ := setupTest(t, processor)
 	task := storedTask(t, manager, "task-fast-failure", "ctx-fast-failure", protocol.TaskStateWorking)
-	if err := manager.client.Set(context.Background(), streamKey("", task.ID), "not-a-stream", 0).Err(); err != nil {
+	if err := manager.client.Set(context.Background(), streamKey("", "", task.ID), "not-a-stream", 0).Err(); err != nil {
 		t.Fatalf("seed wrong-type stream key: %v", err)
 	}
 
@@ -1407,7 +1418,7 @@ func TestCrossNode_PersistenceFailureClosesStreamBeforeProcessorCloses(t *testin
 			manager, _ := setupTest(t, processor)
 			task := storedTask(t, manager, "task-stream-failure-"+test.name,
 				"ctx-stream-failure-"+test.name, protocol.TaskStateWorking)
-			if err := manager.client.Set(context.Background(), streamKey("", task.ID), "not-a-stream", 0).Err(); err != nil {
+			if err := manager.client.Set(context.Background(), streamKey("", "", task.ID), "not-a-stream", 0).Err(); err != nil {
 				t.Fatalf("seed wrong-type stream key: %v", err)
 			}
 
@@ -1465,7 +1476,7 @@ func TestCrossNode_FailedStatusCommitDoesNotAdvanceHistory(t *testing.T) {
 
 	deadline := time.Now().Add(time.Second)
 	for {
-		stored, err := manager.getTaskInternal(context.Background(), "", id)
+		stored, err := manager.getTaskInternal(context.Background(), "", "", id)
 		if err == nil && stored.Status.Message != nil &&
 			stored.Status.Message.Parts[0].TextContent() == "first" {
 			break
@@ -1475,7 +1486,7 @@ func TestCrossNode_FailedStatusCommitDoesNotAdvanceHistory(t *testing.T) {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	if err := manager.client.Set(context.Background(), streamKey("", id), "not-a-stream", 0).Err(); err != nil {
+	if err := manager.client.Set(context.Background(), streamKey("", "", id), "not-a-stream", 0).Err(); err != nil {
 		t.Fatalf("replace stream with wrong type: %v", err)
 	}
 	releaseProcessor()
@@ -1483,7 +1494,7 @@ func TestCrossNode_FailedStatusCommitDoesNotAdvanceHistory(t *testing.T) {
 		t.Fatalf("unexpected failed status result: %v", err)
 	}
 
-	stored, err := manager.getTaskInternal(context.Background(), "", id)
+	stored, err := manager.getTaskInternal(context.Background(), "", "", id)
 	if err != nil {
 		t.Fatalf("get stored task: %v", err)
 	}
@@ -1491,7 +1502,7 @@ func TestCrossNode_FailedStatusCommitDoesNotAdvanceHistory(t *testing.T) {
 		stored.Status.Message.Parts[0].TextContent() != "first" {
 		t.Fatalf("failed commit changed stored status: %+v", stored.Status)
 	}
-	history, err := manager.getConversationHistory(context.Background(), "", stored.ContextID, 100)
+	history, err := manager.getConversationHistory(context.Background(), "", "", stored.ContextID, 100)
 	if err != nil {
 		t.Fatalf("get conversation history: %v", err)
 	}
@@ -1519,11 +1530,11 @@ func TestCrossNode_SubMillisecondExpirationIsClamped(t *testing.T) {
 	update.ContextID = task.ContextID
 	task.Status = update.Status
 	if err := manager.commitTaskEvent(
-		context.Background(), "", task, protocol.NewStreamResponseStatusUpdate(update), false,
-	); err != nil {
+		context.Background(), "", "",
+		task, protocol.NewStreamResponseStatusUpdate(update), false); err != nil {
 		t.Fatalf("commitTaskEvent with sub-millisecond configured TTL: %v", err)
 	}
-	if got, err := manager.client.XLen(context.Background(), streamKey("", task.ID)).Result(); err != nil || got != 1 {
+	if got, err := manager.client.XLen(context.Background(), streamKey("", "", task.ID)).Result(); err != nil || got != 1 {
 		t.Fatalf("stream event missing after clamped TTL: xlen=%d err=%v", got, err)
 	}
 }
@@ -1533,7 +1544,7 @@ func TestCrossNode_SubMillisecondExpirationIsClamped(t *testing.T) {
 func TestCrossNode_TaskCommitRefreshesPushConfigExpiration(t *testing.T) {
 	manager, _ := setupTest(t, scriptedExecutor())
 	task := storedTask(t, manager, "task-push-expire", "ctx-push-expire", protocol.TaskStateWorking)
-	pushKey := pushNotificationPrefix + task.ID
+	pushKey := pushNotificationKey("", "", task.ID)
 	if err := manager.client.HSet(context.Background(), pushKey, "config", "value").Err(); err != nil {
 		t.Fatalf("seed push config: %v", err)
 	}
@@ -1545,8 +1556,8 @@ func TestCrossNode_TaskCommitRefreshesPushConfigExpiration(t *testing.T) {
 	update.ContextID = task.ContextID
 	task.Status = update.Status
 	if err := manager.commitTaskEvent(
-		context.Background(), "", task, protocol.NewStreamResponseStatusUpdate(update), false,
-	); err != nil {
+		context.Background(), "", "",
+		task, protocol.NewStreamResponseStatusUpdate(update), false); err != nil {
 		t.Fatalf("commitTaskEvent: %v", err)
 	}
 	if ttl, err := manager.client.TTL(context.Background(), pushKey).Result(); err != nil || ttl <= 0 {
@@ -1559,7 +1570,7 @@ func TestCrossNode_TaskCommitRefreshesPushConfigExpiration(t *testing.T) {
 func TestCrossNode_CloseRejectsTailerAfterSnapshotRead(t *testing.T) {
 	nodeA, nodeB := twoNodeManagers(t, scriptedExecutor())
 	task := storedTask(t, nodeA, "task-close-admission", "ctx-close-admission", protocol.TaskStateWorking)
-	if _, _, err := nodeB.eventTransport.LoadTaskAndCursor(context.Background(), "", task.ID); err != nil {
+	if _, _, err := nodeB.eventTransport.LoadTaskAndCursor(context.Background(), "", "", task.ID); err != nil {
 		t.Fatalf("warm loadTaskAndCursor script: %v", err)
 	}
 	hook := &blockAfterCommandHook{

--- a/taskmanager/redis/redis_engine.go
+++ b/taskmanager/redis/redis_engine.go
@@ -92,6 +92,9 @@ type execution struct {
 	manager *TaskManager
 	ec      *taskmanager.ExecContext
 	live    *liveExecution
+	// owner is resolved once from the request context and frozen for every
+	// foreground and detached operation performed by this execution.
+	owner string
 
 	// task is the engine's working snapshot; nil until the first task event
 	// creates the task (lazy creation: a pure-Message exchange leaves no
@@ -151,6 +154,7 @@ type execution struct {
 func (m *TaskManager) resolveContinuation(
 	ctx context.Context,
 	tenant string,
+	owner string,
 	message *protocol.Message,
 ) (*protocol.Task, error) {
 	if message.TaskID == nil || *message.TaskID == "" {
@@ -158,7 +162,7 @@ func (m *TaskManager) resolveContinuation(
 	}
 	taskID := *message.TaskID
 
-	loaded, err := m.getTaskInternal(ctx, tenant, taskID)
+	loaded, err := m.getTaskInternal(ctx, tenant, owner, taskID)
 	if err != nil {
 		return nil, err
 	}
@@ -188,6 +192,10 @@ func (m *TaskManager) prepareExecution(
 	request *protocol.SendMessageParams,
 	streaming bool,
 ) (*execution, error) {
+	owner, err := m.resolveOwner(ctx)
+	if err != nil {
+		return nil, err
+	}
 	message := &request.Message
 	if message.MessageID == "" {
 		message.MessageID = protocol.GenerateMessageID()
@@ -209,6 +217,7 @@ func (m *TaskManager) prepareExecution(
 		manager:         m,
 		ec:              &taskmanager.ExecContext{},
 		live:            &liveExecution{cancel: cancel},
+		owner:           owner,
 		immediateResult: make(chan sendOutcome, 1),
 		runFailed:       make(chan error, 1),
 		done:            make(chan struct{}),
@@ -230,7 +239,7 @@ func (m *TaskManager) prepareExecution(
 	// only after that write — so the working copy below can never be a stale
 	// pre-terminal snapshot that would smuggle writes past a terminal state.
 	// A rejected request never reaches the MessageProcessor and leaves no trace.
-	if err := m.registerExecution(ctx, request.Tenant, taskID, ex.live); err != nil {
+	if err := m.registerExecution(ctx, request.Tenant, owner, taskID, ex.live); err != nil {
 		cancel()
 		return nil, err
 	}
@@ -238,9 +247,9 @@ func (m *TaskManager) prepareExecution(
 	// Continuation: a request addressing an existing task loads it, rejects
 	// terminal tasks without invoking the MessageProcessor (the task is frozen), and
 	// hands the MessageProcessor the current snapshot via ec.Task.
-	task, err := m.resolveContinuation(ctx, request.Tenant, message)
+	task, err := m.resolveContinuation(ctx, request.Tenant, owner, message)
 	if err != nil {
-		m.releaseExecution(request.Tenant, taskID, ex.live)
+		m.releaseExecution(request.Tenant, owner, taskID, ex.live)
 		cancel()
 		return nil, err
 	}
@@ -248,8 +257,8 @@ func (m *TaskManager) prepareExecution(
 		// A continuation may take ownership just before the old TTL elapses.
 		// Renew it synchronously before invoking user code; the engine ticker
 		// takes over once ProcessMessage returns its channel.
-		if err := m.refreshTaskLease(ctx, request.Tenant, taskID); err != nil {
-			m.releaseExecution(request.Tenant, taskID, ex.live)
+		if err := m.refreshTaskLease(ctx, request.Tenant, owner, taskID); err != nil {
+			m.releaseExecution(request.Tenant, owner, taskID, ex.live)
 			cancel()
 			return nil, err
 		}
@@ -261,9 +270,9 @@ func (m *TaskManager) prepareExecution(
 		}
 	}
 	acceptedOutputModes, inlinePushConfig := messageConfigurationValues(request.Configuration)
-	pushConfig, pending, err := m.prepareInlinePushConfig(request.Tenant, taskID, task, inlinePushConfig)
+	pushConfig, pending, err := m.prepareInlinePushConfig(request.Tenant, owner, taskID, task, inlinePushConfig)
 	if err != nil {
-		m.releaseExecution(request.Tenant, taskID, ex.live)
+		m.releaseExecution(request.Tenant, owner, taskID, ex.live)
 		cancel()
 		return nil, err
 	}
@@ -290,22 +299,22 @@ func (m *TaskManager) prepareExecution(
 				ContextID: task.ContextID,
 				Status:    task.Status,
 			}
-			if err := m.commitTaskEvent(ctx, request.Tenant, task, protocol.NewStreamResponseStatusUpdate(event), false); err != nil {
-				m.releaseExecution(request.Tenant, taskID, ex.live)
+			if err := m.commitTaskEvent(ctx, request.Tenant, owner, task, protocol.NewStreamResponseStatusUpdate(event), false); err != nil {
+				m.releaseExecution(request.Tenant, owner, taskID, ex.live)
 				cancel()
 				return nil, fmt.Errorf("failed to advance task status history: %w", err)
 			}
-			m.storeStatusMessage(request.Tenant, taskID, contextID, statusMessage)
+			m.storeStatusMessage(request.Tenant, owner, taskID, contextID, statusMessage)
 		}
 		// The engine's working copy must not alias ec.Task (the MessageProcessor's
 		// read-only snapshot).
 		ex.task = copyTask(task)
 	}
-	m.storeMessage(context.Background(), request.Tenant, *message)
+	m.storeMessage(context.Background(), request.Tenant, owner, *message)
 
 	// History is the conversation snapshot truncated per the manager
 	// configuration; the request's historyLength only shapes response tasks.
-	history, err := m.getConversationHistory(ctx, request.Tenant, contextID, m.options.MaxHistoryLength)
+	history, err := m.getConversationHistory(ctx, request.Tenant, owner, contextID, m.options.MaxHistoryLength)
 	if err != nil {
 		log.Warnf("RedisTaskManager: failed to load history for context %s: %v", contextID, err)
 	}
@@ -336,12 +345,12 @@ func (m *TaskManager) prepareExecution(
 	}
 	events, err := m.processor.ProcessMessage(execCtx, &processorEC)
 	if err != nil {
-		m.releaseExecution(request.Tenant, taskID, ex.live)
+		m.releaseExecution(request.Tenant, owner, taskID, ex.live)
 		cancel()
 		return nil, err
 	}
 	if events == nil {
-		m.releaseExecution(request.Tenant, taskID, ex.live)
+		m.releaseExecution(request.Tenant, owner, taskID, ex.live)
 		cancel()
 		return nil, taskmanager.ErrInternalError("processor returned nil channel")
 	}
@@ -367,6 +376,7 @@ func messageConfigurationValues(
 // task event so a failed start or pure-Message reply cannot leave an orphan.
 func (m *TaskManager) prepareInlinePushConfig(
 	tenant string,
+	owner string,
 	taskID string,
 	task *protocol.Task,
 	config *protocol.TaskPushNotificationConfig,
@@ -387,7 +397,7 @@ func (m *TaskManager) prepareInlinePushConfig(
 		return nil, false, taskmanager.ErrInvalidParams(err.Error())
 	}
 	if task != nil {
-		if _, err := m.storePushConfig(context.Background(), pushConfig); err != nil {
+		if _, err := m.storePushConfig(context.Background(), owner, pushConfig); err != nil {
 			return nil, false, err
 		}
 		return &pushConfig, false, nil
@@ -448,7 +458,7 @@ func (ex *execution) refreshTaskLease() {
 	if ex.task == nil || isFinalState(ex.task.Status.State) || ex.yielded || ex.runErr != nil {
 		return
 	}
-	err := ex.manager.refreshTaskLease(context.Background(), ex.ec.Tenant, ex.ec.TaskID)
+	err := ex.manager.refreshTaskLease(context.Background(), ex.ec.Tenant, ex.owner, ex.ec.TaskID)
 	if err == nil {
 		return
 	}
@@ -579,7 +589,7 @@ func (ex *execution) finish() {
 	if ex.pipe != nil {
 		ex.pipe.Close()
 	}
-	ex.manager.deregisterExecution(ex.ec.Tenant, ex.ec.TaskID, ex.live)
+	ex.manager.deregisterExecution(ex.ec.Tenant, ex.owner, ex.ec.TaskID, ex.live)
 	ex.live.cancel()
 	close(ex.done)
 }
@@ -658,7 +668,7 @@ func (ex *execution) processMessageEvent(msg *protocol.Message) {
 	ex.manager.stampReplyMessage(&contextID, msg)
 	response := protocol.NewStreamResponseMessage(msg)
 	if ex.task != nil {
-		if err := ex.manager.appendTaskEvent(context.Background(), ex.ec.Tenant, ex.ec.TaskID, response); err != nil {
+		if err := ex.manager.appendTaskEvent(context.Background(), ex.ec.Tenant, ex.owner, ex.ec.TaskID, response); err != nil {
 			ex.failRun(fmt.Errorf("failed to store message event for task %s: %w", ex.ec.TaskID, err))
 			return
 		}
@@ -666,7 +676,7 @@ func (ex *execution) processMessageEvent(msg *protocol.Message) {
 	// The event journal is the success boundary for a reply attached to a Task.
 	// Store conversation history only after the append succeeds, so a failed
 	// request cannot leave behind an agent reply that no stream observed.
-	ex.manager.storeMessage(context.Background(), ex.ec.Tenant, *msg)
+	ex.manager.storeMessage(context.Background(), ex.ec.Tenant, ex.owner, *msg)
 	ex.lastMessage = msg
 	ex.offerImmediateResult(sendOutcome{message: msg})
 	ex.broadcast(response)
@@ -674,7 +684,7 @@ func (ex *execution) processMessageEvent(msg *protocol.Message) {
 
 // storeStatusMessage stores a stamped copy without mutating the processor's
 // message, which may still be visible in an earlier task snapshot or wire event.
-func (m *TaskManager) storeStatusMessage(tenant, taskID, contextID string, message *protocol.Message) {
+func (m *TaskManager) storeStatusMessage(tenant, owner, taskID, contextID string, message *protocol.Message) {
 	if message == nil {
 		return
 	}
@@ -685,7 +695,7 @@ func (m *TaskManager) storeStatusMessage(tenant, taskID, contextID string, messa
 	if stored.MessageID == "" {
 		stored.MessageID = protocol.GenerateMessageID()
 	}
-	m.storeMessage(context.Background(), tenant, stored)
+	m.storeMessage(context.Background(), tenant, owner, stored)
 }
 
 // rollStatusMessage moves a superseded status message into conversation
@@ -698,7 +708,7 @@ func (ex *execution) rollStatusMessage(message *protocol.Message) {
 		return
 	}
 	ex.lastStatusMsg = message
-	ex.manager.storeStatusMessage(ex.ec.Tenant, ex.ec.TaskID, ex.ec.ContextID, message)
+	ex.manager.storeStatusMessage(ex.ec.Tenant, ex.owner, ex.ec.TaskID, ex.ec.ContextID, message)
 }
 
 // processStatusEvent applies a status update to the task (lazily creating it
@@ -756,15 +766,15 @@ func (ex *execution) processStatusEvent(ev *protocol.TaskStatusUpdateEvent) {
 		// be rejected as a concurrent execution. If cancellation claimed the slot
 		// first, keep this round active so its close rule can persist CANCELED
 		// rather than swallowing the accepted cancellation.
-		yielding = ex.manager.beginExecutionYield(ex.ec.Tenant, ex.ec.TaskID, ex.live)
+		yielding = ex.manager.beginExecutionYield(ex.ec.Tenant, ex.owner, ex.ec.TaskID, ex.live)
 	}
 	// Persist before broadcast (consistency order). A failure terminates the
 	// execution result: the mutated working copy is never returned as if it had
 	// committed successfully.
 	response := protocol.NewStreamResponseStatusUpdate(ev)
-	if err := ex.manager.commitTaskEvent(context.Background(), ex.ec.Tenant, ex.task, response, allowCreate); err != nil {
+	if err := ex.manager.commitTaskEvent(context.Background(), ex.ec.Tenant, ex.owner, ex.task, response, allowCreate); err != nil {
 		if yielding {
-			ex.manager.abortExecutionYield(ex.ec.Tenant, ex.ec.TaskID, ex.live)
+			ex.manager.abortExecutionYield(ex.ec.Tenant, ex.owner, ex.ec.TaskID, ex.live)
 		}
 		ex.failRun(fmt.Errorf("failed to store task %s status %s: %w", ev.TaskID, status.State, err))
 		return
@@ -776,7 +786,7 @@ func (ex *execution) processStatusEvent(ev *protocol.TaskStatusUpdateEvent) {
 	ex.rollStatusMessage(previousStatusMessage)
 	if err := ex.persistInlinePushConfig(); err != nil {
 		if yielding {
-			ex.manager.abortExecutionYield(ex.ec.Tenant, ex.ec.TaskID, ex.live)
+			ex.manager.abortExecutionYield(ex.ec.Tenant, ex.owner, ex.ec.TaskID, ex.live)
 		}
 		log.Errorf("RedisTaskManager: failed to persist inline push config for task %s: %v", ex.ec.TaskID, err)
 		ex.failTask("failed to persist inline push config")
@@ -789,7 +799,7 @@ func (ex *execution) processStatusEvent(ev *protocol.TaskStatusUpdateEvent) {
 		// cannot yet continue. The handoff starts before enqueue so a client that
 		// polls the persisted task also waits instead of being rejected. It also
 		// serializes current-request delivery with a continuation round.
-		ex.manager.dispatchPush(ex.ec.Tenant, ex.ec.TaskID, response)
+		ex.manager.dispatchPush(ex.ec.Tenant, ex.owner, ex.ec.TaskID, response)
 		ex.offerImmediateTask()
 		ex.broadcastWithoutPush(response)
 		ex.closePipe()
@@ -798,7 +808,7 @@ func (ex *execution) processStatusEvent(ev *protocol.TaskStatusUpdateEvent) {
 		// registry: Close cannot discover the execution once the slot is released,
 		// but still waits for its drain engine to finish.
 		ex.live.cancel()
-		ex.manager.deregisterExecution(ex.ec.Tenant, ex.ec.TaskID, ex.live)
+		ex.manager.deregisterExecution(ex.ec.Tenant, ex.owner, ex.ec.TaskID, ex.live)
 		return
 	}
 
@@ -847,7 +857,7 @@ func (ex *execution) processArtifactEvent(ev *protocol.TaskArtifactUpdateEvent) 
 	ex.taskTouched = true
 	// Persist before broadcast (consistency order).
 	response := protocol.NewStreamResponseArtifactUpdate(ev)
-	if err := ex.manager.commitTaskEvent(context.Background(), ex.ec.Tenant, ex.task, response, allowCreate); err != nil {
+	if err := ex.manager.commitTaskEvent(context.Background(), ex.ec.Tenant, ex.owner, ex.task, response, allowCreate); err != nil {
 		ex.failRun(fmt.Errorf("failed to store task %s artifact: %w", ev.TaskID, err))
 		return
 	}
@@ -868,7 +878,7 @@ func (ex *execution) persistInlinePushConfig() error {
 		return nil
 	}
 	ex.inlinePushPending = false
-	if _, err := ex.manager.storePushConfig(context.Background(), *ex.ec.PushConfig); err != nil {
+	if _, err := ex.manager.storePushConfig(context.Background(), ex.owner, *ex.ec.PushConfig); err != nil {
 		return err
 	}
 	return nil
@@ -902,7 +912,7 @@ func (ex *execution) sendInitialTask(task *protocol.Task) {
 	if task == nil || ex.pipe == nil {
 		return
 	}
-	ex.manager.fillTaskHistory(context.Background(), ex.ec.Tenant, task, ex.historyLength)
+	ex.manager.fillTaskHistory(context.Background(), ex.ec.Tenant, ex.owner, task, ex.historyLength)
 	if err := ex.pipe.Send(protocol.NewStreamResponseTask(task)); err != nil {
 		log.Warnf("RedisTaskManager: failed to send initial Task for task %s: %v", ex.ec.TaskID, err)
 	}
@@ -918,7 +928,7 @@ func (ex *execution) broadcast(event protocol.StreamResponse) {
 		}
 	}
 	if ex.task != nil {
-		ex.manager.dispatchPush(ex.ec.Tenant, ex.ec.TaskID, event)
+		ex.manager.dispatchPush(ex.ec.Tenant, ex.owner, ex.ec.TaskID, event)
 	}
 }
 

--- a/taskmanager/redis/redis_engine_test.go
+++ b/taskmanager/redis/redis_engine_test.go
@@ -307,7 +307,7 @@ func TestOnSendMessage_ContinuationContextMismatchRejected(t *testing.T) {
 		t.Fatalf("processor must not run for the rejected round, invocations=%d", got)
 	}
 	// The rejected continuation must not store the request message.
-	if mr.Exists(messagePrefix + "mismatch-msg") {
+	if mr.Exists(messageKey("", "", "mismatch-msg")) {
 		t.Fatal("rejected continuation must not store the request message")
 	}
 }
@@ -332,13 +332,13 @@ func TestOnSendMessage_RejectedContinuationLeavesPersistenceUntouched(t *testing
 		t.Fatalf("round 1 failed: %v", err)
 	}
 	taskID := first.GetTask().ID
-	taskKey := taskPrefix + taskID
-	conversationKey := conversationPrefix + "ctx-rejected-continuation"
-	beforeTask, err := m.client.Get(context.Background(), taskKey).Bytes()
+	storedTaskKey := taskKey("", "", taskID)
+	storedConversationKey := conversationKey("", "", "ctx-rejected-continuation")
+	beforeTask, err := m.client.Get(context.Background(), storedTaskKey).Bytes()
 	if err != nil {
 		t.Fatalf("read task before continuation: %v", err)
 	}
-	beforeHistory, err := m.client.LRange(context.Background(), conversationKey, 0, -1).Result()
+	beforeHistory, err := m.client.LRange(context.Background(), storedConversationKey, 0, -1).Result()
 	if err != nil {
 		t.Fatalf("read history before continuation: %v", err)
 	}
@@ -352,14 +352,14 @@ func TestOnSendMessage_RejectedContinuationLeavesPersistenceUntouched(t *testing
 	_, err = m.OnSendMessage(context.Background(), followUp)
 	assertTaskManagerCode(t, err, taskmanager.ErrPushNotificationNotSupported().Code)
 
-	afterTask, err := m.client.Get(context.Background(), taskKey).Bytes()
+	afterTask, err := m.client.Get(context.Background(), storedTaskKey).Bytes()
 	if err != nil {
 		t.Fatalf("read task after continuation: %v", err)
 	}
 	if !bytes.Equal(afterTask, beforeTask) {
 		t.Fatal("rejected continuation changed the stored task snapshot")
 	}
-	afterHistory, err := m.client.LRange(context.Background(), conversationKey, 0, -1).Result()
+	afterHistory, err := m.client.LRange(context.Background(), storedConversationKey, 0, -1).Result()
 	if err != nil {
 		t.Fatalf("read history after continuation: %v", err)
 	}
@@ -367,7 +367,7 @@ func TestOnSendMessage_RejectedContinuationLeavesPersistenceUntouched(t *testing
 		t.Fatalf("rejected continuation changed history: before=%v after=%v", beforeHistory, afterHistory)
 	}
 	if exists, err := m.client.Exists(
-		context.Background(), messagePrefix+followUp.Message.MessageID,
+		context.Background(), messageKey("", "", followUp.Message.MessageID),
 	).Result(); err != nil || exists != 0 {
 		t.Fatalf("rejected continuation stored its message: exists=%d err=%v", exists, err)
 	}
@@ -408,12 +408,12 @@ func TestEngine_UnspecifiedStateIsViolation(t *testing.T) {
 	}
 
 	// Zero-trace variant: the stateless event is the only one -> -32603 and no
-	// task:* keys.
+	// task keys.
 	m2, mr2 := setupTest(t, scriptedExecutor(statusEvent(protocol.TaskStateUnspecified, nil)))
 	_, err = m2.OnSendMessage(context.Background(), sendParams("go", "ctx-unspec2"))
 	assertTaskManagerCode(t, err, taskmanager.ErrCodeInternalError)
 	for _, key := range mr2.Keys() {
-		if strings.HasPrefix(key, taskPrefix) {
+		if strings.HasPrefix(key, tenantKeyPrefix("")+taskPrefix) {
 			t.Errorf("violation before any task must leave no task key, found %s", key)
 		}
 	}
@@ -549,7 +549,7 @@ func TestOnSendMessageStream_StartupFailureLeavesNoTrace(t *testing.T) {
 		t.Fatalf("expected the startup error, got %v", err)
 	}
 	for _, key := range mr.Keys() {
-		if strings.HasPrefix(key, taskPrefix) {
+		if strings.HasPrefix(key, tenantKeyPrefix("")+taskPrefix) {
 			t.Fatalf("startup failure must leave no task, found %s", key)
 		}
 	}

--- a/taskmanager/redis/redis_event_transport.go
+++ b/taskmanager/redis/redis_event_transport.go
@@ -34,6 +34,7 @@ type taskEventTransport interface {
 	CommitTaskEvent(
 		ctx context.Context,
 		tenant string,
+		owner string,
 		task *protocol.Task,
 		event protocol.StreamResponse,
 		allowCreate bool,
@@ -42,6 +43,7 @@ type taskEventTransport interface {
 	AppendEvent(
 		ctx context.Context,
 		tenant string,
+		owner string,
 		taskID string,
 		event protocol.StreamResponse,
 	) error
@@ -50,6 +52,7 @@ type taskEventTransport interface {
 	LoadTaskAndCursor(
 		ctx context.Context,
 		tenant string,
+		owner string,
 		taskID string,
 	) (*protocol.Task, string, error)
 	// ReadAfter returns an ordered batch strictly after cursor and the cursor for
@@ -58,12 +61,13 @@ type taskEventTransport interface {
 	ReadAfter(
 		ctx context.Context,
 		tenant string,
+		owner string,
 		taskID string,
 		cursor string,
 	) ([]protocol.StreamResponse, string, error)
 	// RefreshTaskLease extends an existing live Task and its event journal. It
 	// must not create a missing Task.
-	RefreshTaskLease(ctx context.Context, tenant string, taskID string) error
+	RefreshTaskLease(ctx context.Context, tenant string, owner string, taskID string) error
 }
 
 const (
@@ -228,29 +232,31 @@ func newRedisTaskEventTransport(
 // streamKey shares the task key's Redis Cluster slot without changing the
 // existing task key. Redis hashes the full task key and the {...} portion of
 // the stream key, which are the same bytes for manager-generated task IDs.
-func streamKey(tenant, taskID string) string {
-	return streamPrefix + "{" + taskKey(tenant, taskID) + "}"
+func streamKey(tenant, owner, taskID string) string {
+	return streamPrefix + "{" + taskKey(tenant, owner, taskID) + "}"
 }
 
-func streamDedupeKey(tenant, taskID string) string {
-	return streamDedupePrefix + "{" + taskKey(tenant, taskID) + "}"
+func streamDedupeKey(tenant, owner, taskID string) string {
+	return streamDedupePrefix + "{" + taskKey(tenant, owner, taskID) + "}"
 }
 
 func (t *redisTaskEventTransport) CommitTaskEvent(
 	ctx context.Context,
 	tenant string,
+	owner string,
 	task *protocol.Task,
 	event protocol.StreamResponse,
 	allowCreate bool,
 ) error {
 	return t.commitTaskEventWithOperationID(
-		ctx, tenant, task, event, allowCreate, "op-"+protocol.GenerateMessageID(),
+		ctx, tenant, owner, task, event, allowCreate, "op-"+protocol.GenerateMessageID(),
 	)
 }
 
 func (t *redisTaskEventTransport) commitTaskEventWithOperationID(
 	ctx context.Context,
 	tenant string,
+	owner string,
 	task *protocol.Task,
 	event protocol.StreamResponse,
 	allowCreate bool,
@@ -272,9 +278,9 @@ func (t *redisTaskEventTransport) commitTaskEventWithOperationID(
 		ctx,
 		t.client,
 		[]string{
-			taskKey(tenant, task.ID),
-			streamKey(tenant, task.ID),
-			streamDedupeKey(tenant, task.ID),
+			taskKey(tenant, owner, task.ID),
+			streamKey(tenant, owner, task.ID),
+			streamDedupeKey(tenant, owner, task.ID),
 		},
 		taskBytes,
 		eventBytes,
@@ -292,17 +298,19 @@ func (t *redisTaskEventTransport) commitTaskEventWithOperationID(
 func (t *redisTaskEventTransport) AppendEvent(
 	ctx context.Context,
 	tenant string,
+	owner string,
 	taskID string,
 	event protocol.StreamResponse,
 ) error {
 	return t.appendEventWithOperationID(
-		ctx, tenant, taskID, event, "op-"+protocol.GenerateMessageID(),
+		ctx, tenant, owner, taskID, event, "op-"+protocol.GenerateMessageID(),
 	)
 }
 
 func (t *redisTaskEventTransport) appendEventWithOperationID(
 	ctx context.Context,
 	tenant string,
+	owner string,
 	taskID string,
 	event protocol.StreamResponse,
 	operationID string,
@@ -315,9 +323,9 @@ func (t *redisTaskEventTransport) appendEventWithOperationID(
 		ctx,
 		t.client,
 		[]string{
-			taskKey(tenant, taskID),
-			streamKey(tenant, taskID),
-			streamDedupeKey(tenant, taskID),
+			taskKey(tenant, owner, taskID),
+			streamKey(tenant, owner, taskID),
+			streamDedupeKey(tenant, owner, taskID),
 		},
 		payload,
 		streamMaxLen,
@@ -332,12 +340,13 @@ func (t *redisTaskEventTransport) appendEventWithOperationID(
 func (t *redisTaskEventTransport) LoadTaskAndCursor(
 	ctx context.Context,
 	tenant string,
+	owner string,
 	taskID string,
 ) (*protocol.Task, string, error) {
 	values, err := loadTaskAndCursorScript.Run(
 		ctx,
 		t.client,
-		[]string{taskKey(tenant, taskID), streamKey(tenant, taskID)},
+		[]string{taskKey(tenant, owner, taskID), streamKey(tenant, owner, taskID)},
 	).Slice()
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to load task %s and stream cursor: %w", taskID, err)
@@ -370,13 +379,14 @@ func (t *redisTaskEventTransport) LoadTaskAndCursor(
 func (t *redisTaskEventTransport) ReadAfter(
 	ctx context.Context,
 	tenant string,
+	owner string,
 	taskID string,
 	cursor string,
 ) ([]protocol.StreamResponse, string, error) {
 	values, err := readAfterScript.Run(
 		ctx,
 		t.client,
-		[]string{taskKey(tenant, taskID), streamKey(tenant, taskID)},
+		[]string{taskKey(tenant, owner, taskID), streamKey(tenant, owner, taskID)},
 		cursor,
 		streamReadCount,
 		streamField,
@@ -418,15 +428,16 @@ func (t *redisTaskEventTransport) ReadAfter(
 func (t *redisTaskEventTransport) RefreshTaskLease(
 	ctx context.Context,
 	tenant string,
+	owner string,
 	taskID string,
 ) error {
 	refreshed, err := refreshTaskLeaseScript.Run(
 		ctx,
 		t.client,
 		[]string{
-			taskKey(tenant, taskID),
-			streamKey(tenant, taskID),
-			streamDedupeKey(tenant, taskID),
+			taskKey(tenant, owner, taskID),
+			streamKey(tenant, owner, taskID),
+			streamDedupeKey(tenant, owner, taskID),
 		},
 		t.expiration.Milliseconds(),
 	).Int()

--- a/taskmanager/redis/redis_manager.go
+++ b/taskmanager/redis/redis_manager.go
@@ -28,12 +28,14 @@ import (
 
 const (
 	// Key prefixes for Redis storage.
-	messagePrefix          = "msg:"
-	conversationPrefix     = "conv:"
-	taskPrefix             = "task:"
-	taskIndexPrefix        = "taskidx:"
-	pushNotificationPrefix = "push:"
-	tenantNamespacePrefix  = "tenant:"
+	messagePrefix           = "msg:"
+	conversationPrefix      = "conv:"
+	taskPrefix              = "task:"
+	taskIndexPrefix         = "taskidx:"
+	pushNotificationPrefix  = "push:"
+	tenantNamespacePrefix   = "tenant:"
+	defaultTenantKeySegment = "~default"
+	ownerNamespacePrefix    = "owner:"
 
 	// Default expiration time for Redis keys (1 hour).
 	defaultExpiration = 1 * time.Hour
@@ -45,43 +47,55 @@ const (
 	taskEventReadIdleMaxDelay       = time.Second
 )
 
-// scopedID is the process-local identity of tenant-owned runtime state.
+// scopedID is the process-local identity of tenant-and-owner-scoped runtime state.
 type scopedID struct {
 	tenant string
+	owner  string
 	id     string
 }
 
-func newScopedID(tenant, id string) scopedID {
-	return scopedID{tenant: tenant, id: id}
+func newScopedID(tenant, owner, id string) scopedID {
+	return scopedID{tenant: tenant, owner: owner, id: id}
 }
 
-// tenantKeyPrefix namespaces Redis data without changing legacy empty-tenant
-// keys. Raw URL-safe base64 makes tenant values unambiguous key segments.
+// tenantKeyPrefix places every Redis key in a tenant namespace. An empty
+// protocol tenant selects an internal sentinel outside the URL-safe base64
+// alphabet; explicit tenant values remain encoded as unambiguous key segments.
 func tenantKeyPrefix(tenant string) string {
 	if tenant == "" {
-		return ""
+		return tenantNamespacePrefix + defaultTenantKeySegment + ":"
 	}
 	return tenantNamespacePrefix + base64.RawURLEncoding.EncodeToString([]byte(tenant)) + ":"
 }
 
-func messageKey(tenant, messageID string) string {
-	return tenantKeyPrefix(tenant) + messagePrefix + messageID
+// ownerKeyPrefix extends the tenant namespace with an authorization owner.
+// Empty owner omits the optional owner segment.
+func ownerKeyPrefix(tenant, owner string) string {
+	prefix := tenantKeyPrefix(tenant)
+	if owner == "" {
+		return prefix
+	}
+	return prefix + ownerNamespacePrefix + base64.RawURLEncoding.EncodeToString([]byte(owner)) + ":"
 }
 
-func conversationKey(tenant, contextID string) string {
-	return tenantKeyPrefix(tenant) + conversationPrefix + contextID
+func messageKey(tenant, owner, messageID string) string {
+	return ownerKeyPrefix(tenant, owner) + messagePrefix + messageID
 }
 
-func taskKey(tenant, taskID string) string {
-	return tenantKeyPrefix(tenant) + taskPrefix + taskID
+func conversationKey(tenant, owner, contextID string) string {
+	return ownerKeyPrefix(tenant, owner) + conversationPrefix + contextID
 }
 
-func taskIndexKey(tenant string) string {
-	return tenantKeyPrefix(tenant) + taskIndexPrefix + "all"
+func taskKey(tenant, owner, taskID string) string {
+	return ownerKeyPrefix(tenant, owner) + taskPrefix + taskID
 }
 
-func pushNotificationKey(tenant, taskID string) string {
-	return tenantKeyPrefix(tenant) + pushNotificationPrefix + taskID
+func taskIndexKey(tenant, owner string) string {
+	return ownerKeyPrefix(tenant, owner) + taskIndexPrefix + "all"
+}
+
+func pushNotificationKey(tenant, owner, taskID string) string {
+	return ownerKeyPrefix(tenant, owner) + pushNotificationPrefix + taskID
 }
 
 // appendConversationMessageScript appends a MessageID exactly once, trims the
@@ -118,7 +132,7 @@ type TaskManager struct {
 	eventTransport taskEventTransport
 	// cancelMu is a mutex for the executions map and the closed flag.
 	cancelMu sync.RWMutex
-	// executions maps tenant-scoped task IDs to live execution handles so OnCancelTask can
+	// executions maps tenant-and-owner-scoped task IDs to live execution handles so OnCancelTask can
 	// cancel the MessageProcessor's context.
 	executions map[scopedID]*liveExecution
 	// closed rejects new runs once Close has begun tearing the manager down.
@@ -149,6 +163,20 @@ type TaskManager struct {
 
 	// options
 	options *TaskManagerOptions
+}
+
+func (m *TaskManager) resolveOwner(ctx context.Context) (string, error) {
+	if m.options.OwnerResolver == nil {
+		return "", nil
+	}
+	owner, err := m.options.OwnerResolver(ctx)
+	if err != nil {
+		return "", taskmanager.ErrInternalError(fmt.Sprintf("resolve task owner: %v", err))
+	}
+	if owner == "" {
+		return "", taskmanager.ErrInternalError("task owner resolver returned an empty owner")
+	}
+	return owner, nil
 }
 
 // NewTaskManager creates a new Redis-based TaskManager with the provided options.
@@ -232,7 +260,7 @@ func (m *TaskManager) OnSendMessage(
 		// background and results stay retrievable via GetTask/subscriptions.
 		select {
 		case out := <-ex.immediateResult:
-			return m.buildSendResponse(request.Tenant, out.task, out.message, historyLength)
+			return m.buildSendResponse(request.Tenant, ex.owner, out.task, out.message, historyLength)
 		case err := <-ex.runFailed:
 			return nil, err
 		case <-ex.done:
@@ -241,7 +269,7 @@ func (m *TaskManager) OnSendMessage(
 			if ex.runErr != nil {
 				return nil, ex.runErr
 			}
-			return m.buildSendResponse(request.Tenant, ex.finalTask, ex.lastMessage, historyLength)
+			return m.buildSendResponse(request.Tenant, ex.owner, ex.finalTask, ex.lastMessage, historyLength)
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		}
@@ -254,7 +282,7 @@ func (m *TaskManager) OnSendMessage(
 		if ex.runErr != nil {
 			return nil, ex.runErr
 		}
-		return m.buildSendResponse(request.Tenant, ex.finalTask, ex.lastMessage, historyLength)
+		return m.buildSendResponse(request.Tenant, ex.owner, ex.finalTask, ex.lastMessage, historyLength)
 	case <-ctx.Done():
 		// The request died first. The execution is detached: it keeps running
 		// and its results stay retrievable via GetTask/resubscribe.
@@ -296,7 +324,11 @@ func (m *TaskManager) OnGetTask(
 	ctx context.Context,
 	params protocol.TaskQueryParams,
 ) (*protocol.Task, error) {
-	task, err := m.getTaskInternal(ctx, params.Tenant, params.ID)
+	owner, err := m.resolveOwner(ctx)
+	if err != nil {
+		return nil, err
+	}
+	task, err := m.getTaskInternal(ctx, params.Tenant, owner, params.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -305,7 +337,7 @@ func (m *TaskManager) OnGetTask(
 	//   - historyLength unset -> no limit (full history)
 	//   - historyLength == 0  -> no messages
 	//   - historyLength > 0   -> the most recent N messages
-	m.fillTaskHistory(ctx, params.Tenant, task, params.HistoryLength)
+	m.fillTaskHistory(ctx, params.Tenant, owner, task, params.HistoryLength)
 
 	return task, nil
 }
@@ -316,6 +348,7 @@ func (m *TaskManager) OnGetTask(
 func (m *TaskManager) fillTaskHistory(
 	ctx context.Context,
 	tenant string,
+	owner string,
 	task *protocol.Task,
 	historyLength *int,
 ) {
@@ -331,7 +364,7 @@ func (m *TaskManager) fillTaskHistory(
 		task.History = nil
 		return
 	}
-	history, err := m.getConversationHistory(ctx, tenant, task.ContextID, length)
+	history, err := m.getConversationHistory(ctx, tenant, owner, task.ContextID, length)
 	if err != nil {
 		log.Warnf("Failed to retrieve message history for task %s: %v", task.ID, err)
 		// Continue without history rather than failing the whole request.
@@ -353,12 +386,13 @@ func historyLengthFromConfig(config *protocol.SendMessageConfiguration) *int {
 // message; an execution that produced neither is an MessageProcessor bug.
 func (m *TaskManager) buildSendResponse(
 	tenant string,
+	owner string,
 	task *protocol.Task,
 	message *protocol.Message,
 	historyLength *int,
 ) (*protocol.SendMessageResponse, error) {
 	if task != nil {
-		m.fillTaskHistory(context.Background(), tenant, task, historyLength)
+		m.fillTaskHistory(context.Background(), tenant, owner, task, historyLength)
 		return protocol.NewSendMessageResponseTask(task), nil
 	}
 	if message != nil {
@@ -378,8 +412,12 @@ func (m *TaskManager) OnCancelTask(
 	ctx context.Context,
 	params protocol.TaskIDParams,
 ) (*protocol.Task, error) {
+	owner, err := m.resolveOwner(ctx)
+	if err != nil {
+		return nil, err
+	}
 	for {
-		live, sentinel, yieldDone := m.claimCancelSlot(params.Tenant, params.ID)
+		live, sentinel, yieldDone := m.claimCancelSlot(params.Tenant, owner, params.ID)
 		if yieldDone != nil {
 			select {
 			case <-yieldDone:
@@ -389,13 +427,13 @@ func (m *TaskManager) OnCancelTask(
 			}
 		}
 		if live == nil {
-			defer m.deregisterExecution(params.Tenant, params.ID, sentinel)
-			return m.cancelWithoutLiveRun(ctx, params)
+			defer m.deregisterExecution(params.Tenant, owner, params.ID, sentinel)
+			return m.cancelWithoutLiveRun(ctx, owner, params)
 		}
 
 		// A stored terminal state is immutable even while the round is still
 		// draining: canceling it must fail like the no-live path does.
-		task, err := m.getTaskInternal(ctx, params.Tenant, params.ID)
+		task, err := m.getTaskInternal(ctx, params.Tenant, owner, params.ID)
 		if err != nil && !errors.Is(err, taskmanager.ErrTaskNotFoundSentinel) {
 			// Storage error, not a missing task: canceling is irreversible, so
 			// do not cancel a healthy run because the lookup blipped.
@@ -407,7 +445,7 @@ func (m *TaskManager) OnCancelTask(
 		// Linearize cancellation against a concurrent suspend handoff. If the
 		// handoff won, wait for it and retry as a no-live cancel; otherwise the
 		// close rule is guaranteed to observe cancelRequested.
-		yieldDone, accepted := m.requestExecutionCancel(params.Tenant, params.ID, live)
+		yieldDone, accepted := m.requestExecutionCancel(params.Tenant, owner, params.ID, live)
 		if yieldDone != nil {
 			select {
 			case <-yieldDone:
@@ -420,7 +458,7 @@ func (m *TaskManager) OnCancelTask(
 			continue
 		}
 
-		if m.liveRun(params.Tenant, params.ID) != live {
+		if m.liveRun(params.Tenant, owner, params.ID) != live {
 			// The run yielded (suspend) or finished while we were canceling, so
 			// its close rule will not persist CANCELED on our behalf. Reassess:
 			// the next pass either claims the free slot and persists CANCELED
@@ -441,9 +479,10 @@ func (m *TaskManager) OnCancelTask(
 // execution slot (sentinel), making this the task's single writer.
 func (m *TaskManager) cancelWithoutLiveRun(
 	ctx context.Context,
+	owner string,
 	params protocol.TaskIDParams,
 ) (*protocol.Task, error) {
-	task, err := m.getTaskInternal(ctx, params.Tenant, params.ID)
+	task, err := m.getTaskInternal(ctx, params.Tenant, owner, params.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -466,11 +505,11 @@ func (m *TaskManager) cancelWithoutLiveRun(
 	response := protocol.NewStreamResponseStatusUpdate(event)
 	// Persist with a background context (like every engine write): the CANCELED
 	// state must land even if the cancel request's own context is already done.
-	if err := m.commitTaskEvent(context.Background(), params.Tenant, task, response, false); err != nil {
+	if err := m.commitTaskEvent(context.Background(), params.Tenant, owner, task, response, false); err != nil {
 		log.Errorf("Error storing cancelled task %s: %v", params.ID, err)
 		return nil, err
 	}
-	m.dispatchPush(params.Tenant, params.ID, response)
+	m.dispatchPush(params.Tenant, owner, params.ID, response)
 
 	return task, nil
 }
@@ -480,16 +519,20 @@ func (m *TaskManager) OnPushNotificationSet(
 	ctx context.Context,
 	params protocol.TaskPushNotificationConfig,
 ) (*protocol.TaskPushNotificationConfig, error) {
+	owner, err := m.resolveOwner(ctx)
+	if err != nil {
+		return nil, err
+	}
 	if !m.pushEnabled {
 		return nil, taskmanager.ErrPushNotificationNotSupported()
 	}
 	if err := push.ValidateConfig(params); err != nil {
 		return nil, taskmanager.ErrInvalidParams(err.Error())
 	}
-	if _, err := m.getTaskInternal(ctx, params.Tenant, params.TaskID); err != nil {
+	if _, err := m.getTaskInternal(ctx, params.Tenant, owner, params.TaskID); err != nil {
 		return nil, err
 	}
-	stored, err := m.storePushConfig(ctx, params)
+	stored, err := m.storePushConfig(ctx, owner, params)
 	if err != nil {
 		return nil, err
 	}
@@ -502,16 +545,20 @@ func (m *TaskManager) OnPushNotificationGet(
 	ctx context.Context,
 	params protocol.GetTaskPushNotificationConfigParams,
 ) (*protocol.TaskPushNotificationConfig, error) {
+	owner, err := m.resolveOwner(ctx)
+	if err != nil {
+		return nil, err
+	}
 	if !m.pushEnabled {
 		return nil, taskmanager.ErrPushNotificationNotSupported()
 	}
 	if params.ID == "" {
 		return nil, taskmanager.ErrInvalidParams("push notification config ID is required")
 	}
-	if _, err := m.getTaskInternal(ctx, params.Tenant, params.TaskID); err != nil {
+	if _, err := m.getTaskInternal(ctx, params.Tenant, owner, params.TaskID); err != nil {
 		return nil, err
 	}
-	configBytes, err := m.client.HGet(ctx, pushNotificationKey(params.Tenant, params.TaskID), params.ID).Bytes()
+	configBytes, err := m.client.HGet(ctx, pushNotificationKey(params.Tenant, owner, params.TaskID), params.ID).Bytes()
 	if err == nil {
 		registration, err := decodePushRegistration(configBytes)
 		if err != nil {
@@ -528,18 +575,22 @@ func (m *TaskManager) OnPushNotificationGet(
 // a v1.0 request leaves historyLength unset (spec: unset means no limit).
 const unlimitedHistoryLength = 1 << 30
 
-// OnListTasks handles the v1.0 ListTasks request from the tenant-local task
+// OnListTasks handles the v1.0 ListTasks request from the tenant-and-owner-local task
 // index, filtering and applying offset-based pagination without a keyspace SCAN.
 func (m *TaskManager) OnListTasks(
 	ctx context.Context,
 	params protocol.ListTasksParams,
 ) (*protocol.ListTasksResult, error) {
+	owner, err := m.resolveOwner(ctx)
+	if err != nil {
+		return nil, err
+	}
 	afterTime, err := taskmanager.ParseListTasksStatusTimestampAfter(params.StatusTimestampAfter)
 	if err != nil {
 		return nil, err
 	}
 
-	indexKey := taskIndexKey(params.Tenant)
+	indexKey := taskIndexKey(params.Tenant, owner)
 	nowMillis := time.Now().UnixMilli()
 	if err := m.client.ZRemRangeByScore(ctx, indexKey, "-inf", strconv.FormatInt(nowMillis, 10)).Err(); err != nil {
 		return nil, fmt.Errorf("failed to prune expired task index entries: %w", err)
@@ -553,11 +604,11 @@ func (m *TaskManager) OnListTasks(
 	}
 
 	// Pipeline the task loads. ClusterClient splits the pipeline by node, so
-	// task records may stay distributed even though the tenant index is one key.
+	// task records may stay distributed even though the scoped index is one key.
 	loads := make([]*redis.StringCmd, len(taskIDs))
 	_, pipelineErr := m.client.Pipelined(ctx, func(pipe redis.Pipeliner) error {
 		for i, taskID := range taskIDs {
-			loads[i] = pipe.Get(ctx, taskKey(params.Tenant, taskID))
+			loads[i] = pipe.Get(ctx, taskKey(params.Tenant, owner, taskID))
 		}
 		return nil
 	})
@@ -596,14 +647,18 @@ func (m *TaskManager) OnPushNotificationList(
 	ctx context.Context,
 	params protocol.ListTaskPushNotificationConfigsParams,
 ) (*protocol.ListTaskPushNotificationConfigsResult, error) {
+	owner, err := m.resolveOwner(ctx)
+	if err != nil {
+		return nil, err
+	}
 	if !m.pushEnabled {
 		return nil, taskmanager.ErrPushNotificationNotSupported()
 	}
-	if _, err := m.getTaskInternal(ctx, params.Tenant, params.TaskID); err != nil {
+	if _, err := m.getTaskInternal(ctx, params.Tenant, owner, params.TaskID); err != nil {
 		return nil, err
 	}
 
-	configs, err := m.readPushConfigs(ctx, params.Tenant, params.TaskID)
+	configs, err := m.readPushConfigs(ctx, params.Tenant, owner, params.TaskID)
 	if err != nil {
 		return nil, err
 	}
@@ -616,16 +671,20 @@ func (m *TaskManager) OnPushNotificationDelete(
 	ctx context.Context,
 	params protocol.DeleteTaskPushNotificationConfigParams,
 ) error {
+	owner, err := m.resolveOwner(ctx)
+	if err != nil {
+		return err
+	}
 	if !m.pushEnabled {
 		return taskmanager.ErrPushNotificationNotSupported()
 	}
 	if params.ID == "" {
 		return taskmanager.ErrInvalidParams("push notification config ID is required")
 	}
-	if _, err := m.getTaskInternal(ctx, params.Tenant, params.TaskID); err != nil {
+	if _, err := m.getTaskInternal(ctx, params.Tenant, owner, params.TaskID); err != nil {
 		return err
 	}
-	pushKey := pushNotificationKey(params.Tenant, params.TaskID)
+	pushKey := pushNotificationKey(params.Tenant, owner, params.TaskID)
 	if err := m.client.HDel(ctx, pushKey, params.ID).Err(); err != nil {
 		return fmt.Errorf("failed to delete push notification config: %w", err)
 	}
@@ -640,7 +699,7 @@ func (m *TaskManager) SupportsPushNotifications() bool {
 
 // storePushConfig persists cfg as one field in the task's push-config hash.
 func (m *TaskManager) storePushConfig(
-	ctx context.Context, cfg protocol.TaskPushNotificationConfig,
+	ctx context.Context, owner string, cfg protocol.TaskPushNotificationConfig,
 ) (protocol.TaskPushNotificationConfig, error) {
 	if cfg.TaskID == "" {
 		return protocol.TaskPushNotificationConfig{}, errors.New("push config store: taskId is required")
@@ -648,10 +707,11 @@ func (m *TaskManager) storePushConfig(
 	if cfg.ID == "" {
 		cfg.ID = "push-" + uuid.New().String()
 	}
-	pushKey := pushNotificationKey(cfg.Tenant, cfg.TaskID)
+	pushKey := pushNotificationKey(cfg.Tenant, owner, cfg.TaskID)
 	registration := push.Registration{
 		Config:     cfg,
 		Generation: uuid.New().String(),
+		Owner:      owner,
 	}
 	configBytes, err := json.Marshal(registration)
 	if err != nil {
@@ -701,9 +761,9 @@ func decodePushRegistration(data []byte) (push.Registration, error) {
 
 // readPushConfigs returns all push configs registered for taskID, ordered by ID.
 func (m *TaskManager) readPushConfigs(
-	ctx context.Context, tenant, taskID string,
+	ctx context.Context, tenant, owner, taskID string,
 ) ([]protocol.TaskPushNotificationConfig, error) {
-	registrations, err := m.readPushRegistrations(ctx, tenant, taskID)
+	registrations, err := m.readPushRegistrations(ctx, tenant, owner, taskID)
 	if err != nil {
 		return nil, err
 	}
@@ -717,9 +777,9 @@ func (m *TaskManager) readPushConfigs(
 // readPushRegistrations returns all persisted push registration snapshots for
 // taskID, ordered by config ID.
 func (m *TaskManager) readPushRegistrations(
-	ctx context.Context, tenant, taskID string,
+	ctx context.Context, tenant, owner, taskID string,
 ) ([]push.Registration, error) {
-	entries, err := m.client.HGetAll(ctx, pushNotificationKey(tenant, taskID)).Result()
+	entries, err := m.client.HGetAll(ctx, pushNotificationKey(tenant, owner, taskID)).Result()
 	if err != nil {
 		return nil, fmt.Errorf("failed to read push notification configs: %w", err)
 	}
@@ -729,6 +789,7 @@ func (m *TaskManager) readPushRegistrations(
 		if err != nil {
 			return nil, fmt.Errorf("failed to deserialize push notification config: %w", err)
 		}
+		registration.Owner = owner
 		registrations = append(registrations, registration)
 	}
 	sort.Slice(registrations, func(i, j int) bool {
@@ -744,7 +805,7 @@ func (m *TaskManager) isCurrentPushRegistration(
 	ctx context.Context, queued push.Registration,
 ) (bool, error) {
 	cfg := queued.Config
-	data, err := m.client.HGet(ctx, pushNotificationKey(cfg.Tenant, cfg.TaskID), cfg.ID).Bytes()
+	data, err := m.client.HGet(ctx, pushNotificationKey(cfg.Tenant, queued.Owner, cfg.TaskID), cfg.ID).Bytes()
 	if errors.Is(err, redis.Nil) {
 		return false, nil
 	}
@@ -762,7 +823,7 @@ func (m *TaskManager) isCurrentPushRegistration(
 // are read at event time before the event enters the bounded queue, so a later
 // registration change cannot retroactively change recipients. A full queue
 // applies backpressure rather than silently dropping an event.
-func (m *TaskManager) dispatchPush(tenant, taskID string, event protocol.StreamResponse) {
+func (m *TaskManager) dispatchPush(tenant, owner, taskID string, event protocol.StreamResponse) {
 	if m.pushDispatcher == nil {
 		return
 	}
@@ -772,7 +833,7 @@ func (m *TaskManager) dispatchPush(tenant, taskID string, event protocol.StreamR
 	if closed {
 		return
 	}
-	registrations, err := m.readPushRegistrations(m.pushCtx, tenant, taskID)
+	registrations, err := m.readPushRegistrations(m.pushCtx, tenant, owner, taskID)
 	if err != nil {
 		if !errors.Is(err, context.Canceled) {
 			log.Warnf("RedisTaskManager: push dispatch: load config for task %s: %v", taskID, err)
@@ -789,10 +850,14 @@ func (m *TaskManager) OnResubscribe(
 	ctx context.Context,
 	params protocol.TaskIDParams,
 ) (<-chan protocol.StreamResponse, error) {
+	owner, err := m.resolveOwner(ctx)
+	if err != nil {
+		return nil, err
+	}
 	// The transport loads the Task and event cursor at one atomic boundary. A
 	// concurrent task-event commit is therefore either reflected by both values
 	// or by neither: the snapshot and subsequent read contain no gap or overlap.
-	task, startID, err := m.eventTransport.LoadTaskAndCursor(ctx, params.Tenant, params.ID)
+	task, startID, err := m.eventTransport.LoadTaskAndCursor(ctx, params.Tenant, owner, params.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -824,7 +889,7 @@ func (m *TaskManager) OnResubscribe(
 	}
 	m.tailerWg.Add(1)
 	m.cancelMu.Unlock()
-	go m.tailTaskEvents(ctx, params.Tenant, params.ID, startID, subscriber)
+	go m.tailTaskEvents(ctx, params.Tenant, owner, params.ID, startID, subscriber)
 
 	return subscriber.Channel(), nil
 }
@@ -836,7 +901,7 @@ func (m *TaskManager) OnResubscribe(
 //nolint:gocyclo // Retry, backpressure, cancellation, and terminal handling stay in one ordered tailer loop.
 func (m *TaskManager) tailTaskEvents(
 	ctx context.Context,
-	tenant, taskID, startID string,
+	tenant, owner, taskID, startID string,
 	sub *taskSubscriber,
 ) {
 	defer m.tailerWg.Done()
@@ -894,7 +959,7 @@ func (m *TaskManager) tailTaskEvents(
 		default:
 		}
 		previousID := startID
-		events, nextID, err := m.eventTransport.ReadAfter(readCtx, tenant, taskID, startID)
+		events, nextID, err := m.eventTransport.ReadAfter(readCtx, tenant, owner, taskID, startID)
 		if err != nil {
 			if readCtx.Err() != nil || errors.Is(err, taskmanager.ErrTaskNotFoundSentinel) {
 				return
@@ -936,10 +1001,11 @@ func (m *TaskManager) tailTaskEvents(
 func (m *TaskManager) appendTaskEvent(
 	ctx context.Context,
 	tenant string,
+	owner string,
 	taskID string,
 	event protocol.StreamResponse,
 ) error {
-	return m.eventTransport.AppendEvent(ctx, tenant, taskID, event)
+	return m.eventTransport.AppendEvent(ctx, tenant, owner, taskID, event)
 }
 
 // =============================================================================
@@ -961,9 +1027,9 @@ func (m *TaskManager) stampReplyMessage(ctxID *string, message *protocol.Message
 }
 
 // storeMessage stores a message in Redis and updates conversation history.
-func (m *TaskManager) storeMessage(ctx context.Context, tenant string, message protocol.Message) {
+func (m *TaskManager) storeMessage(ctx context.Context, tenant, owner string, message protocol.Message) {
 	// Store the message.
-	msgKey := messageKey(tenant, message.MessageID)
+	msgKey := messageKey(tenant, owner, message.MessageID)
 	msgBytes, err := json.Marshal(message)
 	if err != nil {
 		log.Errorf("Failed to serialize message %s: %v", message.MessageID, err)
@@ -978,7 +1044,7 @@ func (m *TaskManager) storeMessage(ctx context.Context, tenant string, message p
 	// If the message has a contextID, add it to conversation history.
 	if message.ContextID != nil {
 		contextID := *message.ContextID
-		convKey := conversationKey(tenant, contextID)
+		convKey := conversationKey(tenant, owner, contextID)
 
 		// The same MessageID may reach this path concurrently from a reply and a
 		// superseded status. Keep the membership check, append, trim, and TTL
@@ -1001,6 +1067,7 @@ func (m *TaskManager) storeMessage(ctx context.Context, tenant string, message p
 func (m *TaskManager) getConversationHistory(
 	ctx context.Context,
 	tenant string,
+	owner string,
 	contextID string,
 	length int,
 ) ([]protocol.Message, error) {
@@ -1008,7 +1075,7 @@ func (m *TaskManager) getConversationHistory(
 		return nil, nil
 	}
 
-	convKey := conversationKey(tenant, contextID)
+	convKey := conversationKey(tenant, owner, contextID)
 
 	// Get the message count.
 	count, err := m.client.LLen(ctx, convKey).Result()
@@ -1031,7 +1098,7 @@ func (m *TaskManager) getConversationHistory(
 	// Retrieve messages.
 	messages := make([]protocol.Message, 0, len(messageIDs))
 	for _, msgID := range messageIDs {
-		msgKey := messageKey(tenant, msgID)
+		msgKey := messageKey(tenant, owner, msgID)
 		msgBytes, err := m.client.Get(ctx, msgKey).Bytes()
 		if err != nil {
 			log.Warnf("Message %s not found in Redis", msgID)
@@ -1054,8 +1121,8 @@ func (m *TaskManager) getConversationHistory(
 // ErrTaskNotFound; any other failure is a storage error and is reported as
 // such — callers that take irreversible actions on not-found (cancel paths)
 // must be able to tell the two apart.
-func (m *TaskManager) getTaskInternal(ctx context.Context, tenant, taskID string) (*protocol.Task, error) {
-	taskBytes, err := m.client.Get(ctx, taskKey(tenant, taskID)).Bytes()
+func (m *TaskManager) getTaskInternal(ctx context.Context, tenant, owner, taskID string) (*protocol.Task, error) {
+	taskBytes, err := m.client.Get(ctx, taskKey(tenant, owner, taskID)).Bytes()
 	if err != nil {
 		if errors.Is(err, redis.Nil) {
 			return nil, taskmanager.ErrTaskNotFound(taskID)
@@ -1071,12 +1138,12 @@ func (m *TaskManager) getTaskInternal(ctx context.Context, tenant, taskID string
 	return &task, nil
 }
 
-// ensureTaskIndexed records taskID in the tenant-local listing index before
+// ensureTaskIndexed records taskID in the tenant-and-owner-local listing index before
 // the Task write. A later Task-write failure may leave a stale member, which
 // ListTasks removes lazily; the reverse ordering could make a successfully
 // persisted task permanently invisible.
-func (m *TaskManager) ensureTaskIndexed(ctx context.Context, tenant, taskID string) error {
-	indexKey := taskIndexKey(tenant)
+func (m *TaskManager) ensureTaskIndexed(ctx context.Context, tenant, owner, taskID string) error {
+	indexKey := taskIndexKey(tenant, owner)
 	indexExpiration := m.expiration
 	if indexExpiration <= time.Duration(1<<63-1)/2 {
 		indexExpiration *= 2
@@ -1093,11 +1160,11 @@ func (m *TaskManager) ensureTaskIndexed(ctx context.Context, tenant, taskID stri
 }
 
 // storeTask stores a task in Redis.
-func (m *TaskManager) storeTask(ctx context.Context, tenant string, task *protocol.Task) error {
-	if err := m.ensureTaskIndexed(ctx, tenant, task.ID); err != nil {
+func (m *TaskManager) storeTask(ctx context.Context, tenant, owner string, task *protocol.Task) error {
+	if err := m.ensureTaskIndexed(ctx, tenant, owner, task.ID); err != nil {
 		return err
 	}
-	return m.storeTaskWithoutIndex(ctx, tenant, task)
+	return m.storeTaskWithoutIndex(ctx, tenant, owner, task)
 }
 
 // commitTaskEvent atomically persists a Task snapshot and the event that
@@ -1105,21 +1172,22 @@ func (m *TaskManager) storeTask(ctx context.Context, tenant string, task *protoc
 func (m *TaskManager) commitTaskEvent(
 	ctx context.Context,
 	tenant string,
+	owner string,
 	task *protocol.Task,
 	event protocol.StreamResponse,
 	allowCreate bool,
 ) error {
-	if err := m.ensureTaskIndexed(ctx, tenant, task.ID); err != nil {
+	if err := m.ensureTaskIndexed(ctx, tenant, owner, task.ID); err != nil {
 		return err
 	}
-	if err := m.eventTransport.CommitTaskEvent(ctx, tenant, task, event, allowCreate); err != nil {
+	if err := m.eventTransport.CommitTaskEvent(ctx, tenant, owner, task, event, allowCreate); err != nil {
 		return err
 	}
 	// Keep the latest v2 storeTask behavior: every Task write refreshes its push
 	// registrations. This key cannot join the atomic script because the existing
 	// push key is in a different Redis Cluster slot; failure here must not turn an
 	// already-committed Task/event pair into a false negative result.
-	if err := m.client.Expire(ctx, pushNotificationKey(tenant, task.ID), m.expiration).Err(); err != nil {
+	if err := m.client.Expire(ctx, pushNotificationKey(tenant, owner, task.ID), m.expiration).Err(); err != nil {
 		log.Warnf("RedisTaskManager: failed to refresh push config expiration for task %s: %v", task.ID, err)
 	}
 	return nil
@@ -1127,31 +1195,31 @@ func (m *TaskManager) commitTaskEvent(
 
 // refreshTaskLease extends the storage owned by a live execution without
 // recreating an expired Task. The Task/Stream/dedupe keys renew atomically;
-// the tenant index and push registrations live in other cluster slots and are
+// the scoped index and push registrations live in other cluster slots and are
 // refreshed afterwards.
-func (m *TaskManager) refreshTaskLease(ctx context.Context, tenant, taskID string) error {
-	if err := m.eventTransport.RefreshTaskLease(ctx, tenant, taskID); err != nil {
+func (m *TaskManager) refreshTaskLease(ctx context.Context, tenant, owner, taskID string) error {
+	if err := m.eventTransport.RefreshTaskLease(ctx, tenant, owner, taskID); err != nil {
 		return err
 	}
-	if err := m.ensureTaskIndexed(ctx, tenant, taskID); err != nil {
+	if err := m.ensureTaskIndexed(ctx, tenant, owner, taskID); err != nil {
 		return err
 	}
-	if err := m.client.Expire(ctx, pushNotificationKey(tenant, taskID), m.expiration).Err(); err != nil {
+	if err := m.client.Expire(ctx, pushNotificationKey(tenant, owner, taskID), m.expiration).Err(); err != nil {
 		log.Warnf("RedisTaskManager: failed to refresh push config expiration for task %s: %v", taskID, err)
 	}
 	return nil
 }
 
 // storeTaskWithoutIndex persists the Task after ensureTaskIndexed succeeded.
-func (m *TaskManager) storeTaskWithoutIndex(ctx context.Context, tenant string, task *protocol.Task) error {
-	key := taskKey(tenant, task.ID)
+func (m *TaskManager) storeTaskWithoutIndex(ctx context.Context, tenant, owner string, task *protocol.Task) error {
+	key := taskKey(tenant, owner, task.ID)
 	taskBytes, err := json.Marshal(task)
 	if err != nil {
 		return fmt.Errorf("failed to serialize task: %w", err)
 	}
 	_, err = m.client.Pipelined(ctx, func(pipe redis.Pipeliner) error {
 		pipe.Set(ctx, key, taskBytes, m.expiration)
-		pipe.Expire(ctx, pushNotificationKey(tenant, task.ID), m.expiration)
+		pipe.Expire(ctx, pushNotificationKey(tenant, owner, task.ID), m.expiration)
 		return nil
 	})
 	if err != nil {
@@ -1182,10 +1250,11 @@ func isSuspendedState(state protocol.TaskState) bool {
 func (m *TaskManager) registerExecution(
 	ctx context.Context,
 	tenant string,
+	owner string,
 	taskID string,
 	live *liveExecution,
 ) error {
-	key := newScopedID(tenant, taskID)
+	key := newScopedID(tenant, owner, taskID)
 	for {
 		m.cancelMu.Lock()
 		if m.closed {
@@ -1218,8 +1287,8 @@ func (m *TaskManager) registerExecution(
 
 // releaseExecution aborts a registered run whose engine never started: it
 // undoes registerExecution's registration and engine count.
-func (m *TaskManager) releaseExecution(tenant, taskID string, live *liveExecution) {
-	m.deregisterExecution(tenant, taskID, live)
+func (m *TaskManager) releaseExecution(tenant, owner, taskID string, live *liveExecution) {
+	m.deregisterExecution(tenant, owner, taskID, live)
 	m.engineWg.Done()
 }
 
@@ -1229,9 +1298,10 @@ func (m *TaskManager) releaseExecution(tenant, taskID string, live *liveExecutio
 // continuation can register (and then write) concurrently with it.
 func (m *TaskManager) claimCancelSlot(
 	tenant string,
+	owner string,
 	taskID string,
 ) (live *liveExecution, sentinel *liveExecution, yieldDone <-chan struct{}) {
-	key := newScopedID(tenant, taskID)
+	key := newScopedID(tenant, owner, taskID)
 	m.cancelMu.Lock()
 	defer m.cancelMu.Unlock()
 	if exec, ok := m.executions[key]; ok {
@@ -1250,10 +1320,11 @@ func (m *TaskManager) claimCancelSlot(
 // after publishing cancelRequested under the registry lock.
 func (m *TaskManager) requestExecutionCancel(
 	tenant string,
+	owner string,
 	taskID string,
 	live *liveExecution,
 ) (yieldDone <-chan struct{}, accepted bool) {
-	key := newScopedID(tenant, taskID)
+	key := newScopedID(tenant, owner, taskID)
 	m.cancelMu.Lock()
 	if m.executions[key] != live {
 		m.cancelMu.Unlock()
@@ -1271,16 +1342,16 @@ func (m *TaskManager) requestExecutionCancel(
 }
 
 // liveRun returns the task's currently registered execution handle, if any.
-func (m *TaskManager) liveRun(tenant, taskID string) *liveExecution {
+func (m *TaskManager) liveRun(tenant, owner, taskID string) *liveExecution {
 	m.cancelMu.RLock()
 	defer m.cancelMu.RUnlock()
-	return m.executions[newScopedID(tenant, taskID)]
+	return m.executions[newScopedID(tenant, owner, taskID)]
 }
 
 // deregisterExecution removes the handle at engine end. It only removes its
 // own entry so a follow-up round on the same task is never evicted.
-func (m *TaskManager) deregisterExecution(tenant, taskID string, live *liveExecution) {
-	key := newScopedID(tenant, taskID)
+func (m *TaskManager) deregisterExecution(tenant, owner, taskID string, live *liveExecution) {
+	key := newScopedID(tenant, owner, taskID)
 	m.cancelMu.Lock()
 	defer m.cancelMu.Unlock()
 	if current, ok := m.executions[key]; ok && current == live {
@@ -1295,8 +1366,8 @@ func (m *TaskManager) deregisterExecution(tenant, taskID string, live *liveExecu
 // beginExecutionYield turns an active slot into a short handoff barrier. The
 // slot remains owned by live until its suspend frame is committed and current
 // request publication completes, but continuations wait instead of failing.
-func (m *TaskManager) beginExecutionYield(tenant, taskID string, live *liveExecution) bool {
-	key := newScopedID(tenant, taskID)
+func (m *TaskManager) beginExecutionYield(tenant, owner, taskID string, live *liveExecution) bool {
+	key := newScopedID(tenant, owner, taskID)
 	m.cancelMu.Lock()
 	defer m.cancelMu.Unlock()
 	if m.executions[key] == live && live.yieldDone == nil && !live.cancelRequested.Load() {
@@ -1308,8 +1379,8 @@ func (m *TaskManager) beginExecutionYield(tenant, taskID string, live *liveExecu
 
 // abortExecutionYield restores an active slot when committing the suspended
 // state fails. Waiters wake and re-evaluate it as an ordinary active run.
-func (m *TaskManager) abortExecutionYield(tenant, taskID string, live *liveExecution) {
-	key := newScopedID(tenant, taskID)
+func (m *TaskManager) abortExecutionYield(tenant, owner, taskID string, live *liveExecution) {
+	key := newScopedID(tenant, owner, taskID)
 	m.cancelMu.Lock()
 	defer m.cancelMu.Unlock()
 	if m.executions[key] == live && live.yieldDone != nil {

--- a/taskmanager/redis/redis_manager_test.go
+++ b/taskmanager/redis/redis_manager_test.go
@@ -100,7 +100,7 @@ func storedTask(t *testing.T, m *TaskManager, id, contextID string, state protoc
 			Timestamp: time.Now().UTC().Format(time.RFC3339),
 		},
 	}
-	if err := m.storeTask(context.Background(), "", task); err != nil {
+	if err := m.storeTask(context.Background(), "", "", task); err != nil {
 		t.Fatalf("storeTask failed: %v", err)
 	}
 	return task
@@ -110,7 +110,7 @@ func waitTaskState(t *testing.T, m *TaskManager, taskID string, state protocol.T
 	t.Helper()
 	deadline := time.Now().Add(3 * time.Second)
 	for time.Now().Before(deadline) {
-		task, err := m.getTaskInternal(context.Background(), "", taskID)
+		task, err := m.getTaskInternal(context.Background(), "", "", taskID)
 		if err == nil && task.Status.State == state {
 			return
 		}
@@ -167,13 +167,13 @@ func TestOnSendMessagePureMessage(t *testing.T) {
 
 	// A pure-message exchange must not leave a task behind in Redis.
 	for _, key := range mr.Keys() {
-		if strings.HasPrefix(key, taskPrefix) {
+		if strings.HasPrefix(key, tenantKeyPrefix("")+taskPrefix) {
 			t.Errorf("unexpected task key in redis: %s", key)
 		}
 	}
 
 	// Both the user message and the reply live in the conversation.
-	history, err := m.getConversationHistory(context.Background(), "", "ctx-pure", 10)
+	history, err := m.getConversationHistory(context.Background(), "", "", "ctx-pure", 10)
 	if err != nil {
 		t.Fatalf("getConversationHistory failed: %v", err)
 	}
@@ -262,7 +262,7 @@ func TestOnSendMessageHistoryLength(t *testing.T) {
 	for _, text := range []string{"m1", "m2"} {
 		msg := protocol.NewMessage(protocol.MessageRoleUser, []*protocol.Part{protocol.NewTextPart(text)})
 		msg.ContextID = &contextID
-		m.storeMessage(context.Background(), "", msg)
+		m.storeMessage(context.Background(), "", "", msg)
 	}
 
 	send := func(text string, historyLength *int) *protocol.Task {
@@ -575,7 +575,8 @@ func TestTerminalTaskSendRejected(t *testing.T) {
 	}
 	// The rejection happens before the request message is stored.
 	for _, key := range mr.Keys() {
-		if strings.HasPrefix(key, messagePrefix) || strings.HasPrefix(key, conversationPrefix) {
+		if strings.HasPrefix(key, tenantKeyPrefix("")+messagePrefix) ||
+			strings.HasPrefix(key, tenantKeyPrefix("")+conversationPrefix) {
 			t.Errorf("rejected send must not store the request message, found %s", key)
 		}
 	}
@@ -654,7 +655,7 @@ func TestTaskSnapshotEventWithoutTaskLeavesNoTrace(t *testing.T) {
 	_, err := m.OnSendMessage(context.Background(), sendParams("go", "ctx-trace"))
 	assertTaskManagerCode(t, err, taskmanager.ErrCodeInternalError)
 	for _, key := range mr.Keys() {
-		if strings.HasPrefix(key, taskPrefix) {
+		if strings.HasPrefix(key, tenantKeyPrefix("")+taskPrefix) {
 			t.Errorf("violation before task creation must not persist a task, found %s", key)
 		}
 	}
@@ -697,7 +698,7 @@ func TestOnSendMessageStreamOrderAndPersistence(t *testing.T) {
 	if initial == nil || initial.Status.State != protocol.TaskStateSubmitted {
 		t.Fatalf("frame 1: expected submitted Task, got %+v", frame1.Result)
 	}
-	storedInitial, err := m.getTaskInternal(context.Background(), "", initial.ID)
+	storedInitial, err := m.getTaskInternal(context.Background(), "", "", initial.ID)
 	if err != nil {
 		t.Fatalf("getTaskInternal failed: %v", err)
 	}
@@ -723,7 +724,7 @@ func TestOnSendMessageStreamOrderAndPersistence(t *testing.T) {
 		t.Fatalf("initial Task IDs = %s/%s, want %s/%s",
 			initial.ID, initial.ContextID, taskID, statusUpdate.ContextID)
 	}
-	stored, err := m.getTaskInternal(context.Background(), "", taskID)
+	stored, err := m.getTaskInternal(context.Background(), "", "", taskID)
 	if err != nil {
 		t.Fatalf("task not persisted before broadcast: %v", err)
 	}
@@ -738,7 +739,7 @@ func TestOnSendMessageStreamOrderAndPersistence(t *testing.T) {
 	if artifactUpdate == nil || artifactUpdate.Artifact.ArtifactID != "artifact-1" {
 		t.Fatalf("frame 3: expected artifact update, got %+v", frame3.Result)
 	}
-	stored, err = m.getTaskInternal(context.Background(), "", taskID)
+	stored, err = m.getTaskInternal(context.Background(), "", "", taskID)
 	if err != nil {
 		t.Fatalf("getTaskInternal failed: %v", err)
 	}
@@ -753,7 +754,7 @@ func TestOnSendMessageStreamOrderAndPersistence(t *testing.T) {
 	if statusUpdate == nil || statusUpdate.Status.State != protocol.TaskStateCompleted {
 		t.Fatalf("frame 4: expected completed status, got %+v", frame4.Result)
 	}
-	stored, err = m.getTaskInternal(context.Background(), "", taskID)
+	stored, err = m.getTaskInternal(context.Background(), "", "", taskID)
 	if err != nil {
 		t.Fatalf("getTaskInternal failed: %v", err)
 	}
@@ -801,7 +802,7 @@ func TestOnSendMessageStreamContinuationStartsWithCurrentTask(t *testing.T) {
 		ArtifactID: "existing-artifact",
 		Parts:      []*protocol.Part{protocol.NewTextPart("existing")},
 	}}
-	if err := m.storeTask(context.Background(), "", task); err != nil {
+	if err := m.storeTask(context.Background(), "", "", task); err != nil {
 		t.Fatalf("storeTask with artifact failed: %v", err)
 	}
 
@@ -843,7 +844,7 @@ func TestOnSendMessageStreamPureMessage(t *testing.T) {
 		t.Error("expected stream closed")
 	}
 	for _, key := range mr.Keys() {
-		if strings.HasPrefix(key, taskPrefix) {
+		if strings.HasPrefix(key, tenantKeyPrefix("")+taskPrefix) {
 			t.Errorf("pure-message stream must not create a task, found %s", key)
 		}
 	}
@@ -868,7 +869,7 @@ func TestOnSendMessageStreamDirectMessageDoesNotSwitchToTask(t *testing.T) {
 		t.Fatalf("expected exactly the first direct Message, got %+v", frames)
 	}
 	for _, key := range mr.Keys() {
-		if strings.HasPrefix(key, taskPrefix) {
+		if strings.HasPrefix(key, tenantKeyPrefix("")+taskPrefix) {
 			t.Fatalf("task event after direct Message must be discarded, found %s", key)
 		}
 	}
@@ -1160,7 +1161,7 @@ func TestOnCancelTaskWithoutLiveExecution(t *testing.T) {
 		t.Error("expected subscriber closed after terminal broadcast")
 	}
 
-	stored, err := m.getTaskInternal(context.Background(), "", "task-idle")
+	stored, err := m.getTaskInternal(context.Background(), "", "", "task-idle")
 	if err != nil {
 		t.Fatalf("getTaskInternal failed: %v", err)
 	}
@@ -1330,7 +1331,7 @@ func TestOnGetTaskHistoryLength(t *testing.T) {
 	for _, text := range []string{"m1", "m2", "m3"} {
 		msg := protocol.NewMessage(protocol.MessageRoleUser, []*protocol.Part{protocol.NewTextPart(text)})
 		msg.ContextID = &contextID
-		m.storeMessage(context.Background(), "", msg)
+		m.storeMessage(context.Background(), "", "", msg)
 	}
 	storedTask(t, m, "task-hist", contextID, protocol.TaskStateWorking)
 
@@ -1443,10 +1444,10 @@ func TestPushNotificationCRUD(t *testing.T) { //nolint:gocyclo // One lifecycle 
 	if first.ID == "" || second.ID == "" || first.ID == second.ID {
 		t.Fatalf("generated IDs must be distinct: first=%q second=%q", first.ID, second.ID)
 	}
-	if !mr.Exists(pushNotificationPrefix + "task-push") {
+	if !mr.Exists(pushNotificationKey("", "", "task-push")) {
 		t.Error("push config key missing in redis")
 	}
-	if got := mr.TTL(pushNotificationPrefix + "task-push"); got != defaultExpiration {
+	if got := mr.TTL(pushNotificationKey("", "", "task-push")); got != defaultExpiration {
 		t.Errorf("push config TTL = %v, want %v", got, defaultExpiration)
 	}
 
@@ -1529,13 +1530,13 @@ func TestTaskWriteRefreshesPushConfigTTL(t *testing.T) {
 		t.Fatal(err)
 	}
 	mr.FastForward(10 * time.Minute)
-	if got := mr.TTL(pushNotificationPrefix + task.ID); got != 20*time.Minute {
+	if got := mr.TTL(pushNotificationKey("", "", task.ID)); got != 20*time.Minute {
 		t.Fatalf("push config TTL before refresh = %v, want 20m", got)
 	}
-	if err := m.storeTask(context.Background(), "", task); err != nil {
+	if err := m.storeTask(context.Background(), "", "", task); err != nil {
 		t.Fatal(err)
 	}
-	if got := mr.TTL(pushNotificationPrefix + task.ID); got != expire {
+	if got := mr.TTL(pushNotificationKey("", "", task.ID)); got != expire {
 		t.Fatalf("push config TTL after task write = %v, want %v", got, expire)
 	}
 }
@@ -1556,15 +1557,15 @@ func TestStorageTTL(t *testing.T) {
 	}
 	taskID := resp.GetTask().ID
 
-	if got := mr.TTL(taskPrefix + taskID); got != expire {
+	if got := mr.TTL(taskKey("", "", taskID)); got != expire {
 		t.Errorf("task TTL = %v, want %v", got, expire)
 	}
-	if got := mr.TTL(conversationPrefix + "ctx-ttl"); got != expire {
+	if got := mr.TTL(conversationKey("", "", "ctx-ttl")); got != expire {
 		t.Errorf("conversation TTL = %v, want %v", got, expire)
 	}
 	var messageKey string
 	for _, key := range mr.Keys() {
-		if strings.HasPrefix(key, messagePrefix) {
+		if strings.HasPrefix(key, tenantKeyPrefix("")+messagePrefix) {
 			messageKey = key
 			break
 		}
@@ -1592,12 +1593,12 @@ func TestStoreMessage_IdempotentByMessageID(t *testing.T) {
 	for i := 0; i < writers; i++ {
 		go func() {
 			defer wg.Done()
-			m.storeMessage(ctx, "", msg)
+			m.storeMessage(ctx, "", "", msg)
 		}()
 	}
 	wg.Wait()
 
-	hist, err := m.getConversationHistory(ctx, "", cid, 100)
+	hist, err := m.getConversationHistory(ctx, "", "", cid, 100)
 	if err != nil {
 		t.Fatalf("getConversationHistory: %v", err)
 	}

--- a/taskmanager/redis/redis_options.go
+++ b/taskmanager/redis/redis_options.go
@@ -11,10 +11,15 @@ import (
 	"time"
 
 	"trpc.group/trpc-go/trpc-a2a-go/v2/push"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
 )
 
 // TaskManagerOptions contains configuration options for RedisTaskManager.
 type TaskManagerOptions struct {
+	// OwnerResolver derives the authorization owner scope from each request.
+	// A nil resolver preserves tenant-wide task sharing for compatibility.
+	OwnerResolver taskmanager.OwnerResolver
+
 	// ExpireTime is the time after which Redis keys expire.
 	ExpireTime time.Duration
 
@@ -88,6 +93,15 @@ func WithTaskSubscriberBufferSize(size int) TaskManagerOption {
 func WithTaskSubscriberBlockingSend(blockingSend bool) TaskManagerOption {
 	return func(opts *TaskManagerOptions) {
 		opts.TaskSubscriberBlockingSend = blockingSend
+	}
+}
+
+// WithOwnerResolver scopes retained tasks and related state to the owner
+// returned for each request. The resolver must return a non-empty owner; an
+// error or empty result rejects the operation before any state is accessed.
+func WithOwnerResolver(resolver taskmanager.OwnerResolver) TaskManagerOption {
+	return func(opts *TaskManagerOptions) {
+		opts.OwnerResolver = resolver
 	}
 }
 

--- a/taskmanager/redis/redis_push_dispatch_test.go
+++ b/taskmanager/redis/redis_push_dispatch_test.go
@@ -156,7 +156,7 @@ func TestRedisInlinePushConfigMessageOnlyLeavesNoOrphan(t *testing.T) {
 		t.Fatal(err)
 	}
 	taskID := <-taskIDs
-	if mr.Exists(taskPrefix+taskID) || mr.Exists(pushNotificationPrefix+taskID) {
+	if mr.Exists(taskKey("", "", taskID)) || mr.Exists(pushNotificationKey("", "", taskID)) {
 		t.Fatalf("message-only round created task or push-config keys for %s", taskID)
 	}
 	list, err := m.OnPushNotificationList(context.Background(),
@@ -274,7 +274,7 @@ func TestRedisStreamingInitialTaskIsNotPushed(t *testing.T) {
 	// ordering for one registration guarantees every earlier delivery is
 	// recorded before the sentinel, without relying on timing.
 	sentinel := agentReply("push-sentinel")
-	m.dispatchPush("", task.ID, protocol.NewStreamResponseMessage(sentinel))
+	m.dispatchPush("", "", task.ID, protocol.NewStreamResponseMessage(sentinel))
 	deadline := time.Now().Add(3 * time.Second)
 	for time.Now().Before(deadline) {
 		calls := sender.snapshot()
@@ -346,13 +346,13 @@ func TestRedisPushQueuedGenerationInvalidatedAcrossManagers(t *testing.T) {
 
 	// Keep the first delivery in flight and leave the old-generation event in
 	// A's process-local queue.
-	managerA.dispatchPush("", task.ID, response(protocol.TaskStateWorking))
+	managerA.dispatchPush("", "", task.ID, response(protocol.TaskStateWorking))
 	select {
 	case <-started:
 	case <-time.After(2 * time.Second):
 		t.Fatal("first push delivery did not start")
 	}
-	managerA.dispatchPush("", task.ID, response(protocol.TaskStateInputRequired))
+	managerA.dispatchPush("", "", task.ID, response(protocol.TaskStateInputRequired))
 
 	// B deletes and recreates the same config ID. Existence and ID checks alone
 	// would revive the queued event; only the shared Redis generation rejects it.
@@ -367,7 +367,7 @@ func TestRedisPushQueuedGenerationInvalidatedAcrossManagers(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("manager B recreate: %v", err)
 	}
-	managerA.dispatchPush("", task.ID, response(protocol.TaskStateCompleted))
+	managerA.dispatchPush("", "", task.ID, response(protocol.TaskStateCompleted))
 	releaseFirst()
 
 	deadline := time.Now().Add(2 * time.Second)
@@ -439,13 +439,13 @@ func TestRedisPushBackpressureSerializesSuspendContinuation(t *testing.T) { //no
 			Status: protocol.TaskStatus{State: state},
 		})
 	}
-	manager.dispatchPush("", prefill.ID, prefillResponse(protocol.TaskStateWorking))
+	manager.dispatchPush("", "", prefill.ID, prefillResponse(protocol.TaskStateWorking))
 	select {
 	case <-started:
 	case <-time.After(2 * time.Second):
 		t.Fatal("prefill push delivery did not start")
 	}
-	manager.dispatchPush("", prefill.ID, prefillResponse(protocol.TaskStateSubmitted))
+	manager.dispatchPush("", "", prefill.ID, prefillResponse(protocol.TaskStateSubmitted))
 
 	params := sendParams("start", "ctx-push-suspend")
 	params.Configuration = &protocol.SendMessageConfiguration{PushConfig: &protocol.TaskPushNotificationConfig{
@@ -467,7 +467,7 @@ func TestRedisPushBackpressureSerializesSuspendContinuation(t *testing.T) { //no
 	// Once INPUT_REQUIRED is visible in Redis, the yield barrier must already
 	// exist. This ordering makes a GetTask-driven continuation safe.
 	manager.cancelMu.RLock()
-	live := manager.executions[newScopedID("", taskID)]
+	live := manager.executions[newScopedID("", "", taskID)]
 	yielding := live != nil && live.yieldDone != nil
 	manager.cancelMu.RUnlock()
 	if !yielding {

--- a/taskmanager/redis/redis_regression_test.go
+++ b/taskmanager/redis/redis_regression_test.go
@@ -41,7 +41,7 @@ func pollTaskState(t *testing.T, m *TaskManager, taskID string, want protocol.Ta
 	deadline := time.Now().Add(2 * time.Second)
 	var last protocol.TaskState
 	for time.Now().Before(deadline) {
-		if task, err := m.getTaskInternal(context.Background(), "", taskID); err == nil {
+		if task, err := m.getTaskInternal(context.Background(), "", "", taskID); err == nil {
 			last = task.Status.State
 			if last == want {
 				return
@@ -164,7 +164,7 @@ func TestTerminal_NotResurrectedByYieldedRound(t *testing.T) {
 	openGate()
 	deadline := time.Now().Add(100 * time.Millisecond)
 	for time.Now().Before(deadline) {
-		stored, err := manager.getTaskInternal(context.Background(), "", taskID)
+		stored, err := manager.getTaskInternal(context.Background(), "", "", taskID)
 		if err != nil {
 			t.Fatalf("getTaskInternal failed: %v", err)
 		}
@@ -269,21 +269,21 @@ func TestRequestExecutionCancelReturnsWinningYieldHandoff(t *testing.T) {
 	const taskID = "task-yield-wins-cancel-race"
 	var canceled atomic.Bool
 	live := &liveExecution{cancel: func() { canceled.Store(true) }}
-	if err := manager.registerExecution(context.Background(), "", taskID, live); err != nil {
+	if err := manager.registerExecution(context.Background(), "", "", taskID, live); err != nil {
 		t.Fatalf("registerExecution: %v", err)
 	}
 	released := false
 	defer func() {
 		if !released {
-			manager.releaseExecution("", taskID, live)
+			manager.releaseExecution("", "", taskID, live)
 		}
 	}()
 
-	if !manager.beginExecutionYield("", taskID, live) {
+	if !manager.beginExecutionYield("", "", taskID, live) {
 		t.Fatal("beginExecutionYield did not claim the live execution")
 	}
 	wantHandoff := live.yieldDone
-	handoff, accepted := manager.requestExecutionCancel("", taskID, live)
+	handoff, accepted := manager.requestExecutionCancel("", "", taskID, live)
 	if accepted {
 		t.Fatal("cancellation was accepted after yield won")
 	}
@@ -294,7 +294,7 @@ func TestRequestExecutionCancelReturnsWinningYieldHandoff(t *testing.T) {
 		t.Fatal("yield-winning execution was canceled")
 	}
 
-	manager.releaseExecution("", taskID, live)
+	manager.releaseExecution("", "", taskID, live)
 	released = true
 	select {
 	case <-handoff:
@@ -392,7 +392,7 @@ func TestClose_PersistsCanceledBeforeClientClose(t *testing.T) {
 		t.Fatalf("Close failed: %v", err)
 	}
 
-	raw, err := mr.Get(taskPrefix + taskID)
+	raw, err := mr.Get(taskKey("", "", taskID))
 	if err != nil {
 		t.Fatalf("task missing from store after Close: %v", err)
 	}

--- a/taskmanager/redis/tenant_isolation_test.go
+++ b/taskmanager/redis/tenant_isolation_test.go
@@ -9,6 +9,7 @@ package redis
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -18,6 +19,167 @@ import (
 	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
 )
 
+type ownerContextKey struct{}
+
+func ownerContext(owner string) context.Context {
+	return context.WithValue(context.Background(), ownerContextKey{}, owner)
+}
+
+func testOwnerResolver(ctx context.Context) (string, error) {
+	owner, _ := ctx.Value(ownerContextKey{}).(string)
+	if owner == "" {
+		return "", fmt.Errorf("owner is missing")
+	}
+	return owner, nil
+}
+
+func TestTaskManagerOwnerIsolation(t *testing.T) {
+	manager, mr := setupTest(t, scriptedExecutor(
+		statusEvent(protocol.TaskStateWorking, nil),
+		statusEvent(protocol.TaskStateInputRequired, nil),
+	), WithOwnerResolver(testOwnerResolver), WithPushNotifications(push.Config{ManualDelivery: true}))
+
+	const tenant = "shared-tenant"
+	aliceCtx := ownerContext("alice")
+	bobCtx := ownerContext("bob")
+	request := sendParams("hello", "shared-context")
+	request.Tenant = tenant
+	request.Message.MessageID = "shared-message"
+
+	aliceResult, err := manager.OnSendMessage(aliceCtx, request)
+	if err != nil {
+		t.Fatalf("alice send: %v", err)
+	}
+	aliceTask := aliceResult.GetTask()
+	if aliceTask == nil {
+		t.Fatal("alice send did not materialize a task")
+	}
+
+	if _, err := manager.OnGetTask(bobCtx, protocol.TaskQueryParams{Tenant: tenant, ID: aliceTask.ID}); !errors.Is(err, taskmanager.ErrTaskNotFoundSentinel) {
+		t.Fatalf("bob must not get alice task: %v", err)
+	}
+	if _, err := manager.OnCancelTask(bobCtx, protocol.TaskIDParams{Tenant: tenant, ID: aliceTask.ID}); !errors.Is(err, taskmanager.ErrTaskNotFoundSentinel) {
+		t.Fatalf("bob must not cancel alice task: %v", err)
+	}
+	if _, err := manager.OnResubscribe(bobCtx, protocol.TaskIDParams{Tenant: tenant, ID: aliceTask.ID}); !errors.Is(err, taskmanager.ErrTaskNotFoundSentinel) {
+		t.Fatalf("bob must not subscribe to alice task: %v", err)
+	}
+	if _, err := manager.OnPushNotificationSet(bobCtx, protocol.TaskPushNotificationConfig{
+		Tenant: tenant, TaskID: aliceTask.ID, URL: "https://bob.example/push",
+	}); !errors.Is(err, taskmanager.ErrTaskNotFoundSentinel) {
+		t.Fatalf("bob must not register push for alice task: %v", err)
+	}
+
+	aliceList, err := manager.OnListTasks(aliceCtx, protocol.ListTasksParams{Tenant: tenant})
+	if err != nil || len(aliceList.Tasks) != 1 || aliceList.Tasks[0].ID != aliceTask.ID {
+		t.Fatalf("alice list = %+v, err=%v", aliceList, err)
+	}
+	bobList, err := manager.OnListTasks(bobCtx, protocol.ListTasksParams{Tenant: tenant})
+	if err != nil || len(bobList.Tasks) != 0 {
+		t.Fatalf("bob list leaked alice task: %+v, err=%v", bobList, err)
+	}
+
+	if mr.Exists(taskKey(tenant, "bob", aliceTask.ID)) {
+		t.Fatal("bob task key was created by alice's request")
+	}
+	if taskKey(tenant, "alice", aliceTask.ID) == taskKey(tenant, "bob", aliceTask.ID) {
+		t.Fatal("different owners produced the same task key")
+	}
+	if streamKey(tenant, "alice", aliceTask.ID) == streamKey(tenant, "bob", aliceTask.ID) {
+		t.Fatal("different owners produced the same stream key")
+	}
+
+	bobTask := &protocol.Task{ID: aliceTask.ID, ContextID: "shared-context",
+		Status: protocol.TaskStatus{State: protocol.TaskStateWorking}}
+	if err := manager.storeTask(bobCtx, tenant, "bob", bobTask); err != nil {
+		t.Fatalf("store same task ID for bob: %v", err)
+	}
+	bobContextID := "shared-context"
+	manager.storeMessage(context.Background(), tenant, "bob", protocol.Message{
+		MessageID: "shared-message", ContextID: &bobContextID, Role: protocol.MessageRoleAgent,
+	})
+	if got, err := manager.OnGetTask(bobCtx, protocol.TaskQueryParams{Tenant: tenant, ID: aliceTask.ID}); err != nil || got.ID != aliceTask.ID || len(got.History) != 1 ||
+		got.History[0].Role != protocol.MessageRoleAgent {
+		t.Fatalf("same task ID must be usable by another owner: task=%+v err=%v", got, err)
+	}
+	if got, err := manager.OnGetTask(aliceCtx, protocol.TaskQueryParams{Tenant: tenant, ID: aliceTask.ID}); err != nil || len(got.History) != 1 || got.History[0].Role != protocol.MessageRoleUser {
+		t.Fatalf("bob's shared message/context IDs changed alice history: task=%+v err=%v", got, err)
+	}
+
+	for _, tc := range []struct {
+		ctx   context.Context
+		owner string
+		url   string
+	}{
+		{aliceCtx, "alice", "https://alice.example/push"},
+		{bobCtx, "bob", "https://bob.example/push"},
+	} {
+		if _, err := manager.OnPushNotificationSet(tc.ctx, protocol.TaskPushNotificationConfig{
+			Tenant: tenant, TaskID: aliceTask.ID, ID: "shared-config", URL: tc.url,
+		}); err != nil {
+			t.Fatalf("set %s push config: %v", tc.owner, err)
+		}
+	}
+	aliceRegistrations, err := manager.readPushRegistrations(context.Background(), tenant, "alice", aliceTask.ID)
+	if err != nil || len(aliceRegistrations) != 1 {
+		t.Fatalf("alice registrations=%+v err=%v", aliceRegistrations, err)
+	}
+	if owner := aliceRegistrations[0].Owner; owner != "alice" {
+		t.Fatalf("queued push owner=%q, want alice", owner)
+	}
+	if current, err := manager.isCurrentPushRegistration(context.Background(), aliceRegistrations[0]); err != nil || !current {
+		t.Fatalf("alice push registration current=%v err=%v", current, err)
+	}
+	if err := manager.OnPushNotificationDelete(bobCtx, protocol.DeleteTaskPushNotificationConfigParams{
+		Tenant: tenant, TaskID: aliceTask.ID, ID: "shared-config",
+	}); err != nil {
+		t.Fatalf("delete bob push config: %v", err)
+	}
+	if current, err := manager.isCurrentPushRegistration(context.Background(), aliceRegistrations[0]); err != nil || !current {
+		t.Fatalf("bob push deletion invalidated alice registration: current=%v err=%v", current, err)
+	}
+
+	subCtx, cancel := context.WithCancel(bobCtx)
+	defer cancel()
+	bobStream, err := manager.OnResubscribe(subCtx, protocol.TaskIDParams{Tenant: tenant, ID: aliceTask.ID})
+	if err != nil {
+		t.Fatalf("bob subscribe to bob-owned task: %v", err)
+	}
+	if initial, ok := recvTimeout(t, bobStream); !ok || initial.GetTask() == nil {
+		t.Fatalf("bob initial stream frame = %+v", initial)
+	}
+	if err := manager.appendTaskEvent(context.Background(), tenant, "alice", aliceTask.ID,
+		protocol.NewStreamResponseMessage(agentReply("alice-only"))); err != nil {
+		t.Fatalf("append alice event: %v", err)
+	}
+	select {
+	case event := <-bobStream:
+		t.Fatalf("alice event reached bob stream: %+v", event)
+	case <-time.After(250 * time.Millisecond):
+	}
+	if err := manager.appendTaskEvent(context.Background(), tenant, "bob", aliceTask.ID,
+		protocol.NewStreamResponseMessage(agentReply("bob-only"))); err != nil {
+		t.Fatalf("append bob event: %v", err)
+	}
+	if event, ok := recvTimeout(t, bobStream); !ok || event.GetMessage() == nil ||
+		event.GetMessage().Parts[0].TextContent() != "bob-only" {
+		t.Fatalf("bob stream did not receive bob event: %+v", event)
+	}
+}
+
+func TestTaskManagerOwnerResolverFailsBeforeWrite(t *testing.T) {
+	manager, mr := setupTest(t, scriptedExecutor(statusEvent(protocol.TaskStateCompleted, nil)),
+		WithOwnerResolver(testOwnerResolver))
+	request := sendParams("hello", "context")
+	request.Message.MessageID = "must-not-store"
+	if _, err := manager.OnSendMessage(context.Background(), request); !errors.Is(err, taskmanager.ErrInternalErrorSentinel) {
+		t.Fatalf("send without owner error = %v, want internal error", err)
+	}
+	if len(mr.Keys()) != 0 || len(manager.executions) != 0 {
+		t.Fatalf("owner failure left state: keys=%v executions=%d", mr.Keys(), len(manager.executions))
+	}
+}
+
 func TestTaskManagerTenantDataIsolationAndTaskIndex(t *testing.T) {
 	manager, mr := setupTest(t, scriptedExecutor())
 	ctx := context.Background()
@@ -25,23 +187,24 @@ func TestTaskManagerTenantDataIsolationAndTaskIndex(t *testing.T) {
 	const contextID = "shared-context"
 	const messageID = "shared-message"
 
-	if err := manager.storeTask(ctx, "tenant-a", &protocol.Task{
+	if err := manager.storeTask(ctx, "tenant-a", "", &protocol.Task{
 		ID: taskID, ContextID: contextID, Status: protocol.TaskStatus{State: protocol.TaskStateWorking},
 	}); err != nil {
 		t.Fatalf("store tenant-a task: %v", err)
 	}
-	if err := manager.storeTask(ctx, "tenant-b", &protocol.Task{
+	if err := manager.storeTask(ctx, "tenant-b", "", &protocol.Task{
 		ID: taskID, ContextID: contextID, Status: protocol.TaskStatus{State: protocol.TaskStateInputRequired},
 	}); err != nil {
 		t.Fatalf("store tenant-b task: %v", err)
 	}
 
 	contextA := contextID
-	manager.storeMessage(ctx, "tenant-a", protocol.Message{
+	manager.storeMessage(ctx, "tenant-a", "", protocol.Message{
 		MessageID: messageID, ContextID: &contextA, Role: protocol.MessageRoleUser,
 	})
+
 	contextB := contextID
-	manager.storeMessage(ctx, "tenant-b", protocol.Message{
+	manager.storeMessage(ctx, "tenant-b", "", protocol.Message{
 		MessageID: messageID, ContextID: &contextB, Role: protocol.MessageRoleAgent,
 	})
 
@@ -70,24 +233,24 @@ func TestTaskManagerTenantDataIsolationAndTaskIndex(t *testing.T) {
 		t.Fatalf("tenant-a list leaked another tenant: result=%+v err=%v", listA, err)
 	}
 
-	indexed, err := manager.client.ZRange(ctx, taskIndexKey("tenant-a"), 0, -1).Result()
+	indexed, err := manager.client.ZRange(ctx, taskIndexKey("tenant-a", ""), 0, -1).Result()
 	if err != nil || len(indexed) != 1 || indexed[0] != taskID {
 		t.Fatalf("tenant task index = %v, err=%v", indexed, err)
 	}
-	if err := manager.client.ZAdd(ctx, taskIndexKey("tenant-a"), redisc.Z{Member: "expired-task"}).Err(); err != nil {
+	if err := manager.client.ZAdd(ctx, taskIndexKey("tenant-a", ""), redisc.Z{Member: "expired-task"}).Err(); err != nil {
 		t.Fatalf("seed stale index member: %v", err)
 	}
 	if _, err := manager.OnListTasks(ctx, protocol.ListTasksParams{Tenant: "tenant-a"}); err != nil {
 		t.Fatalf("list with stale member: %v", err)
 	}
-	if _, err := manager.client.ZScore(ctx, taskIndexKey("tenant-a"), "expired-task").Result(); !errors.Is(err, redisc.Nil) {
+	if _, err := manager.client.ZScore(ctx, taskIndexKey("tenant-a", ""), "expired-task").Result(); !errors.Is(err, redisc.Nil) {
 		t.Fatalf("stale task index member was not pruned: %v", err)
 	}
 
-	// An unindexed legacy-looking task key proves ListTasks no longer discovers
+	// An unindexed task key proves ListTasks no longer discovers
 	// data through SCAN. Existing deployments must drain or explicitly migrate
 	// pre-index tasks before switching list traffic.
-	mr.Set(taskPrefix+"unindexed", `{"id":"unindexed"}`)
+	mr.Set(taskKey("", "", "unindexed"), `{"id":"unindexed"}`)
 	defaultList, err := manager.OnListTasks(ctx, protocol.ListTasksParams{})
 	if err != nil || len(defaultList.Tasks) != 0 {
 		t.Fatalf("ListTasks unexpectedly scanned unindexed keys: result=%+v err=%v", defaultList, err)
@@ -101,28 +264,41 @@ func TestTaskManagerTenantDataIsolationAndTaskIndex(t *testing.T) {
 		t.Fatalf("canceling tenant-a changed tenant-b: task=%+v err=%v", taskB, err)
 	}
 
-	if _, err := manager.storePushConfig(ctx, protocol.TaskPushNotificationConfig{
+	if _, err := manager.storePushConfig(ctx, "", protocol.TaskPushNotificationConfig{
 		Tenant: "tenant-a", TaskID: taskID, ID: "shared-config", URL: "https://a.example/push",
 	}); err != nil {
 		t.Fatalf("store tenant-a push config: %v", err)
 	}
-	if _, err := manager.storePushConfig(ctx, protocol.TaskPushNotificationConfig{
+	if _, err := manager.storePushConfig(ctx, "", protocol.TaskPushNotificationConfig{
 		Tenant: "tenant-b", TaskID: taskID, ID: "shared-config", URL: "https://b.example/push",
 	}); err != nil {
 		t.Fatalf("store tenant-b push config: %v", err)
 	}
-	configsA, err := manager.readPushConfigs(ctx, "tenant-a", taskID)
+	configsA, err := manager.readPushConfigs(ctx, "tenant-a", "", taskID)
 	if err != nil || len(configsA) != 1 || configsA[0].URL != "https://a.example/push" {
 		t.Fatalf("tenant-a push config leaked: configs=%+v err=%v", configsA, err)
 	}
 
-	if taskKey("", taskID) != taskPrefix+taskID {
-		t.Fatalf("empty tenant must preserve legacy Redis keys, got %q", taskKey("", taskID))
+	if got, want := taskKey("", "", taskID), "tenant:~default:"+taskPrefix+taskID; got != want {
+		t.Fatalf("empty tenant task key = %q, want %q", got, want)
 	}
-	if taskKey("tenant-a", taskID) == taskKey("tenant-b", taskID) {
+	if got, want := taskKey("", "alice", taskID),
+		"tenant:~default:owner:YWxpY2U:"+taskPrefix+taskID; got != want {
+		t.Fatalf("default tenant owner task key = %q, want %q", got, want)
+	}
+	if taskKey("_default", "", taskID) == taskKey("", "", taskID) {
+		t.Fatal("explicit _default tenant collided with the internal default namespace")
+	}
+	if taskKey(string([]byte{0xfd, 0xd7, 0x9f, 0x6a, 0xe9, 0x6d}), "", taskID) == taskKey("", "", taskID) {
+		t.Fatal("base64-encoded tenant collided with the internal default namespace")
+	}
+	if got, want := streamKey("", "", taskID), "stream:{"+taskKey("", "", taskID)+"}"; got != want {
+		t.Fatalf("default tenant stream hash tag = %q, want %q", got, want)
+	}
+	if taskKey("tenant-a", "", taskID) == taskKey("tenant-b", "", taskID) {
 		t.Fatal("different tenants produced the same Redis task key")
 	}
-	if got, want := streamKey("tenant-a", taskID), "stream:{"+taskKey("tenant-a", taskID)+"}"; got != want {
+	if got, want := streamKey("tenant-a", "", taskID), "stream:{"+taskKey("tenant-a", "", taskID)+"}"; got != want {
 		t.Fatalf("tenant stream hash tag = %q, want %q", got, want)
 	}
 
@@ -136,7 +312,7 @@ func TestTaskManagerTenantDataIsolationAndTaskIndex(t *testing.T) {
 		t.Fatalf("tenant-b initial snapshot = %+v", initial)
 	}
 	foreign := protocol.NewStreamResponseMessage(agentReply("tenant-a-only"))
-	if err := manager.appendTaskEvent(ctx, "tenant-a", taskID, foreign); err != nil {
+	if err := manager.appendTaskEvent(ctx, "tenant-a", "", taskID, foreign); err != nil {
 		t.Fatalf("append tenant-a event: %v", err)
 	}
 	select {
@@ -145,7 +321,7 @@ func TestTaskManagerTenantDataIsolationAndTaskIndex(t *testing.T) {
 	case <-time.After(250 * time.Millisecond):
 	}
 	local := protocol.NewStreamResponseMessage(agentReply("tenant-b-only"))
-	if err := manager.appendTaskEvent(ctx, "tenant-b", taskID, local); err != nil {
+	if err := manager.appendTaskEvent(ctx, "tenant-b", "", taskID, local); err != nil {
 		t.Fatalf("append tenant-b event: %v", err)
 	}
 	if event, ok := recvTimeout(t, subscriberB); !ok || event.GetMessage() == nil ||
@@ -155,14 +331,14 @@ func TestTaskManagerTenantDataIsolationAndTaskIndex(t *testing.T) {
 
 	liveA := &liveExecution{cancel: func() {}}
 	liveB := &liveExecution{cancel: func() {}}
-	if err := manager.registerExecution(ctx, "tenant-a", taskID, liveA); err != nil {
+	if err := manager.registerExecution(ctx, "tenant-a", "", taskID, liveA); err != nil {
 		t.Fatalf("register tenant-a execution: %v", err)
 	}
-	if err := manager.registerExecution(ctx, "tenant-b", taskID, liveB); err != nil {
+	if err := manager.registerExecution(ctx, "tenant-b", "", taskID, liveB); err != nil {
 		t.Fatalf("register tenant-b execution with the same task ID: %v", err)
 	}
-	manager.releaseExecution("tenant-a", taskID, liveA)
-	manager.releaseExecution("tenant-b", taskID, liveB)
+	manager.releaseExecution("tenant-a", "", taskID, liveA)
+	manager.releaseExecution("tenant-b", "", taskID, liveB)
 }
 
 func TestTaskManagerProcessorCannotMutateTenantScope(t *testing.T) {
@@ -212,12 +388,12 @@ func TestTaskManagerProcessorCannotMutateTenantScope(t *testing.T) {
 	}); !errors.Is(err, taskmanager.ErrTaskNotFoundSentinel) {
 		t.Fatalf("processor moved task into another tenant: %v", err)
 	}
-	configs, err := manager.readPushConfigs(context.Background(), "tenant-a", task.ID)
+	configs, err := manager.readPushConfigs(context.Background(), "tenant-a", "", task.ID)
 	if err != nil || len(configs) != 1 || configs[0].TaskID != task.ID || configs[0].Authentication == nil ||
 		configs[0].Authentication.Credentials != "original-credentials" {
 		t.Fatalf("processor mutation changed stored push scope: configs=%+v err=%v", configs, err)
 	}
-	configs, err = manager.readPushConfigs(context.Background(), "mutated-tenant", "mutated-task")
+	configs, err = manager.readPushConfigs(context.Background(), "mutated-tenant", "", "mutated-task")
 	if err != nil || len(configs) != 0 {
 		t.Fatalf("processor moved push config into another tenant: configs=%+v err=%v", configs, err)
 	}


### PR DESCRIPTION
## Summary

- add a shared `taskmanager.OwnerResolver` and expose `WithOwnerResolver` from the memory and Redis TaskManagers
- scope retained tasks, messages, conversations, live execution slots, subscriptions, Redis Streams, and push notification state by `(tenant, owner)`
- resolve and freeze the owner for each execution round while resolving the current caller independently for cross-request operations
- derive owners from authenticated `auth.User` values in the runnable auth and basic examples, including same-owner success and cross-owner denial checks
- document the difference between tenant routing and end-user authorization in the English and Chinese guides

## Why

Tenant selection routes requests to an agent and its card, but callers inside the same tenant previously shared retained TaskManager state. Applications that authenticate multiple users need a second authorization boundary so one user cannot list, read, continue, cancel, subscribe to, or configure push delivery for another user's task.

## Compatibility and upgrade notes

The feature is opt-in. A nil owner resolver preserves the existing tenant-wide sharing behavior. Resolver failures or empty owners reject the operation before retained state is accessed, and foreign owners receive task-not-found.

Redis now places empty-tenant data under the reserved `tenant:~default:` namespace. This prerelease does not read the former unprefixed keys; deployments should drain active tasks or migrate the documented key families while preserving TTL and Redis Cluster hash-slot relationships.

## Testing

- `GOWORK=off go test ./...`
- `GOWORK=off go test ./...` from `examples`
- `go test ./...` from `taskmanager/redis` with a temporary workspace linking the root module
- `go vet ./...` for the root, examples, and Redis modules
- `go test -race ./auth ./push ./server ./taskmanager/memory`
- `go test -race ./...` for the Redis module
- `mkdocs build --strict --config-file docs/mkdocs.yml`
- `typos` on the updated documentation
- live JSON-RPC auth example checks for Alice, Bob, JWT, same-owner reads, and cross-owner task-not-found
- live HTTP+JSON basic example checks for cross-owner GetTask, SubscribeToTask, and CancelTask denial

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional per-owner isolation for retained tasks, history, subscriptions, push notifications, and execution state in memory and Redis storage.
  * Added authentication-aware owner resolution and validation.
  * Simplified runnable authentication examples for API keys and JWTs.
  * Added Basic Authentication and owner-isolation verification to the basic example.

* **Documentation**
  * Expanded English and Chinese guidance for authentication, owner isolation, tenant routing, and Redis migration considerations.

* **Bug Fixes**
  * Prevented owner-resolution failures from exposing sensitive error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->