### PR TITLE
taskmanager: add retaining store contract and Redis implementation

### DIFF
--- a/docs/taskmanager-store-design.md
+++ b/docs/taskmanager-store-design.md
@@ -149,11 +149,6 @@ type StoredEvent struct {
     Event  protocol.StreamResponse
 }
 
-type StoredPushConfig struct {
-    Config     protocol.TaskPushNotificationConfig
-    Generation uint64
-}
-
 type CommitTaskEventRequest struct {
     Key             TaskKey
     ExpectedVersion uint64
@@ -168,7 +163,6 @@ type CommitMessageEventRequest struct {
     ExpectedVersion uint64
     OperationID     string
     Message         protocol.Message
-    Event           protocol.StreamResponse
 }
 
 type Store interface {
@@ -176,7 +170,7 @@ type Store interface {
     LoadTaskAndCursor(ctx context.Context, key TaskKey) (*TaskRecord, error)
     CommitTaskEvent(ctx context.Context, req CommitTaskEventRequest) (uint64, Cursor, error)
     CommitMessageEvent(ctx context.Context, req CommitMessageEventRequest) (uint64, Cursor, error)
-    ReadTaskEvents(ctx context.Context, key TaskKey, after Cursor, limit int) ([]StoredEvent, error)
+    ReadTaskEvents(ctx context.Context, key TaskKey, after Cursor, limit int) ([]StoredEvent, Cursor, error)
     RefreshTaskLease(ctx context.Context, key TaskKey) error
 
     SaveMessage(ctx context.Context, tenant, owner string, message protocol.Message) error
@@ -184,9 +178,9 @@ type Store interface {
 
     ListTasks(ctx context.Context, tenant, owner string, params protocol.ListTasksParams) (*protocol.ListTasksResult, error)
 
-    SavePushConfig(ctx context.Context, key TaskKey, config protocol.TaskPushNotificationConfig) (StoredPushConfig, error)
-    GetPushConfig(ctx context.Context, key TaskKey, configID string) (StoredPushConfig, error)
-    ListPushConfigs(ctx context.Context, key TaskKey) ([]StoredPushConfig, error)
+    SavePushConfig(ctx context.Context, key TaskKey, config protocol.TaskPushNotificationConfig) (push.Registration, error)
+    GetPushConfig(ctx context.Context, key TaskKey, configID string) (push.Registration, error)
+    ListPushConfigs(ctx context.Context, key TaskKey) ([]push.Registration, error)
     DeletePushConfig(ctx context.Context, key TaskKey, configID string) error
 
     Close() error
@@ -205,7 +199,7 @@ type Notifier interface {
 
 `Cursor` 是一个有类型的 opaque string，对 Manager 完全不透明：Memory 可以编码递增整数，Redis 使用 Stream ID，MySQL 编码 `BIGINT` sequence。Manager 只保存、比较是否为空并原样传回 Store，不解析、不排序，也不能与 ListTasks page token 或 OperationID 混用。
 
-两个 Commit 方法返回“该 OperationID 首次成功提交时”的 Task version 和 Event cursor；Message Event 不改变 Task version，因此返回通过校验的原 version。
+两个 Commit 方法返回“该 OperationID 首次成功提交时”的 Task version 和 Event cursor。Version 是同一 Task 的 event-journal revision，每个 Task-associated Event 都递增，包括不替换 Task 快照的 Message Event；因此任一旧执行只要漏掉一条 Event，其后续 CAS 就会失败。`CommitMessageEvent` 只接收 Message，Store 从它唯一地构造 Message Event，避免同一次提交携带互相矛盾的两份内容。
 
 `OperationID` 在一次逻辑提交的重试过程中保持不变。Store 必须先查询 OperationID，再执行 version/终态校验：相同 OperationID 和相同请求应返回首次提交的原 version/cursor，不重复追加 Event；相同 OperationID 对应不同操作类型或不同请求摘要时必须报错。`CommitMessageEvent` 即使命中已有 OperationID，也要继续尝试请求中携带的幂等 Message/history 投影，因此上次调用已经提交 Event 但投影尚未完成时，重试会补齐投影而不是再次追加 Event。Status message 等由 Manager 在 Commit 之后单独触发的投影，也必须通过 `SaveMessage` 幂等执行。
 
@@ -220,7 +214,7 @@ Store 至少需要让通用 Manager 使用 `errors.Is` 区分以下情况：
 - Task 不存在或已逻辑过期。
 - Task version 冲突。
 - Task 已进入终态，不能再追加新的 Task-associated Event。
-- OperationID 被不同请求复用，或原提交结果已超出幂等保留窗口。
+- OperationID 被不同请求复用，或原提交结果已超出幂等保留窗口；MessageID 被不同内容复用。
 - Commit 结果不确定，必须使用原 OperationID 做有界重试。
 - Event cursor 已落后于后端保留窗口。
 - Store 已关闭。
@@ -255,7 +249,7 @@ Notifier 错误只记录日志并进入轮询退避，不影响已经提交的�
 
 ### 9.3 Task-associated Message
 
-纯 Message 首帧仍然产生无 Task 的直接响应，只通过 `SaveMessage` 保存 Message/history，不创建 Task Event。Task 已存在时，Message 使用当前 Task version 调用 `CommitMessageEvent`：Store 先处理 OperationID，再校验 expectedVersion 和 Task 非终态，随后把 Message 追加到 Task Event journal，并以 MessageID 幂等写入 conversation history；整个方法成功后 Manager 才把 Message 送入本地 SSE pipe。
+纯 Message 首帧仍然产生无 Task 的直接响应，只通过 `SaveMessage` 保存 Message/history，不创建 Task Event。Task 已存在时，Message 使用当前 Task version 调用 `CommitMessageEvent`：Store 先处理 OperationID，再校验 expectedVersion 和 Task 非终态，随后把由 Message 唯一构造的 Event 追加到 Task Event journal、递增 version，并以 MessageID 幂等写入 conversation history；整个方法成功后 Manager 才把 Message 送入本地 SSE pipe。相同 MessageID、不同内容必须返回冲突，不能覆盖原消息。
 
 由于 Redis Cluster 无法对 Task Stream 与 conversation keys 做跨 slot 原子事务，`CommitMessageEvent` 的一致性定义是“通过 version/终态校验的 Event 只追加一次，Message/history 可幂等补写”。MySQL 可以在一个事务内完成全部写入，Redis 使用 OperationID 原提交结果和幂等 history 写入在重试时补齐。若另一个节点已经推进 Task version，尤其已经提交终态，旧执行的 Message 不得进入 Event journal、history 或本地 SSE。
 
@@ -283,10 +277,10 @@ send(record.Task)
 cursor = record.Cursor
 
 loop:
-    events = Store.ReadTaskEvents(key, cursor, batchSize)
+    events, next = Store.ReadTaskEvents(key, cursor, batchSize)
+    cursor = next // 即使坏记录被跳过，物理读取位置也会推进
     if events is not empty:
         send events in order
-        cursor = events[last].Cursor
         reset idle backoff
         continue
 
@@ -313,7 +307,7 @@ Wait 可以丢失、重复或伪唤醒，Manager 每次醒来都重新读取 Sto
 | Event 与跨节点通知 | 先提交 Event，再 best-effort Notify |
 | Resubscribe snapshot 与起始 cursor | 必须来自同一原子观察点 |
 | 同一 Task 的并发更新 | expectedVersion CAS，禁止静默覆盖 |
-| Task-associated Message | OperationID 查询优先，然后校验 expectedVersion 和非终态 |
+| Task-associated Message | OperationID 查询优先，然后校验 expectedVersion 和非终态，并递增 journal version |
 | Event 重试 | OperationID 返回首次提交的 version/cursor，不重复追加 |
 | Message 与 conversation index | 按 MessageID 幂等 |
 | Task Event 与 conversation history 投影 | 有序、可重试；不承诺所有后端全局原子 |
@@ -358,17 +352,17 @@ Memory 的默认 retain 行为保持不变：conversation 默认闲置一小时�
 
 ## 14. Redis 适配
 
-Redis Store 复用当前 Task key、Stream、dedupe journal、Task index、Message/history 和 Push hash，不修改裸 Task JSON；为了正确恢复幂等提交结果，新增一个与 Task key 同 cluster slot 的 `stream-op-results:{taskKey}` HASH。现有私有 `taskEventTransport` 的方法被折叠进 Store 实现，不需要离线迁移已有 Task 数据。
+Redis Store 复用当前 Task key、Stream、dedupe journal、Task index 和 Message/history，不修改裸 Task JSON；为了正确恢复幂等提交结果，新增一个与 Task key 同 cluster slot 的 `stream-op-results:{taskKey}` HASH。Push 不能继续直接使用旧 `push:<taskID>` key：它与 Task key 不同 slot，无法原子校验 Task 可见性，因此 Store 使用同 slot 的 `stream-push:{taskKey}` HASH。Task/Event 数据不需要离线迁移，既有 Push 配置则需要在接入通用 Manager 前迁移或明确丢弃；首版实现不做容易产生双写歧义的运行时兼容读取。
 
-Redis `CommitTaskEvent` 继续使用 Lua 原子写 Task JSON 和 Stream Event。现有 `stream-dedupe` ZSET 保留 `__seq` 并按 operation sequence 提供有界淘汰；新的 result HASH 使用保留字段 `__task_version` 保存 Task version，并以 OperationID 为 field 保存 `{kind, requestDigest, version, cursor}`。Lua 先查 ZSET/HASH 中的 OperationID：摘要一致时返回原结果，摘要不一致时报错；只有新操作才比较 expectedVersion、执行 XADD/SET、递增 version 并记录结果。淘汰旧 ZSET operation member 时必须同时 HDEL 对应 result field，不能删除保留字段；Task/Stream/dedupe/result 四个 key 使用相同 TTL，`RefreshTaskLease` 在一个脚本内刷新四者但不得复活缺失 Task。
+Redis `CommitTaskEvent` 继续使用 Lua 原子写 Task JSON 和 Stream Event。现有 `stream-dedupe` ZSET 保留 `__seq` 并按 operation sequence 提供有界淘汰；新的 result HASH 使用保留字段 `__task_version` 保存 Task version，并以 `op:<OperationID>` 为 field 保存 `{kind, requestDigest, version, cursor}`，避免 OperationID 与保留字段冲突。Lua 先查 ZSET/HASH 中的 OperationID：摘要一致时返回原结果，摘要不一致时报错；只有新操作才比较 expectedVersion、执行 XADD/SET、递增 version 并记录结果。淘汰旧 ZSET operation member 时必须同时 HDEL 对应 result field，不能删除保留字段；Task/Stream/dedupe/result/tagged Push 五个 key 对齐 Task TTL，`RefreshTaskLease` 在一个脚本内刷新它们但不得复活缺失 Task。
 
-`CommitMessageEvent` 使用同一个 Lua 提交边界：幂等命中优先返回原结果；新操作读取当前 Task JSON 和 `__task_version`，校验 expectedVersion 并拒绝终态 Task，随后只追加 Stream Event，不递增 Task version。Redis Cluster slot 外的 Message/history 写入仍在脚本成功后幂等执行，重试即使命中旧 OperationID 也必须再次尝试该投影。
+`CommitMessageEvent` 使用同一个 Lua 提交边界：幂等命中优先返回原结果；新操作读取当前 Task JSON 和 `__task_version`，校验 expectedVersion 并拒绝终态 Task，随后追加 Stream Event 并递增 version，但不替换 Task JSON。Redis Cluster slot 外的 Message/history 写入仍在脚本成功后幂等执行，重试即使命中旧 OperationID 也必须再次尝试该投影。
 
 已有 Task 没有 result HASH 或 `__task_version` 时按 version 0 读取，第一次新版本写入时初始化。`LoadTaskAndCursor` 在同一个 Lua 中返回 Task JSON、Stream tail cursor 和 HASH 中的 Task version。该方案保持裸 Task JSON，但增加一个伴生 key；升级时必须同步升级所有副本，因为旧二进制既不会维护 version，也不会写入可恢复的 operation result。Task version 达到 HASH integer 上限或 operation sequence 达到 ZSET 可精确表示的整数上限前必须报后端错误，不能回绕或产生相同 score。
 
 Redis 首版传入 nil Notifier，依赖 Store 和 Manager 的有界退避轮询，不创建只负责计时的伪 Notifier。后续可以使用阻塞 XREAD 或 Pub/Sub 实现真正的低延迟唤醒；可靠性始终来自 Redis Stream 和定期重读，不来自通知通道。
 
-Redis `ReadTaskEvents` 必须在 Lua 中同时观察 Task、Stream first entry 和请求 cursor。请求 cursor 已不在 Stream 且早于 first entry 时返回 cursor expired，禁止直接返回 first entry 后的数据造成静默缺口；`0-0` 只作为空日志的内部初始位置，不接受客户端构造。
+Redis `ReadTaskEvents` 必须在 Lua 中同时观察 Task、Stream first entry 和请求 cursor。请求 cursor 已不在 Stream 时返回 cursor expired，禁止直接返回 first entry 后的数据造成静默缺口；返回值中的 next cursor 表示最后检查的物理 Stream entry，因此即使坏 entry 被丢弃也能继续前进。`0-0` 只作为空日志的内部初始位置，不接受客户端构造。
 
 Redis 的公开 module path、构造函数、默认 TTL、Stream 约 10,000 条上限、Push 和 Close 行为必须保持兼容。
 
@@ -399,7 +393,7 @@ a2a_push_configs
 
 关键字段：Task scope、`sequence`、`operation_id`、`operation_kind`、`request_digest`、`task_version`、`event_json`、`created_at`。主键或唯一键保证 `(task scope, sequence)` 和 `(task scope, operation_id)` 唯一；该 Event row 本身就是可恢复的 operation result。
 
-两个 Commit 方法都先按 OperationID 查询已有 Event row，命中且摘要一致时返回该 row 的 `task_version/sequence`，摘要不一致时报错。新 `CommitTaskEvent` 在一个事务中锁定或 CAS 更新 Task row、递增 `event_sequence`、插入 Event；新 `CommitMessageEvent` 在同一事务中校验 Task version 和非终态、递增 `event_sequence`、插入 Event 和幂等 Message。`LoadTaskAndCursor` 直接从 Task row 读取 `task_json` 和 `event_sequence`，天然获得同一观察点。
+两个 Commit 方法都先按 OperationID 查询已有 Event row，命中且摘要一致时返回该 row 的 `task_version/sequence`，摘要不一致时报错。新 `CommitTaskEvent` 在一个事务中锁定或 CAS 更新 Task row、同时递增 `version/event_sequence`、插入 Event；新 `CommitMessageEvent` 在同一事务中校验 Task version 和非终态，同样递增 `version/event_sequence`，再插入 Event 和幂等 Message，但不替换 `task_json`。`LoadTaskAndCursor` 直接从 Task row 读取 `task_json`、`version` 和 `event_sequence`，天然获得同一观察点。
 
 ### 15.4 `a2a_messages`
 
@@ -429,7 +423,7 @@ Store 返回的 Task 快照默认不包含 history；通用 Manager 按 `history
 
 ## 17. Push Notification
 
-通用 Manager 继续复用公共 `push.Dispatcher`。当前代码库不存在额外的 `push.Registration` 类型，因此 Store 使用最小的 `StoredPushConfig{Config, Generation}`：Config 是现有协议类型，Generation 是不进入协议 JSON 的存储版本。`TaskKey` 是保存和读取时的权威 scope，Store 不信任可变 Config 中携带的 tenant/taskID。每次注册或替换配置都生成新的 generation；Dispatcher 真正投递前使用 Store 检查当前 generation，已删除或被替换的 queued registration 不再投递。
+通用 Manager 继续复用公共 `push.Dispatcher` 及现有 `push.Registration`，不再新增同义的 Store 类型。`TaskKey` 是保存和读取时的权威 scope；Config 中非空 tenant/taskID 必须与它一致，Store 再覆盖为权威值，避免调用方误传 scope 被静默改写。`SavePushConfig` 必须在同一存储边界确认 Task 仍然可见，不能通过 Manager 先读后写留下 TTL/删除竞态。每次注册或替换配置都生成新的 string generation；Dispatcher 真正投递前使用 Store 检查当前 generation，已删除或被替换的 queued registration 不再投递。
 
 自动投递保持“同一配置有序、有界队列、队列满时背压、进程崩溃不保证 durable delivery”的当前语义。需要 durable outbox 时仍使用 `ManualDelivery`，不把 outbox 强行放入通用 Store。
 
@@ -452,7 +446,7 @@ Redis 与 MySQL 额外运行两个 Manager 实例共享同一后端的跨节点 
 - `memory.NewTaskManager`、Redis module path、`redis.NewTaskManager` 和现有 options 保持不变。
 - `taskmanager.TaskManager` 接口不修改。
 - Memory 的默认 TTL 和历史行为不修改。
-- Redis 保持当前 Task key 和裸 Task JSON，新增同 slot 的 operation result HASH；version 和原提交结果由该 HASH 保存，部署时同步升级所有副本。
+- Redis 保持当前 Task key 和裸 Task JSON，新增同 slot 的 operation result HASH，并把 Push 配置迁移到同 slot 的 tagged HASH；version 和原提交结果由 result HASH 保存，部署时同步升级所有副本。
 - Generic Manager 首先在 Memory 上落地并通过 conformance suite，再迁移 Redis；MySQL 只在 Memory/Redis 都通过后实现。
 - 每个阶段都保留可运行后端，不提交同时破坏 Memory 和 Redis 的中间状态。
 

--- a/docs/taskmanager-store-design.md
+++ b/docs/taskmanager-store-design.md
@@ -1,0 +1,493 @@
+# 通用 Retaining TaskManager、Store 与跨节点事件同步设计
+
+状态：Draft
+
+设计基线：`origin/v2@aed2c1f02f9cb43e8d7eb9bd62f51585fbd2030a`
+
+## 设计摘要
+
+- 新增公共 `taskmanager/retaining`，只维护一套 retaining 生命周期 engine。
+- 首版只公开一个 Store 和一个可选 Notifier，避免过早拆出大量小接口。
+- Store 是持久化真相，Task 快照和对应 Task Event 必须原子提交；Notifier 只做可丢失唤醒。
+- Memory、Redis 保持原构造函数和 options，通过 wrapper 接入通用 Manager；MySQL 使用独立 module。
+- 首版跨节点能力覆盖状态可见性、事件同步和 `SubscribeToTask`（TaskManager 接口方法仍为 `OnResubscribe`），不覆盖 execution 调度、continuation 路由或远端 live cancel。
+- 实施顺序固定为契约测试、Memory、Redis、MySQL，避免一个 PR 同时改动三个后端。
+
+## 1. 背景
+
+当前 `taskmanager/memory` 与 `taskmanager/redis` 都实现了完整的 retaining TaskManager 生命周期，包括 Task lazy creation、事件归约、conversation history、continuation、cancel、suspend/yield、`returnImmediately`、SSE、本地执行注册、Push Notification 和关闭流程，但两套实现分别维护了一套 engine、持久化和订阅逻辑。
+
+Memory 在进程内锁保护下直接修改共享 Task；Redis 使用 execution-local Task 副本，并在事件广播前将 Task 快照和 Redis Stream 事件持久化。Redis 的 `taskEventTransport` 已经形成了一个局部抽象，但它位于 Redis 模块内部，无法直接支持 MySQL 或其他后端。
+
+为了新增 MySQL TaskManager，同时避免继续复制完整生命周期，本设计提取一个通用 retaining TaskManager，由 Store 提供持久化真相和可靠事件日志，由可选 Notifier 提供跨节点低延迟唤醒。
+
+## 2. 目标
+
+- Memory、Redis、MySQL 使用同一套 Task 生命周期 engine。
+- 保持现有 `taskmanager.TaskManager` 接口以及 Memory/Redis 构造函数和 options 的兼容性。
+- Store 同时支持聚合 Task 快照、conversation history、Push 配置、Task 事件日志、版本控制和留存策略。
+- Task 快照更新与产生该快照的 Task 事件必须原子提交。
+- `SubscribeToTask` 可以在任意共享 Store 的节点上先得到一致的当前 Task 快照，再持续读取后续事件。
+- 跨节点通知允许丢失或重复；订阅建立后的无缝读取由持久化事件日志、cursor 和有界轮询共同保证。
+- tenant 与 owner 共同构成所有留存状态的隔离边界。
+- 后端可以使用不同的事务、TTL、索引和通知机制，不要求模拟同一种物理存储模型。
+
+## 3. 非目标
+
+- 不在本阶段实现 active execution 的跨节点迁移或调度。
+- 不在本阶段将 continuation 路由到原执行节点。
+- 不在本阶段将 live cancel 信号发送到其他节点上的 Processor。
+- 不提供 exactly-once webhook 投递；自动 Push 继续使用现有进程内有界 Dispatcher，durable outbox 仍由业务在手动投递模式下实现。
+- 不新增 A2A 协议未定义的按 Task 删除 API。
+- 不要求所有后端采用相同的默认 TTL；现有 Memory 和 Redis 默认值保持不变。
+- 不在首个实现中把 Store 再拆成大量公共 CRUD 接口。
+
+## 4. 核心设计原则
+
+### 4.1 事件日志是跨节点同步的可靠来源
+
+Notifier 只负责唤醒等待者，可能丢失、重复或产生伪唤醒。订阅者被唤醒后必须使用 cursor 从 Store 读取事件；即使完全没有 Notifier，也能通过退避轮询正确工作。
+
+### 4.2 Task 快照与 Task 事件共享提交边界
+
+Status 和 Artifact 事件既会修改聚合 Task 快照，也需要进入事件日志。Store 必须通过单个 `CommitTaskEvent` 操作原子提交二者，禁止在通用 Manager 中先 `UpdateTask` 再 `AppendEvent`。
+
+### 4.3 先持久化，后对外可见
+
+Task 事件只有在 Store 提交成功后才能进入当前请求的 SSE pipe、Push Dispatcher 或本地订阅者。Notifier 在提交后调用，Notifier 失败不回滚已经提交的 Task/Event。
+
+### 4.4 CAS 是跨节点写冲突的最后保护
+
+进程内 execution registry 只能阻止同一进程中的并发轮次。Store 必须保存 Task version，并使用 `expectedVersion` 拒绝跨节点陈旧写入。CAS 可以防止数据被覆盖，但不会撤销 Processor 已经产生的外部副作用，因此它不是分布式执行锁的替代品。
+
+### 4.5 Conversation history 是独立投影
+
+Task 快照与 Task 事件要求强原子性；conversation history 跨 Task、Message 和 Redis Cluster slot，不能对所有后端承诺与 Task/Event 的全局原子事务。Message 写入必须幂等，Store 操作必须支持安全重试；Task/Event 是任务观察面的主真相，history 是独立投影。
+
+### 4.6 Store 边界不共享可变对象
+
+`protocol.Task`、`protocol.Message` 和 `protocol.StreamResponse` 都包含指针、slice 或 map。Store 的所有读操作必须返回深拷贝，所有写操作必须在返回前复制输入；调用方在 Store 方法返回后继续修改原对象，不得改变已经提交的状态。该规则对 Memory、Redis 和 MySQL 完全一致，是 Memory 不绕过 version/CAS 和 Task/Event 原子边界的必要条件。
+
+## 5. 总体架构
+
+```mermaid
+flowchart LR
+    Processor["MessageProcessor"] --> Engine["retaining.Manager"]
+    Engine -->|"CommitTaskEvent / CommitMessageEvent"| Store["Store"]
+    Store --> Snapshot["Task snapshot"]
+    Store --> Journal["Durable event journal"]
+    Store --> History["Messages and history"]
+    Store --> PushConfig["Push registrations"]
+    Engine -->|"after commit"| Pipe["Current request SSE pipe"]
+    Engine -->|"best effort wakeup"| Notifier["Notifier"]
+    Engine --> Push["push.Dispatcher"]
+    Resubscriber["SubscribeToTask"] -->|"snapshot plus cursor"| Store
+    Resubscriber -->|"wait"| Notifier
+    Resubscriber -->|"read after cursor"| Journal
+```
+
+通用 Manager 保留协议和生命周期语义；Store 负责持久化、原子性、查询和留存；Notifier 只提供跨节点唤醒。当前请求的 SSE 不回读事件日志，而是在提交成功后直接发送原事件，避免增加正常流式路径的存储读取延迟。
+
+## 6. 包结构
+
+```text
+taskmanager/
+├── interface.go
+├── retaining/
+│   ├── manager.go
+│   ├── engine.go
+│   ├── execution_registry.go
+│   ├── store.go
+│   ├── notifier.go
+│   ├── subscriber.go
+│   └── options.go
+├── memory/
+│   ├── memory.go
+│   ├── store.go
+│   └── options.go
+└── taskmanagertest/
+    └── retaining_suite.go
+
+taskmanager/redis/                  # 独立 Go module，路径保持不变
+├── redis.go
+├── store.go
+└── options.go
+
+taskmanager/mysql/                  # 新独立 Go module
+├── mysql.go
+├── store.go
+├── options.go
+├── schema.sql
+└── go.mod
+```
+
+`taskmanager/retaining` 必须位于根模块的公共导入路径下，因为 Redis 与 MySQL 是独立 Go module，无法导入根模块的 `internal` 包。现有用户继续通过 `memory.NewTaskManager` 和 `redis.NewTaskManager` 创建实例；直接实现自定义 Store 的用户才需要导入 `taskmanager/retaining`。
+
+## 7. 公共类型与接口草案
+
+下面的接口是语义草案，字段名称可以在实现前微调，但原子边界和错误语义不应改变。
+
+```go
+package retaining
+
+type Cursor string
+
+type TaskKey struct {
+    Tenant string
+    Owner  string
+    ID     string
+}
+
+type TaskRecord struct {
+    Task    *protocol.Task
+    Version uint64
+    Cursor  Cursor
+}
+
+type StoredEvent struct {
+    Cursor Cursor
+    Event  protocol.StreamResponse
+}
+
+type StoredPushConfig struct {
+    Config     protocol.TaskPushNotificationConfig
+    Generation uint64
+}
+
+type CommitTaskEventRequest struct {
+    Key             TaskKey
+    ExpectedVersion uint64
+    AllowCreate     bool
+    OperationID     string
+    Task            *protocol.Task
+    Event           protocol.StreamResponse
+}
+
+type CommitMessageEventRequest struct {
+    Key             TaskKey
+    ExpectedVersion uint64
+    OperationID     string
+    Message         protocol.Message
+    Event           protocol.StreamResponse
+}
+
+type Store interface {
+    LoadTask(ctx context.Context, key TaskKey) (*TaskRecord, error)
+    LoadTaskAndCursor(ctx context.Context, key TaskKey) (*TaskRecord, error)
+    CommitTaskEvent(ctx context.Context, req CommitTaskEventRequest) (uint64, Cursor, error)
+    CommitMessageEvent(ctx context.Context, req CommitMessageEventRequest) (uint64, Cursor, error)
+    ReadTaskEvents(ctx context.Context, key TaskKey, after Cursor, limit int) ([]StoredEvent, error)
+    RefreshTaskLease(ctx context.Context, key TaskKey) error
+
+    SaveMessage(ctx context.Context, tenant, owner string, message protocol.Message) error
+    LoadHistory(ctx context.Context, tenant, owner, contextID string, limit int) ([]protocol.Message, error)
+
+    ListTasks(ctx context.Context, tenant, owner string, params protocol.ListTasksParams) (*protocol.ListTasksResult, error)
+
+    SavePushConfig(ctx context.Context, key TaskKey, config protocol.TaskPushNotificationConfig) (StoredPushConfig, error)
+    GetPushConfig(ctx context.Context, key TaskKey, configID string) (StoredPushConfig, error)
+    ListPushConfigs(ctx context.Context, key TaskKey) ([]StoredPushConfig, error)
+    DeletePushConfig(ctx context.Context, key TaskKey, configID string) error
+
+    Close() error
+}
+
+type Notifier interface {
+    Notify(ctx context.Context, key TaskKey, cursor Cursor) error
+    Wait(ctx context.Context, key TaskKey, after Cursor) error
+    Close() error
+}
+```
+
+首版保留单一 `Store` 公共接口，避免先发布多个细粒度接口后再处理组合、事务和兼容性。实现内部可以按 Task/Event、Message、Push 拆文件，但不要求把每个文件对应的内部结构都公开。
+
+这个公共 `Store` 在首版冻结后不通过直接追加方法扩张可选能力，避免破坏第三方实现。未来的可选能力使用独立扩展接口或新的 major version；首版实现前尚未稳定的能力继续留在 backend 内部。
+
+`Cursor` 是一个有类型的 opaque string，对 Manager 完全不透明：Memory 可以编码递增整数，Redis 使用 Stream ID，MySQL 编码 `BIGINT` sequence。Manager 只保存、比较是否为空并原样传回 Store，不解析、不排序，也不能与 ListTasks page token 或 OperationID 混用。
+
+两个 Commit 方法返回“该 OperationID 首次成功提交时”的 Task version 和 Event cursor；Message Event 不改变 Task version，因此返回通过校验的原 version。
+
+`OperationID` 在一次逻辑提交的重试过程中保持不变。Store 必须先查询 OperationID，再执行 version/终态校验：相同 OperationID 和相同请求应返回首次提交的原 version/cursor，不重复追加 Event；相同 OperationID 对应不同操作类型或不同请求摘要时必须报错。`CommitMessageEvent` 即使命中已有 OperationID，也要继续尝试请求中携带的幂等 Message/history 投影，因此上次调用已经提交 Event 但投影尚未完成时，重试会补齐投影而不是再次追加 Event。Status message 等由 Manager 在 Commit 之后单独触发的投影，也必须通过 `SaveMessage` 幂等执行。
+
+Store 首先完成 backend 自己的有限重试；如果仍无法判断提交是否成功，或 Event 已提交但请求内投影尚未确认完成，则返回可由 `errors.Is` 识别的 commit uncertain error。Manager 只对该错误使用同一个请求和 OperationID 做有界重试，version conflict、terminal、operation conflict 和普通确定性错误都不重试。重试耗尽后当前请求失败，但后续恢复或运维重放仍不得换用新 OperationID 重复提交同一 Event。
+
+OperationID 幂等保证只覆盖 backend 明确配置的 operation journal 保留窗口，该窗口不得短于 Manager 的最大提交重试时长，并默认与 Event journal 一同保留。窗口过期后的旧操作不得被 Manager 自动重试；Store 可以返回 operation expired 或 version conflict，但不能把一次已知仍在 journal 内的重试当成新事件提交。
+
+## 8. 错误模型
+
+Store 至少需要让通用 Manager 使用 `errors.Is` 区分以下情况：
+
+- Task 不存在或已逻辑过期。
+- Task version 冲突。
+- Task 已进入终态，不能再追加新的 Task-associated Event。
+- OperationID 被不同请求复用，或原提交结果已超出幂等保留窗口。
+- Commit 结果不确定，必须使用原 OperationID 做有界重试。
+- Event cursor 已落后于后端保留窗口。
+- Store 已关闭。
+- 普通后端故障。
+
+建议在 `taskmanager/retaining` 中提供少量 sentinel error，不直接使用 JSON-RPC 或 HTTP 错误。通用 Manager 负责把 Store error 映射为现有 `taskmanager.Error`。
+
+Version 冲突不得自动覆盖。当前轮次应停止写入、取消 Processor context，并结束当前响应；如果 Task 已被其他节点推进到终态，终态保持不可变。
+
+Notifier 错误只记录日志并进入轮询退避，不影响已经提交的业务结果。即使 Notifier 正常，Manager 也必须为每次 `Wait` 设置最大等待时间并在超时后重新读取 Store，不能依赖通知通道提供活性保证。
+
+当 `ReadTaskEvents` 返回 cursor expired 时，当前订阅关闭；客户端重新调用 `SubscribeToTask` 后会从新的当前 Task 快照和 tail cursor 继续，不能承诺补回已经被裁剪的中间事件。
+
+## 9. 关键流程
+
+### 9.1 新 Task 的 Status/Artifact 事件
+
+1. Manager 为本轮预分配 Task ID，但此时 Store 中没有 Task。
+2. Processor 发出第一个 Status 或 Artifact 事件。
+3. Engine 构造 Task 快照，提交 `CommitTaskEvent{AllowCreate:true, ExpectedVersion:0}`。
+4. Store 原子创建 Task、写入第一条 Event、设置 version/cursor 和 retention。
+5. Manager 先向当前流发送合成的初始 Task 快照；该快照不进入事件日志。
+6. Manager 再发送已经提交的 Processor 事件，并调用 Notifier 和 Push Dispatcher。
+
+### 9.2 后续 Status/Artifact 事件
+
+1. Engine 在本轮工作副本上归约事件。
+2. Engine 使用上次 Store 返回的 version 调用 `CommitTaskEvent`。
+3. Store 以 CAS 原子更新 Task 快照并追加 Event。
+4. Store 返回该 OperationID 首次提交产生的新 version 和 cursor；响应丢失后的重试仍返回同一结果。
+5. Manager 对外发送事件并 best-effort 通知其他节点。
+
+### 9.3 Task-associated Message
+
+纯 Message 首帧仍然产生无 Task 的直接响应，只通过 `SaveMessage` 保存 Message/history，不创建 Task Event。Task 已存在时，Message 使用当前 Task version 调用 `CommitMessageEvent`：Store 先处理 OperationID，再校验 expectedVersion 和 Task 非终态，随后把 Message 追加到 Task Event journal，并以 MessageID 幂等写入 conversation history；整个方法成功后 Manager 才把 Message 送入本地 SSE pipe。
+
+由于 Redis Cluster 无法对 Task Stream 与 conversation keys 做跨 slot 原子事务，`CommitMessageEvent` 的一致性定义是“通过 version/终态校验的 Event 只追加一次，Message/history 可幂等补写”。MySQL 可以在一个事务内完成全部写入，Redis 使用 OperationID 原提交结果和幂等 history 写入在重试时补齐。若另一个节点已经推进 Task version，尤其已经提交终态，旧执行的 Message 不得进入 Event journal、history 或本地 SSE。
+
+### 9.4 Continuation
+
+1. Manager 使用当前 `(tenant, owner, taskID)` 加载 TaskRecord。
+2. 终态 Task 直接拒绝。
+3. Manager 刷新 Task lease，再调用 Processor。
+4. 当前 status message 若被新一轮 supersede，Manager 将清除后的 Task 快照和同状态 Event 通过 `CommitTaskEvent` 提交，再幂等写入旧 status message history。
+5. 本轮后续写入继续使用新的 version。
+
+Store CAS 会拒绝跨节点陈旧 continuation，但不会阻止两个节点同时执行 Processor。完整的单执行者保证需要未来的跨节点 Coordinator，不属于本阶段。
+
+### 9.5 Cancel
+
+命中本节点 live execution 时，Manager 保留现有本地 cancel/yield 线性化逻辑，由 Processor 结束规则提交最终状态。没有本地 live execution 时，Manager 加载当前 TaskRecord，并用 expectedVersion 提交 CANCELED Event；若发生 version 冲突，则重新加载并判断最新状态，不直接覆盖。
+
+如果 live execution 位于其他节点，首版无法直接取消其 context；CANCELED 的 CAS 提交会阻止该节点继续写入陈旧 Task，但不能撤销 Processor 的外部副作用。文档必须保留与当前 Redis 相同的能力边界。
+
+### 9.6 Resubscribe
+
+```text
+record = Store.LoadTaskAndCursor(key)  // snapshot 与 tail cursor 同一原子观察点
+send(record.Task)
+cursor = record.Cursor
+
+loop:
+    events = Store.ReadTaskEvents(key, cursor, batchSize)
+    if events is not empty:
+        send events in order
+        cursor = events[last].Cursor
+        reset idle backoff
+        continue
+
+    waitCtx = context.WithTimeout(ctx, idleBackoff)
+    if Notifier is not nil:
+        Notifier.Wait(waitCtx, key, cursor)
+    else:
+        wait(waitCtx)
+    cancel(waitCtx)
+```
+
+`LoadTaskAndCursor` 必须保证并发提交要么同时反映在 Task 快照和 cursor 中，要么同时不反映，从而避免 snapshot 与下一次 `ReadTaskEvents` 之间出现丢失或重复。
+
+Wait 可以丢失、重复或伪唤醒，Manager 每次醒来都重新读取 Store。Notifier 为 nil 时直接等待；Notifier 非 nil 时也受同一个带 jitter 的指数退避 deadline 限制，因此 Event 即使在“空读取完成、Wait 尚未注册”的窗口内提交，Manager 最迟也会在 deadline 后重新读取，不会永久停住。
+
+该流程只保证 `LoadTaskAndCursor` 原子观察点之后的事件无缝读取。A2A `SubscribeToTask` 请求没有携带客户端 resume cursor，因此客户端断线后重新调用时会收到新的当前 Task 快照，并从新的 tail cursor 读取未来事件；断线期间已经发生的中间 Event 不会重放，Task-associated Message 也不会因为不属于 Task 聚合快照而自动补回。首版明确接受这个边界；若未来需要精确断点续传，应单独设计协议扩展或 SSE `Last-Event-ID` 映射，不复用当前内部 Cursor。
+
+## 10. 一致性保证
+
+| 数据关系 | 保证 |
+| --- | --- |
+| Task 快照与产生它的 Status/Artifact Event | 必须原子提交 |
+| Event 与当前请求 SSE | Event 提交成功后才发送 |
+| Event 与跨节点通知 | 先提交 Event，再 best-effort Notify |
+| Resubscribe snapshot 与起始 cursor | 必须来自同一原子观察点 |
+| 同一 Task 的并发更新 | expectedVersion CAS，禁止静默覆盖 |
+| Task-associated Message | OperationID 查询优先，然后校验 expectedVersion 和非终态 |
+| Event 重试 | OperationID 返回首次提交的 version/cursor，不重复追加 |
+| Message 与 conversation index | 按 MessageID 幂等 |
+| Task Event 与 conversation history 投影 | 有序、可重试；不承诺所有后端全局原子 |
+| Push 配置与 Task Event | 独立提交；generation 防止陈旧投递 |
+| Store 输入输出对象 | 深拷贝，不与 Manager 共享可变引用 |
+
+## 11. 生命周期与资源所有权
+
+`retaining.Manager.Close` 按以下顺序执行：拒绝新 execution、取消 Processor context、关闭当前请求 pipe、停止 Notifier wait、关闭 Push Dispatcher、等待 engine 最后一次 Store 提交、关闭 Notifier、最后调用 `Store.Close`。
+
+一个 `retaining.Manager` 独占其 Store 和 Notifier 实例，不允许多个 Manager 共享同一个有状态 Store wrapper；底层连接池是否共享由 backend wrapper 决定。`Store.Close` 只释放 Store 自己拥有的资源，并保持现有兼容语义：Redis wrapper 继续关闭传入的 Redis client；Memory 关闭 cleanup goroutine；MySQL 不关闭调用方传入的共享 `*sql.DB`，只停止自己的 cleanup worker。若多个 MySQL Manager 共享连接池，每个 Manager 仍使用独立 Store wrapper。
+
+如果 Redis client 所有权在实现阶段需要调整，应作为独立兼容性决策，不与通用 Manager 提取混在同一个行为变更中。
+
+## 12. Options 分层
+
+通用 Manager options 只包含生命周期参数：
+
+- `OwnerResolver`
+- `MaxHistoryLength`
+- `TaskSubscriberBufferSize`
+- `TaskSubscriberBlockingSend`
+- `push.Config`
+- Event read batch size 与 idle backoff
+- Commit uncertain retry max elapsed 与 backoff
+
+Store-specific options 由 backend wrapper 保留：
+
+- Memory：ConversationTTL、TaskTTL、CleanupInterval。
+- Redis：ExpireTime、Redis Stream retention。
+- MySQL：ExpireTime、CleanupInterval、CleanupBatchSize、EventRetention、poll backoff。
+
+现有 Memory/Redis option 名称保持兼容，wrapper 将其拆分后分别传给 generic Manager 和 backend Store。
+
+## 13. Memory 适配
+
+Memory Store 使用当前 maps 和锁实现 Task、Message、history 与 Push persistence，并新增一个按 Task 递增的内存 event cursor 和同窗口 operation result。事件日志只需要服务当前进程中的 `SubscribeToTask`，按 Task 保留固定上限并在 Task 清理时一起删除，避免默认永久 Task 带来无界事件增长。Store 同时记录 first retained cursor；`ReadTaskEvents` 收到早于该位置的非初始 cursor 时返回 cursor expired，不能从当前最早事件静默续读。
+
+Memory Notifier 使用进程内广播机制，但 Manager 仍执行有界等待。`LoadTask`、`LoadTaskAndCursor`、Message/history 和 Event 读写全部深拷贝；`LoadTaskAndCursor` 在同一 Task 锁下复制 Task 并读取 tail cursor，两个 Commit 方法在同一锁下先处理 OperationID，再应用 version/终态校验和追加 Event。
+
+Memory 的默认 retain 行为保持不变：conversation 默认闲置一小时清理，终态 Task 默认不清理，挂起 Task 不由 terminal-only cleaner 回收。
+
+## 14. Redis 适配
+
+Redis Store 复用当前 Task key、Stream、dedupe journal、Task index、Message/history 和 Push hash，不修改裸 Task JSON；为了正确恢复幂等提交结果，新增一个与 Task key 同 cluster slot 的 `stream-op-results:{taskKey}` HASH。现有私有 `taskEventTransport` 的方法被折叠进 Store 实现，不需要离线迁移已有 Task 数据。
+
+Redis `CommitTaskEvent` 继续使用 Lua 原子写 Task JSON 和 Stream Event。现有 `stream-dedupe` ZSET 保留 `__seq` 并按 operation sequence 提供有界淘汰；新的 result HASH 使用保留字段 `__task_version` 保存 Task version，并以 OperationID 为 field 保存 `{kind, requestDigest, version, cursor}`。Lua 先查 ZSET/HASH 中的 OperationID：摘要一致时返回原结果，摘要不一致时报错；只有新操作才比较 expectedVersion、执行 XADD/SET、递增 version 并记录结果。淘汰旧 ZSET operation member 时必须同时 HDEL 对应 result field，不能删除保留字段；Task/Stream/dedupe/result 四个 key 使用相同 TTL，`RefreshTaskLease` 在一个脚本内刷新四者但不得复活缺失 Task。
+
+`CommitMessageEvent` 使用同一个 Lua 提交边界：幂等命中优先返回原结果；新操作读取当前 Task JSON 和 `__task_version`，校验 expectedVersion 并拒绝终态 Task，随后只追加 Stream Event，不递增 Task version。Redis Cluster slot 外的 Message/history 写入仍在脚本成功后幂等执行，重试即使命中旧 OperationID 也必须再次尝试该投影。
+
+已有 Task 没有 result HASH 或 `__task_version` 时按 version 0 读取，第一次新版本写入时初始化。`LoadTaskAndCursor` 在同一个 Lua 中返回 Task JSON、Stream tail cursor 和 HASH 中的 Task version。该方案保持裸 Task JSON，但增加一个伴生 key；升级时必须同步升级所有副本，因为旧二进制既不会维护 version，也不会写入可恢复的 operation result。Task version 达到 HASH integer 上限或 operation sequence 达到 ZSET 可精确表示的整数上限前必须报后端错误，不能回绕或产生相同 score。
+
+Redis 首版传入 nil Notifier，依赖 Store 和 Manager 的有界退避轮询，不创建只负责计时的伪 Notifier。后续可以使用阻塞 XREAD 或 Pub/Sub 实现真正的低延迟唤醒；可靠性始终来自 Redis Stream 和定期重读，不来自通知通道。
+
+Redis `ReadTaskEvents` 必须在 Lua 中同时观察 Task、Stream first entry 和请求 cursor。请求 cursor 已不在 Stream 且早于 first entry 时返回 cursor expired，禁止直接返回 first entry 后的数据造成静默缺口；`0-0` 只作为空日志的内部初始位置，不接受客户端构造。
+
+Redis 的公开 module path、构造函数、默认 TTL、Stream 约 10,000 条上限、Push 和 Close 行为必须保持兼容。
+
+## 15. MySQL 适配
+
+MySQL 使用独立 module `trpc.group/trpc-go/trpc-a2a-go/taskmanager/mysql/v2`，构造函数接收 `*sql.DB`，实现面向 MySQL 8.0 的 SQL 和事务语义。
+
+### 15.1 最小表结构
+
+首版只使用四张业务表：
+
+```text
+a2a_tasks
+a2a_task_events
+a2a_messages
+a2a_push_configs
+```
+
+不需要单独的 conversation 表，`a2a_messages` 通过 `(tenant, owner, context_id, sequence)` 索引提供历史；不需要 task index 表，MySQL 二级索引直接支持 ListTasks。
+
+### 15.2 `a2a_tasks`
+
+关键字段：`tenant`、`owner`、`task_id`、`context_id`、`state`、`status_timestamp`、`task_json`、`version`、`event_sequence`、`expires_at`、`updated_at`。
+
+`task_json` 保存协议 Task 快照，`context_id/state/status_timestamp` 是为过滤和排序提取的索引字段。所有写入必须同时更新 JSON 和提取字段，禁止依赖 JSON 查询完成高频 ListTasks。
+
+### 15.3 `a2a_task_events`
+
+关键字段：Task scope、`sequence`、`operation_id`、`operation_kind`、`request_digest`、`task_version`、`event_json`、`created_at`。主键或唯一键保证 `(task scope, sequence)` 和 `(task scope, operation_id)` 唯一；该 Event row 本身就是可恢复的 operation result。
+
+两个 Commit 方法都先按 OperationID 查询已有 Event row，命中且摘要一致时返回该 row 的 `task_version/sequence`，摘要不一致时报错。新 `CommitTaskEvent` 在一个事务中锁定或 CAS 更新 Task row、递增 `event_sequence`、插入 Event；新 `CommitMessageEvent` 在同一事务中校验 Task version 和非终态、递增 `event_sequence`、插入 Event 和幂等 Message。`LoadTaskAndCursor` 直接从 Task row 读取 `task_json` 和 `event_sequence`，天然获得同一观察点。
+
+### 15.4 `a2a_messages`
+
+关键字段：`tenant`、`owner`、`message_id`、`context_id`、`sequence`、`message_json`、`expires_at`。MessageID 唯一保证重试幂等，conversation index 按 sequence 读取最近 N 条。
+
+### 15.5 `a2a_push_configs`
+
+关键字段：Task scope、`config_id`、`generation`、`config_json`。Task 物理删除时通过外键级联删除；逻辑读取同时验证 Task 未过期。
+
+### 15.6 留存与清理
+
+所有读取首先过滤 `expires_at`，因此物理清理延迟不会暴露过期 Task。后台 cleaner 使用带索引的小批量 DELETE，Task 删除级联清理 Event 和 Push；Message 按自己的 expires_at 清理。Event retention 清理后，`ReadTaskEvents` 使用 Task row 的 `event_sequence` 和当前最小保留 sequence 区分“已经追平”与“cursor expired”，不能在中间 sequence 已被删除时静默跳过。
+
+活跃 Task 使用 `RefreshTaskLease` 定期更新 expires_at，但不能复活已经逻辑过期的 Task。Task-associated Message Event 只能继承 Task 剩余 retention，不能单独延长 Task 生命周期。
+
+### 15.7 MySQL 空闲订阅
+
+首版传入 nil Notifier，由通用 Manager 执行退避轮询，不新增只等待 poll deadline 的 `PollingNotifier`。必须对 100、1,000、10,000 个空闲订阅进行查询 QPS 和连接池压力测试，再决定是否增加 Redis Pub/Sub、MQ 或其他真正的通知实现。
+
+## 16. ListTasks
+
+Store 负责利用后端索引完成过滤和 keyset pagination，通用 Manager 不把全量 Task 拉入内存排序。统一排序语义为 `status_timestamp DESC, task_id ASC`，page token 继续是 opaque cursor。
+
+Memory 可以复用当前 `taskmanager.PaginateTasks`；Redis 首版可以保持当前 scoped index + 批量加载实现；MySQL 必须直接使用 SQL WHERE/ORDER BY/LIMIT 和独立 COUNT 查询。
+
+Store 返回的 Task 快照默认不包含 history；通用 Manager 按 `historyLength` 调用 `LoadHistory` 填充当前页 Task。`includeArtifacts=false` 时可以在 Manager 返回前裁剪，也可以由支持 JSON projection 的 Store 优化，但语义由通用测试固定。
+
+## 17. Push Notification
+
+通用 Manager 继续复用公共 `push.Dispatcher`。当前代码库不存在额外的 `push.Registration` 类型，因此 Store 使用最小的 `StoredPushConfig{Config, Generation}`：Config 是现有协议类型，Generation 是不进入协议 JSON 的存储版本。`TaskKey` 是保存和读取时的权威 scope，Store 不信任可变 Config 中携带的 tenant/taskID。每次注册或替换配置都生成新的 generation；Dispatcher 真正投递前使用 Store 检查当前 generation，已删除或被替换的 queued registration 不再投递。
+
+自动投递保持“同一配置有序、有界队列、队列满时背压、进程崩溃不保证 durable delivery”的当前语义。需要 durable outbox 时仍使用 `ManualDelivery`，不把 outbox 强行放入通用 Store。
+
+## 18. 可观测性
+
+至少记录以下指标或结构化日志字段：Store operation、backend、latency、error class、CAS conflict、event read batch size、subscriber cursor lag、Notifier wakeup/error、cleanup rows、active executions、active resubscribers 和 Push queue backpressure。
+
+不在首个 PR 引入新的 metrics SDK；优先复用现有日志和 telemetry 接口，避免通用 Manager 因可观测性依赖扩大根模块图。
+
+## 19. Conformance Test Suite
+
+新增 `taskmanager/taskmanagertest`，由 Memory、Redis、MySQL 的测试传入 factory 运行同一套 retaining 行为测试。测试包是为了独立 Go module 复用，不能放在根模块 `internal` 下。
+
+统一测试至少覆盖：direct Message、Task lazy creation、Status、Artifact append、persist-before-broadcast、continuation、suspend/yield、terminal immutable、cancel、returnImmediately、client disconnect、ListTasks、history、tenant/owner isolation、Push CRUD、Push generation、Close、TTL、version conflict、Task 终态与迟到 Message 的并发竞争、OperationID 响应丢失后又发生后续提交再重试、OperationID 摘要冲突、Store 读写对象别名隔离、Read/Wait 窗口丢通知、snapshot/cursor 无缝衔接、重连不回放中间 Message 和 cursor expired。
+
+Redis 与 MySQL 额外运行两个 Manager 实例共享同一后端的跨节点 `SubscribeToTask` 测试；MySQL 必须使用真实 MySQL service，不能只依赖 sqlmock。
+
+## 20. 兼容与迁移策略
+
+- `memory.NewTaskManager`、Redis module path、`redis.NewTaskManager` 和现有 options 保持不变。
+- `taskmanager.TaskManager` 接口不修改。
+- Memory 的默认 TTL 和历史行为不修改。
+- Redis 保持当前 Task key 和裸 Task JSON，新增同 slot 的 operation result HASH；version 和原提交结果由该 HASH 保存，部署时同步升级所有副本。
+- Generic Manager 首先在 Memory 上落地并通过 conformance suite，再迁移 Redis；MySQL 只在 Memory/Redis 都通过后实现。
+- 每个阶段都保留可运行后端，不提交同时破坏 Memory 和 Redis 的中间状态。
+
+## 21. PR 拆分与时间评估
+
+### PR 1：契约与 Conformance Suite，5～7 人日
+
+确定 Store/Notifier、错误、version、typed cursor、OperationID 原结果恢复、对象所有权和有界等待语义，建立共享测试框架，不改变生产实现。
+
+### PR 2：Generic Manager 与 Memory，7～10 人日
+
+提取 lifecycle engine、execution registry、subscriber、Push dispatch 和 shutdown，完成 Memory Store/Notifier 适配，保持原有 API 和默认行为。
+
+### PR 3：Redis Store 迁移，8～12 人日
+
+复用现有 Lua、Stream 和 dedupe ZSET，增加 operation result HASH，接入 Generic Manager，并实现 version CAS、Message 终态保护、原提交结果恢复和跨节点 `SubscribeToTask`；首版不实现 Redis Notifier。
+
+### PR 4：MySQL Store，10～15 人日
+
+实现 schema、事务、CAS、ListTasks、history、Push、TTL cleaner、轮询 `SubscribeToTask`、真实 MySQL 测试和独立 module CI。
+
+### PR 5：生产增强，4～6 人日
+
+完成压测、故障注入、死锁重试、文档、example、发布 tag 和升级说明。
+
+总体预计 37～53 人日。若再实现断线精确事件回放，需要先确定协议 cursor/`Last-Event-ID` 扩展；若再实现跨节点 execution lease、continuation 路由和 live cancel 信令，另计 15～20 人日，并应使用单独的 Coordinator 设计，不扩张 Store 或 Notifier 的职责。
+
+## 22. 待确认事项
+
+1. 首版 Generic Store 是否要求所有 Message/history 写入错误都使请求失败，还是暂时保留 Redis 当前部分 best-effort 行为。
+2. MySQL 最低版本是否固定为 8.0。
+3. MySQL Task/Event 默认 retention 是否与 Redis 一致为一小时。
+4. MySQL 首版是否包含自动 Push；如果需要压缩首个 PR，可先返回 PushNotificationNotSupported，在下一 PR 补齐。
+5. 首版跨节点能力是否只覆盖 state/event visibility 与 `SubscribeToTask`，不包含 execution coordination。
+
+## 23. 推荐结论
+
+建议采用“Generic retaining Manager + 单一 Store + 可选 Notifier”的最小公共抽象。Store 内部必须保留 Task/Event 原子提交、Task-associated Message 的 version/终态保护、typed cursor、可恢复原提交结果的 OperationID，以及严格的对象拷贝边界；Notifier 只做可丢失唤醒，Manager 始终保留有界重读。先用 Memory 固化生命周期，再迁移 Redis 证明抽象不削弱现有语义，最后实现 MySQL；不要在同一个 PR 中同时抽象、迁移两个现有后端并新增 MySQL。

--- a/taskmanager/redis/redis_store.go
+++ b/taskmanager/redis/redis_store.go
@@ -1,0 +1,1092 @@
+// Tencent is pleased to support the open source community by making trpc-a2a-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-a2a-go is licensed under the Apache License Version 2.0.
+
+package redis
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/uuid"
+	redisclient "github.com/redis/go-redis/v9"
+
+	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/push"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager/retaining"
+)
+
+const (
+	storeOperationResultsPrefix = "stream-op-results:"
+	storePushPrefix             = "stream-push:"
+	storeVersionField           = "__task_version"
+	storeOperationFieldPrefix   = "op:"
+	storeMaxExactInteger        = uint64(1<<53 - 1)
+)
+
+// retainingStore implements retaining.Store with Redis Strings, Streams, Lists, and
+// Hashes. It owns client and closes it from Close, matching TaskManager's
+// existing Redis-client ownership behavior.
+type retainingStore struct {
+	client           redisclient.UniversalClient
+	expiration       time.Duration
+	maxHistoryLength int
+	closed           atomic.Bool
+	closeOnce        sync.Once
+	closeErr         error
+}
+
+var _ retaining.Store = (*retainingStore)(nil)
+
+// newRetainingStore creates a retaining Store using the existing Redis TaskManager
+// options for TTL and conversation-history limits.
+func newRetainingStore(client redisclient.UniversalClient, opts ...TaskManagerOption) (*retainingStore, error) {
+	if client == nil {
+		return nil, errors.New("redis store: client cannot be nil")
+	}
+	if err := client.Ping(context.Background()).Err(); err != nil {
+		return nil, fmt.Errorf("redis store: connect: %w", err)
+	}
+	options := DefaultRedisTaskManagerOptions()
+	for _, opt := range opts {
+		opt(options)
+	}
+	expiration := options.ExpireTime
+	if expiration < time.Millisecond {
+		expiration = time.Millisecond
+	}
+	maxHistoryLength := options.MaxHistoryLength
+	if maxHistoryLength <= 0 {
+		maxHistoryLength = defaultMaxHistoryLength
+	}
+	return &retainingStore{
+		client:           client,
+		expiration:       expiration,
+		maxHistoryLength: maxHistoryLength,
+	}, nil
+}
+
+func storeOperationResultsKey(tenant, owner, taskID string) string {
+	return storeOperationResultsPrefix + "{" + taskKey(tenant, owner, taskID) + "}"
+}
+
+// storePushKey intentionally differs from the legacy pushNotificationKey. The
+// hash tag puts Task and Push in one Redis Cluster slot, which is required for
+// SavePushConfig to reject an expired Task and write the config atomically.
+func storePushKey(tenant, owner, taskID string) string {
+	return storePushPrefix + "{" + taskKey(tenant, owner, taskID) + "}"
+}
+
+var storeLoadTaskScript = redisclient.NewScript(`
+local task = redis.call('GET', KEYS[1])
+if not task then
+    return {0, '', '0-0', '0'}
+end
+local tail = redis.call('XREVRANGE', KEYS[2], '+', '-', 'COUNT', 1)
+local cursor = '0-0'
+if #tail > 0 then
+    cursor = tail[1][1]
+end
+local version = redis.call('HGET', KEYS[3], ARGV[1]) or '0'
+return {1, task, cursor, version}
+`)
+
+// storeCommitEventScript is shared by Task-changing and Message events. Every
+// Task-associated event advances one revision, while only kind=task replaces
+// the Task JSON. Operation lookup precedes CAS and terminal checks.
+var storeCommitEventScript = redisclient.NewScript(`
+local task_type = redis.call('TYPE', KEYS[1]).ok
+if task_type ~= 'none' and task_type ~= 'string' then
+    return redis.error_reply('STORE_WRONG_TASK_TYPE')
+end
+local stream_type = redis.call('TYPE', KEYS[2]).ok
+if stream_type ~= 'none' and stream_type ~= 'stream' then
+    return redis.error_reply('STORE_WRONG_STREAM_TYPE')
+end
+local dedupe_type = redis.call('TYPE', KEYS[3]).ok
+if dedupe_type ~= 'none' and dedupe_type ~= 'zset' then
+    return redis.error_reply('STORE_WRONG_DEDUPE_TYPE')
+end
+local result_type = redis.call('TYPE', KEYS[4]).ok
+if result_type ~= 'none' and result_type ~= 'hash' then
+    return redis.error_reply('STORE_WRONG_RESULT_TYPE')
+end
+
+local existing = redis.call('HGET', KEYS[4], ARGV[10])
+if existing then
+    local decoded = cjson.decode(existing)
+    if decoded.kind ~= ARGV[1] or decoded.digest ~= ARGV[2] then
+        return redis.error_reply('STORE_OPERATION_CONFLICT')
+    end
+    return {tostring(decoded.version), decoded.cursor, '1'}
+end
+if redis.call('ZSCORE', KEYS[3], ARGV[10]) or redis.call('ZSCORE', KEYS[3], ARGV[11]) then
+    return redis.error_reply('STORE_OPERATION_EXPIRED')
+end
+
+local task = redis.call('GET', KEYS[1])
+if not task then
+    if ARGV[1] ~= 'task' or ARGV[4] ~= '1' then
+        return redis.error_reply('STORE_TASK_NOT_FOUND')
+    end
+end
+
+local version = tonumber(redis.call('HGET', KEYS[4], ARGV[12]) or '0')
+local expected = tonumber(ARGV[3])
+if not version or not expected or version ~= expected then
+    return redis.error_reply('STORE_VERSION_CONFLICT')
+end
+if version >= tonumber(ARGV[13]) then
+    return redis.error_reply('STORE_VERSION_OVERFLOW')
+end
+if task then
+    local current_task = cjson.decode(task)
+    local state = current_task.status and current_task.status.state or ''
+    if state == 'TASK_STATE_COMPLETED' or state == 'TASK_STATE_FAILED' or
+       state == 'TASK_STATE_CANCELED' or state == 'TASK_STATE_REJECTED' then
+        return redis.error_reply('STORE_TASK_TERMINAL')
+    end
+end
+local sequence = tonumber(redis.call('ZSCORE', KEYS[3], '__seq') or '0')
+if not sequence or sequence >= tonumber(ARGV[13]) then
+    return redis.error_reply('STORE_OPERATION_SEQUENCE_OVERFLOW')
+end
+local next_version = version + 1
+local next_sequence = sequence + 1
+local event_id = redis.call(
+    'XADD', KEYS[2], 'MAXLEN', '~', ARGV[7], '*', ARGV[8], ARGV[6]
+)
+if ARGV[1] == 'task' then
+    redis.call('SET', KEYS[1], ARGV[5], 'PX', ARGV[9])
+end
+redis.call('HSET', KEYS[4], ARGV[12], tostring(next_version))
+local result = cjson.encode({
+    kind=ARGV[1], digest=ARGV[2], version=next_version, cursor=event_id
+})
+redis.call('HSET', KEYS[4], ARGV[10], result)
+
+redis.call('ZADD', KEYS[3], next_sequence, '__seq')
+redis.call('ZADD', KEYS[3], next_sequence, ARGV[10])
+local excess = redis.call('ZCARD', KEYS[3]) - (tonumber(ARGV[7]) + 1)
+if excess > 0 then
+    local victims = redis.call('ZRANGE', KEYS[3], 0, excess - 1)
+    for _, victim in ipairs(victims) do
+        if victim ~= '__seq' then
+            redis.call('ZREM', KEYS[3], victim)
+            redis.call('HDEL', KEYS[4], victim)
+        end
+    end
+end
+
+local ttl = tonumber(ARGV[9])
+if ARGV[1] == 'message' then
+    ttl = redis.call('PTTL', KEYS[1])
+end
+if ttl == -1 then
+    redis.call('PERSIST', KEYS[2])
+    redis.call('PERSIST', KEYS[3])
+    redis.call('PERSIST', KEYS[4])
+else
+    ttl = math.max(1, ttl)
+    redis.call('PEXPIRE', KEYS[2], ttl)
+    redis.call('PEXPIRE', KEYS[3], ttl)
+    redis.call('PEXPIRE', KEYS[4], ttl)
+end
+if ARGV[1] == 'task' then
+    redis.call('PEXPIRE', KEYS[5], tonumber(ARGV[9]))
+end
+return {tostring(next_version), event_id, '0'}
+`)
+
+var storeReadEventsScript = redisclient.NewScript(`
+if redis.call('EXISTS', KEYS[1]) == 0 then
+    return redis.error_reply('STORE_TASK_NOT_FOUND')
+end
+local first = redis.call('XRANGE', KEYS[2], '-', '+', 'COUNT', 1)
+if ARGV[1] ~= '0-0' then
+    if #first == 0 then
+        return redis.error_reply('STORE_CURSOR_EXPIRED')
+    end
+    local exact = redis.call('XRANGE', KEYS[2], ARGV[1], ARGV[1], 'COUNT', 1)
+    if #exact == 0 then
+        return redis.error_reply('STORE_CURSOR_EXPIRED')
+    end
+end
+local entries = redis.call('XRANGE', KEYS[2], ARGV[1], '+', 'COUNT', tonumber(ARGV[2]) + 1)
+local result = {}
+local count = 0
+for _, entry in ipairs(entries) do
+    if entry[1] ~= ARGV[1] and count < tonumber(ARGV[2]) then
+        local payload = ''
+        for field_index = 1, #entry[2], 2 do
+            if entry[2][field_index] == ARGV[3] then
+                payload = entry[2][field_index + 1]
+                break
+            end
+        end
+        table.insert(result, entry[1])
+        table.insert(result, payload)
+        count = count + 1
+    end
+end
+return result
+`)
+
+var storeRefreshLeaseScript = redisclient.NewScript(`
+if redis.call('PEXPIRE', KEYS[1], ARGV[1]) == 0 then
+    return 0
+end
+redis.call('PEXPIRE', KEYS[2], ARGV[1])
+redis.call('PEXPIRE', KEYS[3], ARGV[1])
+redis.call('PEXPIRE', KEYS[4], ARGV[1])
+redis.call('PEXPIRE', KEYS[5], ARGV[1])
+return 1
+`)
+
+var storeSavePushScript = redisclient.NewScript(`
+local task_ttl = redis.call('PTTL', KEYS[1])
+if task_ttl == -2 then
+    return redis.error_reply('STORE_TASK_NOT_FOUND')
+end
+local push_type = redis.call('TYPE', KEYS[2]).ok
+if push_type ~= 'none' and push_type ~= 'hash' then
+    return redis.error_reply('STORE_WRONG_PUSH_TYPE')
+end
+redis.call('HSET', KEYS[2], ARGV[1], ARGV[2])
+if task_ttl == -1 then
+    redis.call('PERSIST', KEYS[2])
+else
+    redis.call('PEXPIRE', KEYS[2], math.max(1, task_ttl))
+end
+return 1
+`)
+
+var storeGetPushScript = redisclient.NewScript(`
+if redis.call('EXISTS', KEYS[1]) == 0 then
+    return redis.error_reply('STORE_TASK_NOT_FOUND')
+end
+return redis.call('HGET', KEYS[2], ARGV[1])
+`)
+
+var storeListPushScript = redisclient.NewScript(`
+if redis.call('EXISTS', KEYS[1]) == 0 then
+    return redis.error_reply('STORE_TASK_NOT_FOUND')
+end
+return redis.call('HGETALL', KEYS[2])
+`)
+
+var storeDeletePushScript = redisclient.NewScript(`
+if redis.call('EXISTS', KEYS[1]) == 0 then
+    return redis.error_reply('STORE_TASK_NOT_FOUND')
+end
+return redis.call('HDEL', KEYS[2], ARGV[1])
+`)
+
+func (s *retainingStore) checkOpen() error {
+	if s == nil || s.closed.Load() {
+		return retaining.ErrStoreClosed
+	}
+	return nil
+}
+
+func validateTaskKey(key retaining.TaskKey) error {
+	if key.ID == "" {
+		return errors.New("redis store: task ID is required")
+	}
+	return nil
+}
+
+// LoadTask returns an atomic Task/version observation.
+func (s *retainingStore) LoadTask(ctx context.Context, key retaining.TaskKey) (*retaining.TaskRecord, error) {
+	record, err := s.loadTask(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	record.Cursor = ""
+	return record, nil
+}
+
+// LoadTaskAndCursor returns an atomic Task/version/stream-tail observation.
+func (s *retainingStore) LoadTaskAndCursor(
+	ctx context.Context, key retaining.TaskKey,
+) (*retaining.TaskRecord, error) {
+	return s.loadTask(ctx, key)
+}
+
+func (s *retainingStore) loadTask(ctx context.Context, key retaining.TaskKey) (*retaining.TaskRecord, error) {
+	if err := s.checkOpen(); err != nil {
+		return nil, err
+	}
+	if err := validateTaskKey(key); err != nil {
+		return nil, err
+	}
+	values, err := storeLoadTaskScript.Run(
+		ctx,
+		s.client,
+		[]string{
+			taskKey(key.Tenant, key.Owner, key.ID),
+			streamKey(key.Tenant, key.Owner, key.ID),
+			storeOperationResultsKey(key.Tenant, key.Owner, key.ID),
+		},
+		storeVersionField,
+	).Slice()
+	if err != nil {
+		return nil, fmt.Errorf("redis store: load task %s: %w", key.ID, err)
+	}
+	if len(values) != 4 {
+		return nil, fmt.Errorf("redis store: load task %s: unexpected result", key.ID)
+	}
+	exists, ok := values[0].(int64)
+	if !ok || exists == 0 {
+		return nil, retaining.ErrTaskNotFound
+	}
+	taskJSON, ok := redisString(values[1])
+	if !ok {
+		return nil, fmt.Errorf("redis store: load task %s: invalid payload", key.ID)
+	}
+	cursor, ok := redisString(values[2])
+	if !ok {
+		return nil, fmt.Errorf("redis store: load task %s: invalid cursor", key.ID)
+	}
+	versionText, ok := redisString(values[3])
+	if !ok {
+		return nil, fmt.Errorf("redis store: load task %s: invalid version", key.ID)
+	}
+	version, err := strconv.ParseUint(versionText, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("redis store: load task %s: parse version: %w", key.ID, err)
+	}
+	var task protocol.Task
+	if err := json.Unmarshal([]byte(taskJSON), &task); err != nil {
+		return nil, fmt.Errorf("redis store: load task %s: decode: %w", key.ID, err)
+	}
+	return &retaining.TaskRecord{Task: &task, Version: version, Cursor: retaining.Cursor(cursor)}, nil
+}
+
+// CommitTaskEvent atomically applies CAS, replaces the snapshot, and appends
+// the corresponding event.
+func (s *retainingStore) CommitTaskEvent(
+	ctx context.Context, req retaining.CommitTaskEventRequest,
+) (uint64, retaining.Cursor, error) {
+	if err := s.checkOpen(); err != nil {
+		return 0, "", err
+	}
+	if req.Task == nil {
+		return 0, "", errors.New("redis store: task is required")
+	}
+	if err := validateTaskKey(req.Key); err != nil {
+		return 0, "", err
+	}
+	if req.Task.ID != req.Key.ID {
+		return 0, "", errors.New("redis store: TaskKey ID and Task ID differ")
+	}
+	if err := validateTaskEvent(req.Task, req.Event); err != nil {
+		return 0, "", err
+	}
+	if req.OperationID == "" {
+		return 0, "", errors.New("redis store: OperationID is required")
+	}
+	taskJSON, err := json.Marshal(req.Task)
+	if err != nil {
+		return 0, "", fmt.Errorf("redis store: encode task: %w", err)
+	}
+	eventJSON, err := json.Marshal(req.Event)
+	if err != nil {
+		return 0, "", fmt.Errorf("redis store: encode task event: %w", err)
+	}
+	digest, err := requestDigest(struct {
+		Kind            string
+		Key             retaining.TaskKey
+		ExpectedVersion uint64
+		AllowCreate     bool
+		Task            json.RawMessage
+		Event           json.RawMessage
+	}{"task", req.Key, req.ExpectedVersion, req.AllowCreate, taskJSON, eventJSON})
+	if err != nil {
+		return 0, "", err
+	}
+	if err := s.ensureTaskIndexed(ctx, req.Key); err != nil {
+		return 0, "", err
+	}
+	return s.commitEvent(ctx, req.Key, "task", req.ExpectedVersion, req.AllowCreate,
+		req.OperationID, digest, taskJSON, eventJSON)
+}
+
+// CommitMessageEvent appends the event derived from Message, advances the Task
+// revision, then completes the cross-slot history projection idempotently.
+func (s *retainingStore) CommitMessageEvent(
+	ctx context.Context, req retaining.CommitMessageEventRequest,
+) (uint64, retaining.Cursor, error) {
+	if err := s.checkOpen(); err != nil {
+		return 0, "", err
+	}
+	if err := validateTaskKey(req.Key); err != nil {
+		return 0, "", err
+	}
+	if req.Message.MessageID == "" {
+		return 0, "", errors.New("redis store: MessageID is required")
+	}
+	if req.Message.TaskID == nil || *req.Message.TaskID != req.Key.ID {
+		return 0, "", errors.New("redis store: TaskKey ID and Message TaskID differ")
+	}
+	event := protocol.NewStreamResponseMessage(&req.Message)
+	eventJSON, err := json.Marshal(event)
+	if err != nil {
+		return 0, "", fmt.Errorf("redis store: encode message event: %w", err)
+	}
+	digest, err := requestDigest(struct {
+		Kind            string
+		Key             retaining.TaskKey
+		ExpectedVersion uint64
+		Message         protocol.Message
+	}{"message", req.Key, req.ExpectedVersion, req.Message})
+	if err != nil {
+		return 0, "", err
+	}
+	operationExists, err := s.checkOperationConflict(ctx, req.Key, req.OperationID, "message", digest)
+	if err != nil {
+		return 0, "", err
+	}
+	if !operationExists {
+		if err := s.checkMessageConflict(ctx, req.Key.Tenant, req.Key.Owner, req.Message); err != nil {
+			return 0, "", err
+		}
+	}
+	version, cursor, err := s.commitEvent(ctx, req.Key, "message", req.ExpectedVersion,
+		false, req.OperationID, digest, nil, eventJSON)
+	if err != nil {
+		return 0, "", err
+	}
+	if err := s.SaveMessage(ctx, req.Key.Tenant, req.Key.Owner, req.Message); err != nil {
+		return version, cursor, fmt.Errorf("%w: project message: %v", retaining.ErrCommitUncertain, err)
+	}
+	return version, cursor, nil
+}
+
+func (s *retainingStore) commitEvent(
+	ctx context.Context,
+	key retaining.TaskKey,
+	kind string,
+	expectedVersion uint64,
+	allowCreate bool,
+	operationID string,
+	digest string,
+	taskJSON []byte,
+	eventJSON []byte,
+) (uint64, retaining.Cursor, error) {
+	if err := s.checkOpen(); err != nil {
+		return 0, "", err
+	}
+	if operationID == "" {
+		return 0, "", errors.New("redis store: OperationID is required")
+	}
+	if expectedVersion > storeMaxExactInteger {
+		return 0, "", errors.New("redis store: expected version exceeds Redis Lua exact integer range")
+	}
+	allowCreateFlag := 0
+	if allowCreate {
+		allowCreateFlag = 1
+	}
+	opField := storeOperationFieldPrefix + operationID
+	values, err := storeCommitEventScript.Run(
+		ctx,
+		s.client,
+		[]string{
+			taskKey(key.Tenant, key.Owner, key.ID),
+			streamKey(key.Tenant, key.Owner, key.ID),
+			streamDedupeKey(key.Tenant, key.Owner, key.ID),
+			storeOperationResultsKey(key.Tenant, key.Owner, key.ID),
+			storePushKey(key.Tenant, key.Owner, key.ID),
+		},
+		kind,
+		digest,
+		expectedVersion,
+		allowCreateFlag,
+		taskJSON,
+		eventJSON,
+		streamMaxLen,
+		streamField,
+		s.expiration.Milliseconds(),
+		opField,
+		operationID,
+		storeVersionField,
+		storeMaxExactInteger,
+	).Slice()
+	if err != nil {
+		if mapped := mapStoreScriptError(err); mapped != nil {
+			return 0, "", mapped
+		}
+		return 0, "", fmt.Errorf("%w: commit %s event: %v", retaining.ErrCommitUncertain, kind, err)
+	}
+	if len(values) != 3 {
+		return 0, "", fmt.Errorf("%w: commit %s event returned unexpected result", retaining.ErrCommitUncertain, kind)
+	}
+	versionText, ok := redisString(values[0])
+	if !ok {
+		return 0, "", fmt.Errorf("%w: commit %s event returned invalid version", retaining.ErrCommitUncertain, kind)
+	}
+	version, err := strconv.ParseUint(versionText, 10, 64)
+	if err != nil {
+		return 0, "", fmt.Errorf("%w: parse committed version: %v", retaining.ErrCommitUncertain, err)
+	}
+	cursor, ok := redisString(values[1])
+	if !ok || cursor == "" {
+		return 0, "", fmt.Errorf("%w: commit %s event returned invalid cursor", retaining.ErrCommitUncertain, kind)
+	}
+	return version, retaining.Cursor(cursor), nil
+}
+
+func validateTaskEvent(task *protocol.Task, event protocol.StreamResponse) error {
+	if status := event.GetStatusUpdate(); status != nil {
+		if status.TaskID != task.ID || status.ContextID != task.ContextID {
+			return errors.New("redis store: status event scope disagrees with Task snapshot")
+		}
+		return nil
+	}
+	if artifact := event.GetArtifactUpdate(); artifact != nil {
+		if artifact.TaskID != task.ID || artifact.ContextID != task.ContextID {
+			return errors.New("redis store: artifact event scope disagrees with Task snapshot")
+		}
+		return nil
+	}
+	return errors.New("redis store: CommitTaskEvent requires a Status or Artifact event")
+}
+
+func (s *retainingStore) checkOperationConflict(
+	ctx context.Context,
+	key retaining.TaskKey,
+	operationID string,
+	kind string,
+	digest string,
+) (bool, error) {
+	if operationID == "" {
+		return false, errors.New("redis store: OperationID is required")
+	}
+	payload, err := s.client.HGet(
+		ctx,
+		storeOperationResultsKey(key.Tenant, key.Owner, key.ID),
+		storeOperationFieldPrefix+operationID,
+	).Bytes()
+	if errors.Is(err, redisclient.Nil) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("redis store: load operation result: %w", err)
+	}
+	var result struct {
+		Kind   string `json:"kind"`
+		Digest string `json:"digest"`
+	}
+	if err := json.Unmarshal(payload, &result); err != nil {
+		return false, fmt.Errorf("redis store: decode operation result: %w", err)
+	}
+	if result.Kind != kind || result.Digest != digest {
+		return true, retaining.ErrOperationConflict
+	}
+	return true, nil
+}
+
+// ReadTaskEvents returns decodable events strictly after after and separately
+// advances next over every physical Stream entry inspected.
+func (s *retainingStore) ReadTaskEvents(
+	ctx context.Context,
+	key retaining.TaskKey,
+	after retaining.Cursor,
+	limit int,
+) ([]retaining.StoredEvent, retaining.Cursor, error) {
+	if err := s.checkOpen(); err != nil {
+		return nil, after, err
+	}
+	if err := validateTaskKey(key); err != nil {
+		return nil, after, err
+	}
+	if limit <= 0 {
+		return []retaining.StoredEvent{}, after, nil
+	}
+	start := string(after)
+	if start == "" {
+		start = "0-0"
+	}
+	values, err := storeReadEventsScript.Run(
+		ctx,
+		s.client,
+		[]string{taskKey(key.Tenant, key.Owner, key.ID), streamKey(key.Tenant, key.Owner, key.ID)},
+		start,
+		limit,
+		streamField,
+	).Slice()
+	if err != nil {
+		if mapped := mapStoreScriptError(err); mapped != nil {
+			return nil, after, mapped
+		}
+		return nil, after, fmt.Errorf("redis store: read task %s events: %w", key.ID, err)
+	}
+	next := retaining.Cursor(start)
+	events := make([]retaining.StoredEvent, 0, len(values)/2)
+	for i := 0; i+1 < len(values); i += 2 {
+		entryID, ok := redisString(values[i])
+		if !ok || entryID == "" {
+			continue
+		}
+		next = retaining.Cursor(entryID)
+		payload, ok := redisBytes(values[i+1])
+		if !ok {
+			continue
+		}
+		var event protocol.StreamResponse
+		if err := json.Unmarshal(payload, &event); err != nil {
+			continue
+		}
+		events = append(events, retaining.StoredEvent{Cursor: next, Event: event})
+	}
+	return events, next, nil
+}
+
+// RefreshTaskLease refreshes only state owned by a still-live Task.
+func (s *retainingStore) RefreshTaskLease(ctx context.Context, key retaining.TaskKey) error {
+	if err := s.checkOpen(); err != nil {
+		return err
+	}
+	if err := validateTaskKey(key); err != nil {
+		return err
+	}
+	refreshed, err := storeRefreshLeaseScript.Run(
+		ctx,
+		s.client,
+		[]string{
+			taskKey(key.Tenant, key.Owner, key.ID),
+			streamKey(key.Tenant, key.Owner, key.ID),
+			streamDedupeKey(key.Tenant, key.Owner, key.ID),
+			storeOperationResultsKey(key.Tenant, key.Owner, key.ID),
+			storePushKey(key.Tenant, key.Owner, key.ID),
+		},
+		s.expiration.Milliseconds(),
+	).Int()
+	if err != nil {
+		return fmt.Errorf("redis store: refresh task %s lease: %w", key.ID, err)
+	}
+	if refreshed == 0 {
+		return retaining.ErrTaskNotFound
+	}
+	return s.ensureTaskIndexed(ctx, key)
+}
+
+// SaveMessage writes immutable Message content and idempotently appends its ID
+// to the conversation index.
+func (s *retainingStore) SaveMessage(
+	ctx context.Context, tenant, owner string, message protocol.Message,
+) error {
+	if err := s.checkOpen(); err != nil {
+		return err
+	}
+	if message.MessageID == "" {
+		return errors.New("redis store: MessageID is required")
+	}
+	payload, err := json.Marshal(message)
+	if err != nil {
+		return fmt.Errorf("redis store: encode message %s: %w", message.MessageID, err)
+	}
+	key := messageKey(tenant, owner, message.MessageID)
+	created, err := s.client.SetNX(ctx, key, payload, s.expiration).Result()
+	if err != nil {
+		return fmt.Errorf("redis store: save message %s: %w", message.MessageID, err)
+	}
+	if !created {
+		if err := s.checkMessageConflict(ctx, tenant, owner, message); err != nil {
+			return err
+		}
+		if err := s.client.Expire(ctx, key, s.expiration).Err(); err != nil {
+			return fmt.Errorf("redis store: refresh message %s: %w", message.MessageID, err)
+		}
+	}
+	if message.ContextID == nil || *message.ContextID == "" {
+		return nil
+	}
+	if _, err := appendConversationMessageScript.Run(
+		ctx,
+		s.client,
+		[]string{conversationKey(tenant, owner, *message.ContextID)},
+		message.MessageID,
+		s.expiration.Milliseconds(),
+		s.maxHistoryLength,
+	).Result(); err != nil {
+		return fmt.Errorf("redis store: index message %s: %w", message.MessageID, err)
+	}
+	return nil
+}
+
+func (s *retainingStore) checkMessageConflict(
+	ctx context.Context, tenant, owner string, message protocol.Message,
+) error {
+	stored, err := s.client.Get(ctx, messageKey(tenant, owner, message.MessageID)).Bytes()
+	if errors.Is(err, redisclient.Nil) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("redis store: load message %s: %w", message.MessageID, err)
+	}
+	want, err := json.Marshal(message)
+	if err != nil {
+		return fmt.Errorf("redis store: encode message %s: %w", message.MessageID, err)
+	}
+	if bytes.Equal(stored, want) {
+		return nil
+	}
+	var decoded protocol.Message
+	if err := json.Unmarshal(stored, &decoded); err == nil {
+		canonical, marshalErr := json.Marshal(decoded)
+		if marshalErr == nil && bytes.Equal(canonical, want) {
+			return nil
+		}
+	}
+	return retaining.ErrMessageConflict
+}
+
+// LoadHistory loads the newest limit Messages in protocol order.
+func (s *retainingStore) LoadHistory(
+	ctx context.Context, tenant, owner, contextID string, limit int,
+) ([]protocol.Message, error) {
+	if err := s.checkOpen(); err != nil {
+		return nil, err
+	}
+	if contextID == "" || limit == 0 {
+		return []protocol.Message{}, nil
+	}
+	start := int64(0)
+	if limit > 0 {
+		start = -int64(limit)
+	}
+	messageIDs, err := s.client.LRange(ctx, conversationKey(tenant, owner, contextID), start, -1).Result()
+	if err != nil {
+		return nil, fmt.Errorf("redis store: load conversation %s: %w", contextID, err)
+	}
+	messages := make([]protocol.Message, 0, len(messageIDs))
+	for _, messageID := range messageIDs {
+		payload, err := s.client.Get(ctx, messageKey(tenant, owner, messageID)).Bytes()
+		if errors.Is(err, redisclient.Nil) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("redis store: load message %s: %w", messageID, err)
+		}
+		var message protocol.Message
+		if err := json.Unmarshal(payload, &message); err != nil {
+			return nil, fmt.Errorf("redis store: decode message %s: %w", messageID, err)
+		}
+		messages = append(messages, message)
+	}
+	return messages, nil
+}
+
+// ListTasks uses the existing scoped expiry index and shared keyset paginator.
+func (s *retainingStore) ListTasks(
+	ctx context.Context, tenant, owner string, params protocol.ListTasksParams,
+) (*protocol.ListTasksResult, error) {
+	if err := s.checkOpen(); err != nil {
+		return nil, err
+	}
+	if params.Tenant != "" && params.Tenant != tenant {
+		return nil, errors.New("redis store: ListTasks tenant disagrees with authoritative scope")
+	}
+	params.Tenant = tenant
+	afterTime, err := taskmanager.ParseListTasksStatusTimestampAfter(params.StatusTimestampAfter)
+	if err != nil {
+		return nil, err
+	}
+	indexKey := taskIndexKey(tenant, owner)
+	nowMillis := time.Now().UnixMilli()
+	if err := s.client.ZRemRangeByScore(ctx, indexKey, "-inf", strconv.FormatInt(nowMillis, 10)).Err(); err != nil {
+		return nil, fmt.Errorf("redis store: prune task index: %w", err)
+	}
+	taskIDs, err := s.client.ZRangeByScore(ctx, indexKey, &redisclient.ZRangeBy{
+		Min: "(" + strconv.FormatInt(nowMillis, 10), Max: "+inf",
+	}).Result()
+	if err != nil {
+		return nil, fmt.Errorf("redis store: load task index: %w", err)
+	}
+	loads := make([]*redisclient.StringCmd, len(taskIDs))
+	_, pipelineErr := s.client.Pipelined(ctx, func(pipe redisclient.Pipeliner) error {
+		for i, taskID := range taskIDs {
+			loads[i] = pipe.Get(ctx, taskKey(tenant, owner, taskID))
+		}
+		return nil
+	})
+	if pipelineErr != nil && !errors.Is(pipelineErr, redisclient.Nil) {
+		return nil, fmt.Errorf("redis store: load indexed tasks: %w", pipelineErr)
+	}
+	filtered := make([]*protocol.Task, 0, len(loads))
+	for i, load := range loads {
+		payload, err := load.Bytes()
+		if errors.Is(err, redisclient.Nil) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("redis store: load task %s: %w", taskIDs[i], err)
+		}
+		var task protocol.Task
+		if err := json.Unmarshal(payload, &task); err != nil {
+			return nil, fmt.Errorf("redis store: decode task %s: %w", taskIDs[i], err)
+		}
+		task.History = nil
+		if taskmanager.TaskMatchesListFilter(&task, params, afterTime) {
+			filtered = append(filtered, &task)
+		}
+	}
+	return taskmanager.PaginateTasks(filtered, params)
+}
+
+func (s *retainingStore) ensureTaskIndexed(ctx context.Context, key retaining.TaskKey) error {
+	indexExpiration := s.expiration
+	if indexExpiration <= time.Duration(1<<63-1)/2 {
+		indexExpiration *= 2
+	}
+	expiresAt := time.Now().Add(indexExpiration).UnixMilli()
+	_, err := s.client.TxPipelined(ctx, func(pipe redisclient.Pipeliner) error {
+		pipe.ZAdd(ctx, taskIndexKey(key.Tenant, key.Owner), redisclient.Z{
+			Score: float64(expiresAt), Member: key.ID,
+		})
+		pipe.Expire(ctx, taskIndexKey(key.Tenant, key.Owner), indexExpiration)
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("redis store: index task %s: %w", key.ID, err)
+	}
+	return nil
+}
+
+// SavePushConfig writes a generated registration only if the Task is visible
+// at the same Redis linearization point.
+func (s *retainingStore) SavePushConfig(
+	ctx context.Context,
+	key retaining.TaskKey,
+	config protocol.TaskPushNotificationConfig,
+) (push.Registration, error) {
+	if err := s.checkOpen(); err != nil {
+		return push.Registration{}, err
+	}
+	if err := validateTaskKey(key); err != nil {
+		return push.Registration{}, err
+	}
+	if config.Tenant != "" && config.Tenant != key.Tenant {
+		return push.Registration{}, errors.New("redis store: push config tenant disagrees with TaskKey")
+	}
+	if config.TaskID != "" && config.TaskID != key.ID {
+		return push.Registration{}, errors.New("redis store: push config task ID disagrees with TaskKey")
+	}
+	config.Tenant = key.Tenant
+	config.TaskID = key.ID
+	if config.ID == "" {
+		config.ID = "push-" + uuid.New().String()
+	}
+	registration := push.Registration{
+		Config: config, Generation: uuid.New().String(), Owner: key.Owner,
+	}
+	payload, err := json.Marshal(registration)
+	if err != nil {
+		return push.Registration{}, fmt.Errorf("redis store: encode push config: %w", err)
+	}
+	_, err = storeSavePushScript.Run(
+		ctx,
+		s.client,
+		[]string{taskKey(key.Tenant, key.Owner, key.ID), storePushKey(key.Tenant, key.Owner, key.ID)},
+		config.ID,
+		payload,
+	).Result()
+	if err != nil {
+		if mapped := mapStoreScriptError(err); mapped != nil {
+			return push.Registration{}, mapped
+		}
+		return push.Registration{}, fmt.Errorf("redis store: save push config: %w", err)
+	}
+	stored, err := decodePushRegistration(payload)
+	if err != nil {
+		return push.Registration{}, fmt.Errorf("redis store: copy push config: %w", err)
+	}
+	stored.Owner = key.Owner
+	return stored, nil
+}
+
+// GetPushConfig returns one current registration for a visible Task.
+func (s *retainingStore) GetPushConfig(
+	ctx context.Context, key retaining.TaskKey, configID string,
+) (push.Registration, error) {
+	if err := s.checkOpen(); err != nil {
+		return push.Registration{}, err
+	}
+	if err := validateTaskKey(key); err != nil {
+		return push.Registration{}, err
+	}
+	value, err := storeGetPushScript.Run(
+		ctx,
+		s.client,
+		[]string{taskKey(key.Tenant, key.Owner, key.ID), storePushKey(key.Tenant, key.Owner, key.ID)},
+		configID,
+	).Result()
+	if errors.Is(err, redisclient.Nil) {
+		return push.Registration{}, retaining.ErrPushConfigNotFound
+	}
+	if err != nil {
+		if mapped := mapStoreScriptError(err); mapped != nil {
+			return push.Registration{}, mapped
+		}
+		return push.Registration{}, fmt.Errorf("redis store: get push config: %w", err)
+	}
+	payload, ok := redisBytes(value)
+	if !ok {
+		return push.Registration{}, fmt.Errorf("redis store: get push config: invalid payload")
+	}
+	registration, err := decodePushRegistration(payload)
+	if err != nil {
+		return push.Registration{}, fmt.Errorf("redis store: decode push config: %w", err)
+	}
+	registration.Owner = key.Owner
+	return registration, nil
+}
+
+// ListPushConfigs returns registrations ordered by config ID.
+func (s *retainingStore) ListPushConfigs(
+	ctx context.Context, key retaining.TaskKey,
+) ([]push.Registration, error) {
+	if err := s.checkOpen(); err != nil {
+		return nil, err
+	}
+	if err := validateTaskKey(key); err != nil {
+		return nil, err
+	}
+	values, err := storeListPushScript.Run(
+		ctx,
+		s.client,
+		[]string{taskKey(key.Tenant, key.Owner, key.ID), storePushKey(key.Tenant, key.Owner, key.ID)},
+	).Slice()
+	if err != nil {
+		if mapped := mapStoreScriptError(err); mapped != nil {
+			return nil, mapped
+		}
+		return nil, fmt.Errorf("redis store: list push configs: %w", err)
+	}
+	registrations := make([]push.Registration, 0, len(values)/2)
+	for i := 0; i+1 < len(values); i += 2 {
+		payload, ok := redisBytes(values[i+1])
+		if !ok {
+			return nil, fmt.Errorf("redis store: list push configs: invalid payload")
+		}
+		registration, err := decodePushRegistration(payload)
+		if err != nil {
+			return nil, fmt.Errorf("redis store: decode push config: %w", err)
+		}
+		registration.Owner = key.Owner
+		registrations = append(registrations, registration)
+	}
+	sort.Slice(registrations, func(i, j int) bool {
+		return registrations[i].Config.ID < registrations[j].Config.ID
+	})
+	return registrations, nil
+}
+
+// DeletePushConfig removes a config for a still-visible Task. Missing configs
+// remain a no-op.
+func (s *retainingStore) DeletePushConfig(
+	ctx context.Context, key retaining.TaskKey, configID string,
+) error {
+	if err := s.checkOpen(); err != nil {
+		return err
+	}
+	if err := validateTaskKey(key); err != nil {
+		return err
+	}
+	_, err := storeDeletePushScript.Run(
+		ctx,
+		s.client,
+		[]string{taskKey(key.Tenant, key.Owner, key.ID), storePushKey(key.Tenant, key.Owner, key.ID)},
+		configID,
+	).Result()
+	if err != nil {
+		if mapped := mapStoreScriptError(err); mapped != nil {
+			return mapped
+		}
+		return fmt.Errorf("redis store: delete push config: %w", err)
+	}
+	return nil
+}
+
+// Close closes the Redis client exactly once.
+func (s *retainingStore) Close() error {
+	if s == nil {
+		return nil
+	}
+	s.closeOnce.Do(func() {
+		s.closed.Store(true)
+		s.closeErr = s.client.Close()
+	})
+	return s.closeErr
+}
+
+func requestDigest(value any) (string, error) {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return "", fmt.Errorf("redis store: encode request digest: %w", err)
+	}
+	digest := sha256.Sum256(payload)
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func redisString(value any) (string, bool) {
+	switch typed := value.(type) {
+	case string:
+		return typed, true
+	case []byte:
+		return string(typed), true
+	case int64:
+		return strconv.FormatInt(typed, 10), true
+	default:
+		return "", false
+	}
+}
+
+func redisBytes(value any) ([]byte, bool) {
+	switch typed := value.(type) {
+	case string:
+		return []byte(typed), true
+	case []byte:
+		return typed, true
+	default:
+		return nil, false
+	}
+}
+
+func mapStoreScriptError(err error) error {
+	if err == nil {
+		return nil
+	}
+	message := err.Error()
+	switch {
+	case strings.Contains(message, "STORE_TASK_NOT_FOUND"):
+		return retaining.ErrTaskNotFound
+	case strings.Contains(message, "STORE_VERSION_CONFLICT"):
+		return retaining.ErrVersionConflict
+	case strings.Contains(message, "STORE_TASK_TERMINAL"):
+		return retaining.ErrTaskTerminal
+	case strings.Contains(message, "STORE_OPERATION_CONFLICT"):
+		return retaining.ErrOperationConflict
+	case strings.Contains(message, "STORE_OPERATION_EXPIRED"):
+		return retaining.ErrOperationExpired
+	case strings.Contains(message, "STORE_CURSOR_EXPIRED"):
+		return retaining.ErrCursorExpired
+	default:
+		return nil
+	}
+}

--- a/taskmanager/redis/redis_store_test.go
+++ b/taskmanager/redis/redis_store_test.go
@@ -1,0 +1,405 @@
+// Tencent is pleased to support the open source community by making trpc-a2a-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-a2a-go is licensed under the Apache License Version 2.0.
+
+package redis
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	miniredis "github.com/alicebob/miniredis/v2"
+	redisclient "github.com/redis/go-redis/v9"
+
+	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/taskmanager/retaining"
+)
+
+func TestRedisStoreCommitCASIdempotencyAndTerminal(t *testing.T) {
+	store, client := newTestStore(t)
+	ctx := context.Background()
+	key := retaining.TaskKey{Tenant: "tenant", Owner: "owner", ID: "task-1"}
+
+	created := testStoreTask(key.ID, protocol.TaskStateWorking, "2026-08-14T01:00:00Z")
+	createReq := retaining.CommitTaskEventRequest{
+		Key: key, ExpectedVersion: 0, AllowCreate: true, OperationID: "create",
+		Task: created, Event: testStoreStatusEvent(created),
+	}
+	version, cursor, err := store.CommitTaskEvent(ctx, createReq)
+	if err != nil {
+		t.Fatalf("CommitTaskEvent(create) error = %v", err)
+	}
+	if version != 1 || cursor == "" {
+		t.Fatalf("CommitTaskEvent(create) = (%d, %q), want (1, non-empty)", version, cursor)
+	}
+
+	retryVersion, retryCursor, err := store.CommitTaskEvent(ctx, createReq)
+	if err != nil {
+		t.Fatalf("CommitTaskEvent(retry) error = %v", err)
+	}
+	if retryVersion != version || retryCursor != cursor {
+		t.Fatalf("CommitTaskEvent(retry) = (%d, %q), want (%d, %q)",
+			retryVersion, retryCursor, version, cursor)
+	}
+	if got := client.XLen(ctx, streamKey(key.Tenant, key.Owner, key.ID)).Val(); got != 1 {
+		t.Fatalf("stream length after retry = %d, want 1", got)
+	}
+	if err := client.ZAdd(ctx, streamDedupeKey(key.Tenant, key.Owner, key.ID),
+		redisclient.Z{Score: 1, Member: "legacy-op"}).Err(); err != nil {
+		t.Fatalf("seed legacy operation error = %v", err)
+	}
+	legacyRetry := newStoreTaskRequest(key, 1, "legacy-op", "2026-08-14T01:00:30Z")
+	if _, _, err := store.CommitTaskEvent(ctx, legacyRetry); !errors.Is(err, retaining.ErrOperationExpired) {
+		t.Fatalf("legacy operation without result error = %v, want ErrOperationExpired", err)
+	}
+
+	changed := createReq
+	changed.ExpectedVersion = 1
+	if _, _, err := store.CommitTaskEvent(ctx, changed); !errors.Is(err, retaining.ErrOperationConflict) {
+		t.Fatalf("changed request with reused OperationID error = %v, want ErrOperationConflict", err)
+	}
+
+	requests := []retaining.CommitTaskEventRequest{
+		newStoreTaskRequest(key, 1, "concurrent-a", "2026-08-14T01:01:00Z"),
+		newStoreTaskRequest(key, 1, "concurrent-b", "2026-08-14T01:02:00Z"),
+	}
+	var wg sync.WaitGroup
+	errs := make(chan error, len(requests))
+	for i := range requests {
+		wg.Add(1)
+		go func(req retaining.CommitTaskEventRequest) {
+			defer wg.Done()
+			_, _, err := store.CommitTaskEvent(ctx, req)
+			errs <- err
+		}(requests[i])
+	}
+	wg.Wait()
+	close(errs)
+	successes, conflicts := 0, 0
+	for err := range errs {
+		switch {
+		case err == nil:
+			successes++
+		case errors.Is(err, retaining.ErrVersionConflict):
+			conflicts++
+		default:
+			t.Fatalf("concurrent commit error = %v", err)
+		}
+	}
+	if successes != 1 || conflicts != 1 {
+		t.Fatalf("concurrent commits successes/conflicts = %d/%d, want 1/1", successes, conflicts)
+	}
+
+	terminal := testStoreTask(key.ID, protocol.TaskStateCompleted, "2026-08-14T01:03:00Z")
+	terminalReq := retaining.CommitTaskEventRequest{
+		Key: key, ExpectedVersion: 2, OperationID: "terminal",
+		Task: terminal, Event: testStoreStatusEvent(terminal),
+	}
+	terminalVersion, terminalCursor, err := store.CommitTaskEvent(ctx, terminalReq)
+	if err != nil {
+		t.Fatalf("CommitTaskEvent(terminal) error = %v", err)
+	}
+	if terminalVersion != 3 {
+		t.Fatalf("terminal version = %d, want 3", terminalVersion)
+	}
+	if gotVersion, gotCursor, err := store.CommitTaskEvent(ctx, terminalReq); err != nil ||
+		gotVersion != terminalVersion || gotCursor != terminalCursor {
+		t.Fatalf("terminal retry = (%d, %q, %v), want (%d, %q, nil)",
+			gotVersion, gotCursor, err, terminalVersion, terminalCursor)
+	}
+	late := newStoreTaskRequest(key, 3, "late", "2026-08-14T01:04:00Z")
+	if _, _, err := store.CommitTaskEvent(ctx, late); !errors.Is(err, retaining.ErrTaskTerminal) {
+		t.Fatalf("late terminal commit error = %v, want ErrTaskTerminal", err)
+	}
+
+	record, err := store.LoadTaskAndCursor(ctx, key)
+	if err != nil {
+		t.Fatalf("LoadTaskAndCursor error = %v", err)
+	}
+	if record.Version != 3 || record.Task.Status.State != protocol.TaskStateCompleted {
+		t.Fatalf("loaded record = version %d state %s, want 3/completed",
+			record.Version, record.Task.Status.State)
+	}
+}
+
+func TestRedisStoreMessageAdvancesRevisionAndProjectsOnce(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+	key := retaining.TaskKey{Tenant: "tenant", Owner: "owner", ID: "task-message"}
+	create := newStoreTaskRequest(key, 0, "create", "2026-08-14T02:00:00Z")
+	create.AllowCreate = true
+	if version, _, err := store.CommitTaskEvent(ctx, create); err != nil || version != 1 {
+		t.Fatalf("create = (%d, %v), want version 1", version, err)
+	}
+
+	contextID := "context-message"
+	taskID := key.ID
+	message := protocol.Message{
+		MessageID: "message-1", ContextID: &contextID, TaskID: &taskID,
+		Role: protocol.MessageRoleAgent, Parts: []*protocol.Part{},
+	}
+	req := retaining.CommitMessageEventRequest{
+		Key: key, ExpectedVersion: 1, OperationID: "message-op", Message: message,
+	}
+	version, cursor, err := store.CommitMessageEvent(ctx, req)
+	if err != nil {
+		t.Fatalf("CommitMessageEvent error = %v", err)
+	}
+	if version != 2 {
+		t.Fatalf("message version = %d, want 2", version)
+	}
+	if gotVersion, gotCursor, err := store.CommitMessageEvent(ctx, req); err != nil ||
+		gotVersion != version || gotCursor != cursor {
+		t.Fatalf("message retry = (%d, %q, %v), want (%d, %q, nil)",
+			gotVersion, gotCursor, err, version, cursor)
+	}
+	changedRequest := req
+	changedRequest.Message.Role = protocol.MessageRoleUser
+	if _, _, err := store.CommitMessageEvent(ctx, changedRequest); !errors.Is(err, retaining.ErrOperationConflict) {
+		t.Fatalf("changed Message with reused OperationID error = %v, want ErrOperationConflict", err)
+	}
+
+	history, err := store.LoadHistory(ctx, key.Tenant, key.Owner, contextID, -1)
+	if err != nil {
+		t.Fatalf("LoadHistory error = %v", err)
+	}
+	if len(history) != 1 || history[0].MessageID != message.MessageID {
+		t.Fatalf("history = %#v, want one message %q", history, message.MessageID)
+	}
+	record, err := store.LoadTask(ctx, key)
+	if err != nil {
+		t.Fatalf("LoadTask error = %v", err)
+	}
+	if record.Version != 2 {
+		t.Fatalf("record version after Message = %d, want 2", record.Version)
+	}
+
+	stale := req
+	stale.OperationID = "stale-message"
+	if _, _, err := store.CommitMessageEvent(ctx, stale); !errors.Is(err, retaining.ErrVersionConflict) {
+		t.Fatalf("stale Message error = %v, want ErrVersionConflict", err)
+	}
+	conflict := message
+	conflict.Role = protocol.MessageRoleUser
+	if err := store.SaveMessage(ctx, key.Tenant, key.Owner, conflict); !errors.Is(err, retaining.ErrMessageConflict) {
+		t.Fatalf("conflicting MessageID error = %v, want ErrMessageConflict", err)
+	}
+}
+
+func TestRedisStoreCursorAdvancesPastMalformedAndDetectsTrim(t *testing.T) {
+	store, client := newTestStore(t)
+	ctx := context.Background()
+	key := retaining.TaskKey{ID: "task-cursor"}
+	create := newStoreTaskRequest(key, 0, "create", "2026-08-14T03:00:00Z")
+	create.AllowCreate = true
+	_, firstCursor, err := store.CommitTaskEvent(ctx, create)
+	if err != nil {
+		t.Fatalf("create error = %v", err)
+	}
+	second := newStoreTaskRequest(key, 1, "second", "2026-08-14T03:01:00Z")
+	_, secondCursor, err := store.CommitTaskEvent(ctx, second)
+	if err != nil {
+		t.Fatalf("second error = %v", err)
+	}
+
+	malformedID, err := client.XAdd(ctx, &redisclient.XAddArgs{
+		Stream: streamKey(key.Tenant, key.Owner, key.ID), Values: map[string]any{streamField: "not-json"},
+	}).Result()
+	if err != nil {
+		t.Fatalf("XAdd malformed entry error = %v", err)
+	}
+	events, next, err := store.ReadTaskEvents(ctx, key, secondCursor, 1)
+	if err != nil {
+		t.Fatalf("ReadTaskEvents(malformed) error = %v", err)
+	}
+	if len(events) != 0 || string(next) != malformedID {
+		t.Fatalf("ReadTaskEvents(malformed) = (%d events, %q), want (0, %q)",
+			len(events), next, malformedID)
+	}
+
+	third := newStoreTaskRequest(key, 2, "third", "2026-08-14T03:02:00Z")
+	_, thirdCursor, err := store.CommitTaskEvent(ctx, third)
+	if err != nil {
+		t.Fatalf("third error = %v", err)
+	}
+	events, next, err = store.ReadTaskEvents(ctx, key, next, 2)
+	if err != nil {
+		t.Fatalf("ReadTaskEvents(after malformed) error = %v", err)
+	}
+	if len(events) != 1 || events[0].Cursor != thirdCursor || next != thirdCursor {
+		t.Fatalf("ReadTaskEvents(after malformed) = %#v, next %q, want third %q",
+			events, next, thirdCursor)
+	}
+
+	if err := client.XTrimMaxLen(ctx, streamKey(key.Tenant, key.Owner, key.ID), 2).Err(); err != nil {
+		t.Fatalf("XTrimMaxLen error = %v", err)
+	}
+	if _, _, err := store.ReadTaskEvents(ctx, key, firstCursor, 1); !errors.Is(err, retaining.ErrCursorExpired) {
+		t.Fatalf("ReadTaskEvents(trimmed cursor) error = %v, want ErrCursorExpired", err)
+	}
+}
+
+func TestRedisStorePushUsesAuthoritativeScopeAndGeneration(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+	key := retaining.TaskKey{Tenant: "tenant", Owner: "owner", ID: "task-push"}
+	authentication := &protocol.AuthenticationInfo{Scheme: "Bearer", Credentials: "secret"}
+	config := protocol.TaskPushNotificationConfig{
+		ID: "config-b", URL: "https://example.test/b", Authentication: authentication,
+	}
+	if _, err := store.SavePushConfig(ctx, key, config); !errors.Is(err, retaining.ErrTaskNotFound) {
+		t.Fatalf("SavePushConfig(missing task) error = %v, want ErrTaskNotFound", err)
+	}
+	create := newStoreTaskRequest(key, 0, "create", "2026-08-14T04:00:00Z")
+	create.AllowCreate = true
+	if _, _, err := store.CommitTaskEvent(ctx, create); err != nil {
+		t.Fatalf("create error = %v", err)
+	}
+
+	first, err := store.SavePushConfig(ctx, key, config)
+	if err != nil {
+		t.Fatalf("SavePushConfig error = %v", err)
+	}
+	if first.Config.Tenant != key.Tenant || first.Config.TaskID != key.ID ||
+		first.Owner != key.Owner || first.Generation == "" {
+		t.Fatalf("stored registration = %#v, want authoritative scope and generation", first)
+	}
+	authentication.Credentials = "mutated"
+	if first.Config.Authentication == nil || first.Config.Authentication.Credentials != "secret" {
+		t.Fatalf("SavePushConfig returned caller-aliased authentication: %#v", first.Config.Authentication)
+	}
+	second, err := store.SavePushConfig(ctx, key, config)
+	if err != nil {
+		t.Fatalf("SavePushConfig(update) error = %v", err)
+	}
+	if second.Generation == first.Generation {
+		t.Fatal("updated push config reused generation")
+	}
+	if _, err := store.SavePushConfig(ctx, key, protocol.TaskPushNotificationConfig{
+		Tenant: "other", TaskID: key.ID, URL: "https://example.test/conflict",
+	}); err == nil {
+		t.Fatal("SavePushConfig accepted conflicting tenant")
+	}
+	if _, err := store.SavePushConfig(ctx, key, protocol.TaskPushNotificationConfig{
+		ID: "config-a", URL: "https://example.test/a",
+	}); err != nil {
+		t.Fatalf("SavePushConfig(config-a) error = %v", err)
+	}
+	registrations, err := store.ListPushConfigs(ctx, key)
+	if err != nil {
+		t.Fatalf("ListPushConfigs error = %v", err)
+	}
+	if len(registrations) != 2 || registrations[0].Config.ID != "config-a" ||
+		registrations[1].Config.ID != "config-b" {
+		t.Fatalf("ListPushConfigs order = %#v", registrations)
+	}
+	if err := store.DeletePushConfig(ctx, key, "config-b"); err != nil {
+		t.Fatalf("DeletePushConfig error = %v", err)
+	}
+	if _, err := store.GetPushConfig(ctx, key, "config-b"); !errors.Is(err, retaining.ErrPushConfigNotFound) {
+		t.Fatalf("GetPushConfig(deleted) error = %v, want ErrPushConfigNotFound", err)
+	}
+}
+
+func TestRedisStoreScopeIsolationAndClose(t *testing.T) {
+	server := miniredis.RunT(t)
+	ctx := context.Background()
+	keys := []retaining.TaskKey{
+		{Tenant: "", Owner: "owner-a", ID: "same"},
+		{Tenant: "~default", Owner: "owner-a", ID: "same"},
+		{Tenant: "", Owner: "owner-b", ID: "same"},
+	}
+	stores := make([]*retainingStore, 0, len(keys))
+	for i, key := range keys {
+		client := redisclient.NewClient(&redisclient.Options{Addr: server.Addr()})
+		store, err := newRetainingStore(client)
+		if err != nil {
+			t.Fatalf("newRetainingStore(%d) error = %v", i, err)
+		}
+		stores = append(stores, store)
+		req := newStoreTaskRequest(key, 0, fmt.Sprintf("create-%d", i),
+			fmt.Sprintf("2026-08-14T05:0%d:00Z", i))
+		req.AllowCreate = true
+		if version, _, err := store.CommitTaskEvent(ctx, req); err != nil || version != 1 {
+			t.Fatalf("scope %d create = (%d, %v), want version 1", i, version, err)
+		}
+	}
+	for i, key := range keys {
+		record, err := stores[i].LoadTask(ctx, key)
+		if err != nil {
+			t.Fatalf("scope %d LoadTask error = %v", i, err)
+		}
+		if record.Task.Status.Timestamp != fmt.Sprintf("2026-08-14T05:0%d:00Z", i) {
+			t.Fatalf("scope %d loaded timestamp = %q", i, record.Task.Status.Timestamp)
+		}
+	}
+	for i, store := range stores {
+		if err := store.Close(); err != nil {
+			t.Fatalf("scope %d Close error = %v", i, err)
+		}
+		if err := store.Close(); err != nil {
+			t.Fatalf("scope %d second Close error = %v", i, err)
+		}
+		if _, err := store.LoadTask(ctx, keys[i]); !errors.Is(err, retaining.ErrStoreClosed) {
+			t.Fatalf("scope %d LoadTask after Close error = %v, want ErrStoreClosed", i, err)
+		}
+	}
+}
+
+func TestRedisStoreTaskOwnedKeysShareTaskHashInput(t *testing.T) {
+	key := retaining.TaskKey{Tenant: "tenant", Owner: "owner", ID: "task-slot"}
+	want := taskKey(key.Tenant, key.Owner, key.ID)
+	keys := []string{
+		streamKey(key.Tenant, key.Owner, key.ID),
+		streamDedupeKey(key.Tenant, key.Owner, key.ID),
+		storeOperationResultsKey(key.Tenant, key.Owner, key.ID),
+		storePushKey(key.Tenant, key.Owner, key.ID),
+	}
+	for _, redisKey := range keys {
+		start := len(redisKey) - len(want) - 2
+		if start < 0 || redisKey[start:] != "{"+want+"}" {
+			t.Fatalf("key %q does not use task hash input %q", redisKey, want)
+		}
+	}
+}
+
+func newTestStore(t *testing.T) (*retainingStore, *redisclient.Client) {
+	t.Helper()
+	server := miniredis.RunT(t)
+	client := redisclient.NewClient(&redisclient.Options{Addr: server.Addr()})
+	store, err := newRetainingStore(client, WithExpireTime(time.Hour), WithMaxHistoryLength(10))
+	if err != nil {
+		t.Fatalf("newRetainingStore error = %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store, client
+}
+
+func newStoreTaskRequest(
+	key retaining.TaskKey, expected uint64, operationID, timestamp string,
+) retaining.CommitTaskEventRequest {
+	task := testStoreTask(key.ID, protocol.TaskStateWorking, timestamp)
+	return retaining.CommitTaskEventRequest{
+		Key: key, ExpectedVersion: expected, OperationID: operationID,
+		Task: task, Event: testStoreStatusEvent(task),
+	}
+}
+
+func testStoreTask(id string, state protocol.TaskState, timestamp string) *protocol.Task {
+	return &protocol.Task{
+		ID: id, ContextID: "context-" + id,
+		Status: protocol.TaskStatus{State: state, Timestamp: timestamp},
+	}
+}
+
+func testStoreStatusEvent(task *protocol.Task) protocol.StreamResponse {
+	return protocol.NewStreamResponseStatusUpdate(&protocol.TaskStatusUpdateEvent{
+		TaskID: task.ID, ContextID: task.ContextID, Status: task.Status,
+	})
+}

--- a/taskmanager/retaining/contract_test.go
+++ b/taskmanager/retaining/contract_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/push"
 )
 
 var storeErrors = []error{
@@ -20,6 +21,7 @@ var storeErrors = []error{
 	ErrVersionConflict,
 	ErrTaskTerminal,
 	ErrOperationConflict,
+	ErrMessageConflict,
 	ErrOperationExpired,
 	ErrCommitUncertain,
 	ErrCursorExpired,
@@ -85,8 +87,8 @@ func (*contractStore) ReadTaskEvents(
 	TaskKey,
 	Cursor,
 	int,
-) ([]StoredEvent, error) {
-	return nil, nil
+) ([]StoredEvent, Cursor, error) {
+	return nil, "", nil
 }
 
 func (*contractStore) RefreshTaskLease(context.Context, TaskKey) error {
@@ -120,19 +122,19 @@ func (*contractStore) SavePushConfig(
 	context.Context,
 	TaskKey,
 	protocol.TaskPushNotificationConfig,
-) (StoredPushConfig, error) {
-	return StoredPushConfig{}, nil
+) (push.Registration, error) {
+	return push.Registration{}, nil
 }
 
 func (*contractStore) GetPushConfig(
 	context.Context,
 	TaskKey,
 	string,
-) (StoredPushConfig, error) {
-	return StoredPushConfig{}, nil
+) (push.Registration, error) {
+	return push.Registration{}, nil
 }
 
-func (*contractStore) ListPushConfigs(context.Context, TaskKey) ([]StoredPushConfig, error) {
+func (*contractStore) ListPushConfigs(context.Context, TaskKey) ([]push.Registration, error) {
 	return nil, nil
 }
 

--- a/taskmanager/retaining/contract_test.go
+++ b/taskmanager/retaining/contract_test.go
@@ -1,0 +1,159 @@
+// Tencent is pleased to support the open source community by making trpc-a2a-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-a2a-go is licensed under the Apache License Version 2.0.
+
+package retaining
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
+)
+
+var storeErrors = []error{
+	ErrTaskNotFound,
+	ErrVersionConflict,
+	ErrTaskTerminal,
+	ErrOperationConflict,
+	ErrOperationExpired,
+	ErrCommitUncertain,
+	ErrCursorExpired,
+	ErrPushConfigNotFound,
+	ErrStoreClosed,
+}
+
+func TestStoreErrorsSupportErrorsIs(t *testing.T) {
+	for i, target := range storeErrors {
+		wrapped := fmt.Errorf("backend context: %w", target)
+		if !errors.Is(wrapped, target) {
+			t.Fatalf("errors.Is(%q) = false", target)
+		}
+		for j, other := range storeErrors {
+			if i != j && errors.Is(wrapped, other) {
+				t.Fatalf("error %q unexpectedly matches %q", target, other)
+			}
+		}
+	}
+}
+
+func TestCursorPreservesOpaqueValue(t *testing.T) {
+	const value = "1741597012345-7"
+	cursor := Cursor(value)
+	if got := string(cursor); got != value {
+		t.Fatalf("Cursor round trip = %q, want %q", got, value)
+	}
+}
+
+// Compile-time implementations pin the initial public contract without adding
+// a production mock or another abstraction.
+var (
+	_ Store    = (*contractStore)(nil)
+	_ Notifier = (*contractNotifier)(nil)
+)
+
+type contractStore struct{}
+
+func (*contractStore) LoadTask(context.Context, TaskKey) (*TaskRecord, error) {
+	return nil, nil
+}
+
+func (*contractStore) LoadTaskAndCursor(context.Context, TaskKey) (*TaskRecord, error) {
+	return nil, nil
+}
+
+func (*contractStore) CommitTaskEvent(
+	context.Context,
+	CommitTaskEventRequest,
+) (uint64, Cursor, error) {
+	return 0, "", nil
+}
+
+func (*contractStore) CommitMessageEvent(
+	context.Context,
+	CommitMessageEventRequest,
+) (uint64, Cursor, error) {
+	return 0, "", nil
+}
+
+func (*contractStore) ReadTaskEvents(
+	context.Context,
+	TaskKey,
+	Cursor,
+	int,
+) ([]StoredEvent, error) {
+	return nil, nil
+}
+
+func (*contractStore) RefreshTaskLease(context.Context, TaskKey) error {
+	return nil
+}
+
+func (*contractStore) SaveMessage(context.Context, string, string, protocol.Message) error {
+	return nil
+}
+
+func (*contractStore) LoadHistory(
+	context.Context,
+	string,
+	string,
+	string,
+	int,
+) ([]protocol.Message, error) {
+	return nil, nil
+}
+
+func (*contractStore) ListTasks(
+	context.Context,
+	string,
+	string,
+	protocol.ListTasksParams,
+) (*protocol.ListTasksResult, error) {
+	return nil, nil
+}
+
+func (*contractStore) SavePushConfig(
+	context.Context,
+	TaskKey,
+	protocol.TaskPushNotificationConfig,
+) (StoredPushConfig, error) {
+	return StoredPushConfig{}, nil
+}
+
+func (*contractStore) GetPushConfig(
+	context.Context,
+	TaskKey,
+	string,
+) (StoredPushConfig, error) {
+	return StoredPushConfig{}, nil
+}
+
+func (*contractStore) ListPushConfigs(context.Context, TaskKey) ([]StoredPushConfig, error) {
+	return nil, nil
+}
+
+func (*contractStore) DeletePushConfig(context.Context, TaskKey, string) error {
+	return nil
+}
+
+func (*contractStore) Close() error {
+	return nil
+}
+
+type contractNotifier struct{}
+
+func (*contractNotifier) Notify(context.Context, TaskKey, Cursor) error {
+	return nil
+}
+
+func (*contractNotifier) Wait(context.Context, TaskKey, Cursor) error {
+	return nil
+}
+
+func (*contractNotifier) Close() error {
+	return nil
+}

--- a/taskmanager/retaining/errors.go
+++ b/taskmanager/retaining/errors.go
@@ -1,0 +1,32 @@
+// Tencent is pleased to support the open source community by making trpc-a2a-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-a2a-go is licensed under the Apache License Version 2.0.
+
+package retaining
+
+import "errors"
+
+// Store errors are transport-neutral. The retaining Manager maps them to the
+// public taskmanager error model at the protocol boundary.
+var (
+	// ErrTaskNotFound reports a missing or logically expired Task.
+	ErrTaskNotFound = errors.New("retaining store: task not found")
+	// ErrVersionConflict reports a failed expected-version comparison.
+	ErrVersionConflict = errors.New("retaining store: task version conflict")
+	// ErrTaskTerminal reports an attempt to append a new event to a terminal Task.
+	ErrTaskTerminal = errors.New("retaining store: task is terminal")
+	// ErrOperationConflict reports reuse of an OperationID for different content.
+	ErrOperationConflict = errors.New("retaining store: operation id conflict")
+	// ErrOperationExpired reports that an idempotent result left the operation journal.
+	ErrOperationExpired = errors.New("retaining store: operation result expired")
+	// ErrCommitUncertain asks the Manager to retry with the original OperationID.
+	ErrCommitUncertain = errors.New("retaining store: commit result uncertain")
+	// ErrCursorExpired reports that an event cursor fell behind retention.
+	ErrCursorExpired = errors.New("retaining store: event cursor expired")
+	// ErrPushConfigNotFound reports a missing push configuration for an existing Task.
+	ErrPushConfigNotFound = errors.New("retaining store: push config not found")
+	// ErrStoreClosed reports an operation attempted after Store.Close.
+	ErrStoreClosed = errors.New("retaining store: closed")
+)

--- a/taskmanager/retaining/errors.go
+++ b/taskmanager/retaining/errors.go
@@ -19,6 +19,8 @@ var (
 	ErrTaskTerminal = errors.New("retaining store: task is terminal")
 	// ErrOperationConflict reports reuse of an OperationID for different content.
 	ErrOperationConflict = errors.New("retaining store: operation id conflict")
+	// ErrMessageConflict reports reuse of a MessageID for different content.
+	ErrMessageConflict = errors.New("retaining store: message id conflict")
 	// ErrOperationExpired reports that an idempotent result left the operation journal.
 	ErrOperationExpired = errors.New("retaining store: operation result expired")
 	// ErrCommitUncertain asks the Manager to retry with the original OperationID.

--- a/taskmanager/retaining/notifier.go
+++ b/taskmanager/retaining/notifier.go
@@ -1,0 +1,26 @@
+// Tencent is pleased to support the open source community by making trpc-a2a-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-a2a-go is licensed under the Apache License Version 2.0.
+
+package retaining
+
+import "context"
+
+// Notifier provides best-effort, low-latency wakeups for Task event readers.
+// Durability and ordering come from Store, not from Notifier.
+//
+// Notifications may be lost, duplicated, or delivered spuriously. Wait must
+// honor ctx; the retaining Manager always supplies a bounded context and reads
+// Store again after Wait returns. Close must be safe to call more than once.
+type Notifier interface {
+	// Notify announces that key may have events through cursor.
+	Notify(ctx context.Context, key TaskKey, cursor Cursor) error
+
+	// Wait blocks until key may have events after cursor or ctx ends.
+	Wait(ctx context.Context, key TaskKey, cursor Cursor) error
+
+	// Close releases resources owned by this Notifier wrapper.
+	Close() error
+}

--- a/taskmanager/retaining/store.go
+++ b/taskmanager/retaining/store.go
@@ -1,0 +1,163 @@
+// Tencent is pleased to support the open source community by making trpc-a2a-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-a2a-go is licensed under the Apache License Version 2.0.
+
+// Package retaining defines the persistence and notification contracts used by
+// retaining task managers.
+package retaining
+
+import (
+	"context"
+
+	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
+)
+
+// Cursor is an opaque position in one Task's event journal.
+//
+// A Store chooses the physical representation. Callers may only preserve a
+// Cursor and pass it back to the same Store; they must not parse, order, or
+// compare it with cursors from another Task or Store implementation.
+type Cursor string
+
+// TaskKey is the complete persistence and isolation scope of one Task.
+type TaskKey struct {
+	Tenant string
+	Owner  string
+	ID     string
+}
+
+// TaskRecord is a Task snapshot and the Store metadata observed with it.
+// Cursor is populated by LoadTaskAndCursor and may be empty after LoadTask.
+type TaskRecord struct {
+	Task    *protocol.Task
+	Version uint64
+	Cursor  Cursor
+}
+
+// StoredEvent is one journal event and its position.
+type StoredEvent struct {
+	Cursor Cursor
+	Event  protocol.StreamResponse
+}
+
+// StoredPushConfig pairs a wire-level push configuration with its internal
+// storage generation. Generation is not exposed through the A2A protocol.
+type StoredPushConfig struct {
+	Config     protocol.TaskPushNotificationConfig
+	Generation uint64
+}
+
+// CommitTaskEventRequest atomically replaces a Task snapshot and appends the
+// Status or Artifact event that produced it.
+type CommitTaskEventRequest struct {
+	Key             TaskKey
+	ExpectedVersion uint64
+	AllowCreate     bool
+	OperationID     string
+	Task            *protocol.Task
+	Event           protocol.StreamResponse
+}
+
+// CommitMessageEventRequest appends a Message event to an existing Task and
+// idempotently projects the Message into conversation history.
+type CommitMessageEventRequest struct {
+	Key             TaskKey
+	ExpectedVersion uint64
+	OperationID     string
+	Message         protocol.Message
+	Event           protocol.StreamResponse
+}
+
+// Store is the persistence boundary of a retaining task manager.
+//
+// Implementations must be safe for concurrent use. All input and output
+// protocol values cross the boundary by value: implementations must not retain
+// caller-owned mutable references or return references to mutable stored state.
+//
+// Commit methods are operation-idempotent. A repeated OperationID for the same
+// request returns the version and cursor produced by its first successful
+// commit. The OperationID lookup happens before version and terminal-state
+// checks. Reusing an OperationID for different request content returns
+// ErrOperationConflict.
+type Store interface {
+	// LoadTask returns a deep copy of the current Task snapshot and its version.
+	LoadTask(ctx context.Context, key TaskKey) (*TaskRecord, error)
+
+	// LoadTaskAndCursor observes the Task snapshot, version, and event-journal
+	// tail at one atomic boundary.
+	LoadTaskAndCursor(ctx context.Context, key TaskKey) (*TaskRecord, error)
+
+	// CommitTaskEvent atomically updates the Task snapshot and appends its event.
+	// It returns the version and cursor produced by this OperationID's first
+	// successful commit.
+	CommitTaskEvent(ctx context.Context, req CommitTaskEventRequest) (uint64, Cursor, error)
+
+	// CommitMessageEvent first resolves OperationID idempotency, then atomically
+	// checks ExpectedVersion and rejects terminal Tasks before appending Event.
+	// Message/history projection is idempotent by MessageID and is retried even
+	// when the OperationID already exists. A Message event does not increment the
+	// Task version.
+	CommitMessageEvent(ctx context.Context, req CommitMessageEventRequest) (uint64, Cursor, error)
+
+	// ReadTaskEvents returns events strictly after after, in Store order. It
+	// returns ErrCursorExpired rather than silently skipping trimmed events.
+	ReadTaskEvents(
+		ctx context.Context,
+		key TaskKey,
+		after Cursor,
+		limit int,
+	) ([]StoredEvent, error)
+
+	// RefreshTaskLease extends a live Task and its owned journal state without
+	// recreating a missing or logically expired Task.
+	RefreshTaskLease(ctx context.Context, key TaskKey) error
+
+	// SaveMessage idempotently stores message and its conversation index entry by
+	// MessageID. It is used for direct Messages and projections outside
+	// CommitMessageEvent.
+	SaveMessage(ctx context.Context, tenant, owner string, message protocol.Message) error
+
+	// LoadHistory returns at most limit Messages for one conversation in protocol
+	// order. A negative limit requests all retained Messages.
+	LoadHistory(
+		ctx context.Context,
+		tenant string,
+		owner string,
+		contextID string,
+		limit int,
+	) ([]protocol.Message, error)
+
+	// ListTasks performs backend-native filtering, ordering, and keyset
+	// pagination. Returned Tasks do not contain conversation history.
+	ListTasks(
+		ctx context.Context,
+		tenant string,
+		owner string,
+		params protocol.ListTasksParams,
+	) (*protocol.ListTasksResult, error)
+
+	// SavePushConfig creates or replaces a config scoped by key. The Store treats
+	// key as authoritative, assigns server-owned fields, advances Generation, and
+	// returns a deep copy of the stored value.
+	SavePushConfig(
+		ctx context.Context,
+		key TaskKey,
+		config protocol.TaskPushNotificationConfig,
+	) (StoredPushConfig, error)
+
+	// GetPushConfig returns one config only while its Task remains visible.
+	GetPushConfig(ctx context.Context, key TaskKey, configID string) (StoredPushConfig, error)
+
+	// ListPushConfigs returns the visible configs for key in stable backend order.
+	ListPushConfigs(ctx context.Context, key TaskKey) ([]StoredPushConfig, error)
+
+	// DeletePushConfig removes configID from key. Deleting an absent config is a
+	// no-op, preserving the existing TaskManager behavior.
+	DeletePushConfig(ctx context.Context, key TaskKey, configID string) error
+
+	// Close releases resources owned by this Store wrapper. It must be safe to
+	// call more than once.
+	Close() error
+}

--- a/taskmanager/retaining/store.go
+++ b/taskmanager/retaining/store.go
@@ -12,6 +12,7 @@ import (
 	"context"
 
 	"trpc.group/trpc-go/trpc-a2a-go/v2/protocol"
+	"trpc.group/trpc-go/trpc-a2a-go/v2/push"
 )
 
 // Cursor is an opaque position in one Task's event journal.
@@ -42,13 +43,6 @@ type StoredEvent struct {
 	Event  protocol.StreamResponse
 }
 
-// StoredPushConfig pairs a wire-level push configuration with its internal
-// storage generation. Generation is not exposed through the A2A protocol.
-type StoredPushConfig struct {
-	Config     protocol.TaskPushNotificationConfig
-	Generation uint64
-}
-
 // CommitTaskEventRequest atomically replaces a Task snapshot and appends the
 // Status or Artifact event that produced it.
 type CommitTaskEventRequest struct {
@@ -67,7 +61,6 @@ type CommitMessageEventRequest struct {
 	ExpectedVersion uint64
 	OperationID     string
 	Message         protocol.Message
-	Event           protocol.StreamResponse
 }
 
 // Store is the persistence boundary of a retaining task manager.
@@ -95,27 +88,31 @@ type Store interface {
 	CommitTaskEvent(ctx context.Context, req CommitTaskEventRequest) (uint64, Cursor, error)
 
 	// CommitMessageEvent first resolves OperationID idempotency, then atomically
-	// checks ExpectedVersion and rejects terminal Tasks before appending Event.
+	// checks ExpectedVersion and rejects terminal Tasks before appending the
+	// Message event derived from Message.
 	// Message/history projection is idempotent by MessageID and is retried even
-	// when the OperationID already exists. A Message event does not increment the
-	// Task version.
+	// when the OperationID already exists. Every Task-associated event advances
+	// Version, including an event that does not replace the Task snapshot.
 	CommitMessageEvent(ctx context.Context, req CommitMessageEventRequest) (uint64, Cursor, error)
 
-	// ReadTaskEvents returns events strictly after after, in Store order. It
-	// returns ErrCursorExpired rather than silently skipping trimmed events.
+	// ReadTaskEvents returns events strictly after after, in Store order, plus
+	// the last physical position inspected. next may advance past malformed
+	// backend entries even when no decodable event is returned. It returns
+	// ErrCursorExpired rather than silently skipping trimmed events.
 	ReadTaskEvents(
 		ctx context.Context,
 		key TaskKey,
 		after Cursor,
 		limit int,
-	) ([]StoredEvent, error)
+	) ([]StoredEvent, Cursor, error)
 
 	// RefreshTaskLease extends a live Task and its owned journal state without
 	// recreating a missing or logically expired Task.
 	RefreshTaskLease(ctx context.Context, key TaskKey) error
 
 	// SaveMessage idempotently stores message and its conversation index entry by
-	// MessageID. It is used for direct Messages and projections outside
+	// MessageID. Reusing a MessageID for different content returns
+	// ErrMessageConflict. It is used for direct Messages and projections outside
 	// CommitMessageEvent.
 	SaveMessage(ctx context.Context, tenant, owner string, message protocol.Message) error
 
@@ -139,19 +136,20 @@ type Store interface {
 	) (*protocol.ListTasksResult, error)
 
 	// SavePushConfig creates or replaces a config scoped by key. The Store treats
-	// key as authoritative, assigns server-owned fields, advances Generation, and
-	// returns a deep copy of the stored value.
+	// key as authoritative, rejects a payload whose non-empty scope disagrees,
+	// atomically verifies that the Task remains visible, assigns server-owned
+	// fields, advances Generation, and returns a deep copy of the registration.
 	SavePushConfig(
 		ctx context.Context,
 		key TaskKey,
 		config protocol.TaskPushNotificationConfig,
-	) (StoredPushConfig, error)
+	) (push.Registration, error)
 
 	// GetPushConfig returns one config only while its Task remains visible.
-	GetPushConfig(ctx context.Context, key TaskKey, configID string) (StoredPushConfig, error)
+	GetPushConfig(ctx context.Context, key TaskKey, configID string) (push.Registration, error)
 
 	// ListPushConfigs returns the visible configs for key in stable backend order.
-	ListPushConfigs(ctx context.Context, key TaskKey) ([]StoredPushConfig, error)
+	ListPushConfigs(ctx context.Context, key TaskKey) ([]push.Registration, error)
 
 	// DeletePushConfig removes configID from key. Deleting an absent config is a
 	// no-op, preserving the existing TaskManager behavior.


### PR DESCRIPTION
## Summary

- Add the public `taskmanager/retaining` Store and Notifier contracts together with the proposed generic retaining TaskManager design.
- Add a Redis Store implementation covering Task/Event CAS, operation idempotency, event cursors, history, task listing, push registrations, TTL refresh, and shutdown.
- Add Redis Store tests for concurrent CAS, terminal-state protection, Message revision handling, cursor trimming, malformed Stream entries, scope isolation, push generations, and close behavior.

## Design notes

- Every Task-associated event advances the Task journal revision, including Message events that do not replace the Task snapshot.
- Operation results persist the request digest, revision, and Redis Stream cursor so ambiguous retries can recover the original result without appending a duplicate event.
- Redis push registrations use a Task-slot-tagged key so Task visibility validation and config persistence can share one Lua boundary. Existing push registrations require an explicit migration decision before integration.
- This draft does not switch `redis.NewTaskManager` to the new Store yet; it is intended to validate the storage contract before extracting the shared lifecycle manager.

## Testing

- `go test ./...` in the root module
- `go test ./...` in `taskmanager/redis`
- `go test -race -run '^TestRedisStore' ./...` in `taskmanager/redis`
- `go vet ./...` in `taskmanager/redis`